### PR TITLE
Feat 1.2: tipos en cartas/enemigos + UI básica

### DIFF
--- a/Assets/Scripts/Gameplay/Cards/CardDefinition.cs
+++ b/Assets/Scripts/Gameplay/Cards/CardDefinition.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
+using RoguelikeCardBattler.Gameplay.Combat;
 
 namespace RoguelikeCardBattler.Gameplay.Cards
 {
@@ -15,6 +16,7 @@ namespace RoguelikeCardBattler.Gameplay.Cards
         [SerializeField] private CardTarget target = CardTarget.SingleEnemy;
         [SerializeField] private List<string> tags = new List<string>();
         [SerializeField] private List<EffectRef> effects = new List<EffectRef>();
+        [SerializeField] private ElementType elementType = ElementType.None;
 
         public string Id => id;
         public string CardName => cardName;
@@ -25,6 +27,7 @@ namespace RoguelikeCardBattler.Gameplay.Cards
         public CardTarget Target => target;
         public IReadOnlyList<string> Tags => tags;
         public IReadOnlyList<EffectRef> Effects => effects;
+        public ElementType ElementType => elementType;
 
         public void SetDebugData(
             string newId,
@@ -35,7 +38,8 @@ namespace RoguelikeCardBattler.Gameplay.Cards
             CardRarity newRarity,
             CardTarget newTarget,
             List<string> newTags,
-            List<EffectRef> newEffects)
+            List<EffectRef> newEffects,
+            ElementType newElementType = ElementType.None)
         {
             id = newId;
             cardName = newName;
@@ -46,6 +50,7 @@ namespace RoguelikeCardBattler.Gameplay.Cards
             target = newTarget;
             tags = newTags;
             effects = newEffects;
+            elementType = newElementType;
         }
     }
 }

--- a/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
@@ -28,6 +28,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         private Text _playerEnergyText;
         private Text _playerHpLabel;
         private Text _enemyHpLabel;
+        private Text _enemyTypeLabel;
         private Text _playerBlockText;
         private Text _enemyBlockText;
         private Text _drawPileText;
@@ -192,6 +193,12 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             enemyHpRect.anchorMax = new Vector2(0.9f, -0.02f);
             enemyHpRect.offsetMin = Vector2.zero;
             enemyHpRect.offsetMax = Vector2.zero;
+            _enemyTypeLabel = CreateText("EnemyTypeLabel", _enemyAvatarImage.rectTransform, "Type: —", 18, TextAnchor.UpperCenter);
+            RectTransform enemyTypeRect = _enemyTypeLabel.GetComponent<RectTransform>();
+            enemyTypeRect.anchorMin = new Vector2(0.05f, 1.22f);
+            enemyTypeRect.anchorMax = new Vector2(0.95f, 1.35f);
+            enemyTypeRect.offsetMin = Vector2.zero;
+            enemyTypeRect.offsetMax = Vector2.zero;
             CreateBlockUI(_enemyAvatarImage.rectTransform, "Enemy", out _enemyBlockOverlay, out _enemyBlockText);
 
             _enemyIntentText = CreateText("EnemyIntent", _enemyAvatarImage.rectTransform, "?", 26, TextAnchor.LowerCenter);
@@ -462,6 +469,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             _playerEnergyText.text = $"Energy {turnManager.PlayerEnergy}/{turnManager.PlayerMaxEnergy}";
             _playerHpLabel.text = $"{turnManager.PlayerHP}/{turnManager.PlayerMaxHP}";
             _enemyHpLabel.text = $"{turnManager.EnemyHP}/{turnManager.EnemyMaxHP}";
+            _enemyTypeLabel.text = BuildEnemyTypeLabel();
             _drawPileText.text = $"Draw: {turnManager.PlayerDrawPileCount}";
             _discardPileText.text = $"Discard: {turnManager.PlayerDiscardPileCount}";
             _enemyIntentText.text = BuildEnemyIntentLabel();
@@ -590,7 +598,10 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 prefix = turnManager.CurrentWorld == TurnManager.WorldSide.A ? "[A] " : "[B] ";
             }
 
-            string title = string.IsNullOrEmpty(prefix) ? activeCard.CardName : $"{prefix}{activeCard.CardName}";
+            string typePrefix = activeCard.ElementType != ElementType.None ? $"[{activeCard.ElementType}] " : string.Empty;
+            string title = string.IsNullOrEmpty(prefix)
+                ? $"{typePrefix}{activeCard.CardName}"
+                : $"{prefix}{typePrefix}{activeCard.CardName}";
             return $"{title} (Cost {activeCard.Cost})\n{activeCard.Description}";
         }
 
@@ -607,6 +618,17 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 EnemyIntentType.Defend => "DEFEND",
                 _ => "?"
             };
