### PR TITLE
Feat 1.6: feedback de combate + rename a Momentum

### DIFF
--- a/Assets/Scenes/BattleScene.unity
+++ b/Assets/Scenes/BattleScene.unity
@@ -391,6 +391,8 @@ MonoBehaviour:
   energyPerTurn: 3
   startingHandSize: 5
   cardsPerTurn: 5
+  maxWorldSwitchesPerCombat: 1
+  debugUnlimitedWorldSwitches: 1
   currentWorld: 0
 --- !u!114 &876543212
 MonoBehaviour:

--- a/Assets/ScriptableObjects/Cards/StrikeSideB.asset
+++ b/Assets/ScriptableObjects/Cards/StrikeSideB.asset
@@ -28,4 +28,4 @@ MonoBehaviour:
     target: 1
     statusType: 0
     extraParams: []
-
+  elementType: 5

--- a/Assets/Scripts/Gameplay/Combat/TurnManager.cs
+++ b/Assets/Scripts/Gameplay/Combat/TurnManager.cs
@@ -76,6 +76,8 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         public int MaxWorldSwitchesPerCombat => maxWorldSwitchesPerCombat;
         public bool DebugUnlimitedWorldSwitches => debugUnlimitedWorldSwitches;
 
+        public event Action<Effectiveness, bool> PlayerHitEffectiveness;
+
         private void Start()
         {
             InitializeCombat();
@@ -362,12 +364,15 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             int adjusted = Mathf.RoundToInt(baseAmount * multiplier);
             int finalAmount = Math.Max(0, adjusted);
 
+            bool momentumGranted = false;
             if (effectiveness == Effectiveness.SuperEficaz && finalAmount > 0)
             {
                 _freePlays++;
-                Debug.Log("ONE MORE: Free Play +1");
+                momentumGranted = true;
+                Debug.Log("MOMENTUM: Free Play +1");
             }
 
+            PlayerHitEffectiveness?.Invoke(effectiveness, momentumGranted);
             return finalAmount;
         }
 


### PR DESCRIPTION
- Renombra referencias visibles de “One More” a “Momentum” (logs y HUD: “Momentum: X”).
- TurnManager expone un evento PlayerHitEffectiveness para reportar efectividad (WEAK/RESIST) y si se otorgó Momentum.
- CombatUIController se suscribe al evento y muestra un popup temporal: “WEAK!” + “MOMENTUM +1” o “RESIST” (Neutro no muestra).
- Mantiene reglas de gameplay; solo añade feedback UI.
- EditMode tests: siguen en verde.