### PR TITLE
Feat 1.3: daño por efectividad (Super/Poco/Neutro)

### DIFF
--- a/Assets/Tests/EditMode/CombatTestBase.cs
+++ b/Assets/Tests/EditMode/CombatTestBase.cs
@@ -36,7 +36,39 @@ namespace RoguelikeCardBattler.Tests.EditMode
                 CardRarity.Common,
                 target,
                 new List<string>(),
-                effectList);
+                effectList,
+                ElementType.None);
+
+            _createdAssets.Add(card);
+            return card;
+        }
+
+        protected CardDefinition CreateCardWithElement(
+            string id,
+            CardType type,
+            CardTarget target,
+            int cost,
+            ElementType elementType,
+            params EffectRef[] effects)
+        {
+            var card = ScriptableObject.CreateInstance<CardDefinition>();
+            var effectList = new List<EffectRef>();
+            if (effects != null)
+            {
+                effectList.AddRange(effects);
+            }
+
+            card.SetDebugData(
+                id,
+                id,
+                $"{id} description",
+                cost,
+                type,
+                CardRarity.Common,
+                target,
+                new List<string>(),
+                effectList,
+                elementType);
 
             _createdAssets.Add(card);
             return card;
@@ -85,7 +117,8 @@ namespace RoguelikeCardBattler.Tests.EditMode
             string name,
             int maxHp,
             EnemyAIPattern pattern,
-            List<EnemyMove> moves)
+            List<EnemyMove> moves,
+            ElementType elementType = ElementType.None)
         {
             var enemy = ScriptableObject.CreateInstance<EnemyDefinition>();
             enemy.SetDebugData(
@@ -95,7 +128,10 @@ namespace RoguelikeCardBattler.Tests.EditMode
                 0,
                 pattern,
                 new List<string>(),
-                moves ?? new List<EnemyMove>());
+                moves ?? new List<EnemyMove>(),
+                1f,
+                null,
+                elementType);
 
             _createdAssets.Add(enemy);
             return enemy;

--- a/Assets/Tests/EditMode/DamageEffectivenessTests.cs
+++ b/Assets/Tests/EditMode/DamageEffectivenessTests.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using RoguelikeCardBattler.Gameplay.Cards;
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Gameplay.Enemies;
+
+namespace RoguelikeCardBattler.Tests.EditMode
+{
+    public class DamageEffectivenessTests : CombatTestBase
+    {
+        private TurnManager CreateTurnManager(CardDefinition card, EnemyDefinition enemy)
+        {
+            var deck = new List<CardDeckEntry> { CreateSingleCardEntry(card) };
+
+            var go = CreateGameObject("TurnManager");
+            var manager = AddComponent<TurnManager>(go);
+            manager.SetTestConfig(maxHp: 30, energy: 3, startingHand: 1, cardsPerTurnCount: 1);
+            manager.SetTestData(deck, enemy);
+            return manager;
+        }
+
+        [Test]
+        public void PlayerDamage_SuperEffective_DealsIncreasedDamage()
+        {
+            var damage = CreateEffect(EffectType.Damage, 10, EffectTarget.SingleEnemy);
+            var card = CreateCardWithElement(
+                "strike_rojo",
+                CardType.Attack,
+                CardTarget.SingleEnemy,
+                cost: 0,
+                elementType: ElementType.Rojo,
+                damage);
+
+            var enemy = CreateEnemyDefinition(
+                "enemy_azul",
+                "Enemy Azul",
+                maxHp: 20,
+                pattern: EnemyAIPattern.Sequence,
+                moves: new List<EnemyMove>(),
+                elementType: ElementType.Azul);
+
+            var manager = CreateTurnManager(card, enemy);
+            manager.InitializeCombat();
+
+            var cardEntry = manager.PlayerHand[0];
+            bool played = manager.PlayCard(cardEntry);
+
+            Assert.IsTrue(played);
+            Assert.AreEqual(5, manager.EnemyHP); // 20 - round(10 * 1.5) = 5
+        }
+
+        [Test]
+        public void PlayerDamage_LessEffective_DealsReducedDamage()
+        {
+            var damage = CreateEffect(EffectType.Damage, 10, EffectTarget.SingleEnemy);
+            var card = CreateCardWithElement(
+                "strike_azul",
+                CardType.Attack,
+                CardTarget.SingleEnemy,
+                cost: 0,
+                elementType: ElementType.Azul,
+                damage);
+
+            var enemy = CreateEnemyDefinition(
+                "enemy_rojo",
+                "Enemy Rojo",
+                maxHp: 20,
+                pattern: EnemyAIPattern.Sequence,
+                moves: new List<EnemyMove>(),
+                elementType: ElementType.Rojo);
+
+            var manager = CreateTurnManager(card, enemy);
+            manager.InitializeCombat();
+
+            var cardEntry = manager.PlayerHand[0];
+            bool played = manager.PlayCard(cardEntry);
+
+            Assert.IsTrue(played);
+            Assert.AreEqual(12, manager.EnemyHP); // 20 - round(10 * 0.75) = 12
+        }
+    }
+}
+

--- a/Assets/Tests/EditMode/DamageEffectivenessTests.cs.meta
+++ b/Assets/Tests/EditMode/DamageEffectivenessTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7be0318ce711eae40bfe0b24f3099526


### PR DESCRIPTION
- Aplica multiplicadores de daño según efectividad cuando una carta del jugador daña al enemigo (x1.5 / x0.75 / x1.0, Mathf.RoundToInt).
- Mantiene DamageAction intacto; el daño llega ya ajustado desde TurnManager.
- Añade helpers de test para crear cartas/enemigos con ElementType.
- Agrega tests EditMode (DamageEffectivenessTests) para casos SuperEficaz (10→15) y PocoEficaz (10→8).
- Tests EditMode: 52/52 en verde.