+        }
+
+        private string BuildEnemyTypeLabel()
+        {
+            if (turnManager == null)
+            {
+                return "Type: —";
+            }
+
+            ElementType type = turnManager.EnemyElementType;
+            return type == ElementType.None ? "Type: —" : $"Type: {type}";
         }
 
         private void UpdateBlockVisuals(Text label, Image overlay, int blockValue)

--- a/Assets/Scripts/Gameplay/Combat/TurnManager.cs
+++ b/Assets/Scripts/Gameplay/Combat/TurnManager.cs
@@ -65,6 +65,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         public WorldSide CurrentWorld => currentWorld;
         public float CurrentEnemyAvatarScale => enemyDefinition != null ? Mathf.Max(0.1f, enemyDefinition.AvatarScale) : 1f;
         public Vector2 CurrentEnemyAvatarOffset => enemyDefinition != null ? enemyDefinition.AvatarOffset : Vector2.zero;
+        public ElementType EnemyElementType => enemyDefinition != null ? enemyDefinition.ElementType : ElementType.None;
 
         private void Start()
         {

--- a/Assets/Scripts/Gameplay/Enemies/EnemyDefinition.cs
+++ b/Assets/Scripts/Gameplay/Enemies/EnemyDefinition.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
+using RoguelikeCardBattler.Gameplay.Combat;
 
 namespace RoguelikeCardBattler.Gameplay.Enemies
 {
@@ -15,6 +16,7 @@ namespace RoguelikeCardBattler.Gameplay.Enemies
         [SerializeField] private List<EnemyMove> moves = new List<EnemyMove>();
         [SerializeField] private float avatarScale = 1f;
         [SerializeField] private Vector2 avatarOffset = Vector2.zero;
+        [SerializeField] private ElementType elementType = ElementType.None;
 
         public string Id => id;
         public string EnemyName => enemyName;
@@ -25,6 +27,7 @@ namespace RoguelikeCardBattler.Gameplay.Enemies
         public IReadOnlyList<EnemyMove> Moves => moves;
         public float AvatarScale => avatarScale;
         public Vector2 AvatarOffset => avatarOffset;
+        public ElementType ElementType => elementType;
 
 #if UNITY_EDITOR || UNITY_INCLUDE_TESTS
         public void SetDebugData(
@@ -36,7 +39,8 @@ namespace RoguelikeCardBattler.Gameplay.Enemies
             List<string> newTags,
             List<EnemyMove> newMoves,
             float newAvatarScale = 1f,
-            Vector2? newAvatarOffset = null)
+            Vector2? newAvatarOffset = null,
+            ElementType newElementType = ElementType.None)
         {
             id = newId;
             enemyName = newName;
@@ -47,6 +51,7 @@ namespace RoguelikeCardBattler.Gameplay.Enemies
             moves = newMoves ?? new List<EnemyMove>();
             avatarScale = Mathf.Max(0.1f, newAvatarScale);
             avatarOffset = newAvatarOffset ?? Vector2.zero;
+            elementType = newElementType;
         }
 #endif
     }

--- a/Assets/Tests/EditMode/DefinitionTypeDefaultsTests.cs
+++ b/Assets/Tests/EditMode/DefinitionTypeDefaultsTests.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+using RoguelikeCardBattler.Gameplay.Cards;
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Gameplay.Enemies;
+using UnityEngine;
+
+namespace RoguelikeCardBattler.Tests.EditMode
+{
+    public class DefinitionTypeDefaultsTests
+    {
+        [Test]
+        public void CardDefinition_DefaultsToNoneElement()
+        {
+            var card = ScriptableObject.CreateInstance<CardDefinition>();
+            Assert.AreEqual(ElementType.None, card.ElementType);
+            Object.DestroyImmediate(card);
+        }
+
+        [Test]
+        public void EnemyDefinition_DefaultsToNoneElement()
+        {
+            var enemy = ScriptableObject.CreateInstance<EnemyDefinition>();
+            Assert.AreEqual(ElementType.None, enemy.ElementType);
+            Object.DestroyImmediate(enemy);
+        }
+    }
+}
+

--- a/Assets/Tests/EditMode/DefinitionTypeDefaultsTests.cs.meta
+++ b/Assets/Tests/EditMode/DefinitionTypeDefaultsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ecac0b4acb7b7b144aa7c54f0fa63b34


### PR DESCRIPTION
- Añade ElementType (default None) a CardDefinition y EnemyDefinition, con soporte en SetDebugData.
- Expone el tipo del enemigo desde TurnManager para consumo de UI.
- UI: muestra [Tipo] en el nombre de la carta (si no es None) y muestra “Type: X/—” para el enemigo.
- Agrega tests EditMode para validar defaults (CardDefinition/EnemyDefinition arrancan en None).
- Tests EditMode: 50/50 en verde.