### PR TITLE
chore: add code documentation/comments pass

### DIFF
--- a/Assets/Scripts/Gameplay/Cards/CardDeckEntry.cs
+++ b/Assets/Scripts/Gameplay/Cards/CardDeckEntry.cs
@@ -5,6 +5,10 @@ using UnityEngine;
 namespace RoguelikeCardBattler.Gameplay.Cards
 {
     [Serializable]
+    /// <summary>
+    /// Entrada que puede apuntar a una carta simple o dual. Resuelve la activa
+    /// según el WorldSide actual.
+    /// </summary>
     public class CardDeckEntry
     {
         [SerializeField] private CardDefinition singleCard;

--- a/Assets/Scripts/Gameplay/Cards/CardDefinition.cs
+++ b/Assets/Scripts/Gameplay/Cards/CardDefinition.cs
@@ -4,6 +4,9 @@ using RoguelikeCardBattler.Gameplay.Combat;
 
 namespace RoguelikeCardBattler.Gameplay.Cards
 {
+    /// <summary>
+    /// ScriptableObject de carta simple: coste, efectos, tipo elemental y metadatos.
+    /// </summary>
     [CreateAssetMenu(menuName = "Cards/Card Definition", fileName = "CardDefinition")]
     public class CardDefinition : ScriptableObject
     {

--- a/Assets/Scripts/Gameplay/Cards/DualCardDefinition.cs
+++ b/Assets/Scripts/Gameplay/Cards/DualCardDefinition.cs
@@ -3,6 +3,9 @@ using RoguelikeCardBattler.Gameplay.Combat;
 
 namespace RoguelikeCardBattler.Gameplay.Cards
 {
+    /// <summary>
+    /// Carta dual con dos lados (A/B) elegidos según WorldSide. Ambas mitades comparten ID y coste.
+    /// </summary>
     [CreateAssetMenu(menuName = "Cards/Dual Card Definition", fileName = "DualCardDefinition")]
     public class DualCardDefinition : ScriptableObject
     {

--- a/Assets/Scripts/Gameplay/Combat/ActionQueue.cs
+++ b/Assets/Scripts/Gameplay/Combat/ActionQueue.cs
@@ -4,7 +4,8 @@ using System.Collections.Generic;
 namespace RoguelikeCardBattler.Gameplay.Combat
 {
     /// <summary>
-    /// Deterministic FIFO queue that resolves gameplay actions one at a time.
+    /// Cola FIFO determinista que resuelve IGameAction una por una.
+    /// Garantiza orden y no reentrar ProcessAll mientras está procesando.
     /// </summary>
     public class ActionQueue
     {

--- a/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
@@ -8,7 +8,9 @@ using RoguelikeCardBattler.Gameplay.Enemies;
 namespace RoguelikeCardBattler.Gameplay.Combat
 {
     /// <summary>
-    /// Runtime UI that builds a simple battle HUD, placeholders, and card buttons.
+    /// Construye la UI de combate en runtime: HUD (energía, momentum, mundo, switches),
+    /// mano de cartas y popups de feedback. Reconstruye el canvas y captura sprites
+    /// existentes si fueron asignados en escena/inspector para que no se pierdan.
     /// </summary>
     public class CombatUIController : MonoBehaviour
     {
@@ -131,6 +133,8 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         /// <summary>
         /// Si ya existen instancias de UI en escena (por ejemplo, con sprites asignados en editor),
         /// preserva esos sprites y limpia la UI previa para que BuildUI regenere con esos sprites.
+        /// IMPORTANTE: sprites asignados dentro del canvas original se pierden si no se
+        /// configuran aquí; asignarlos al controller o asegurarse de que estén capturados.
         /// </summary>
         private void CaptureExistingAvatarSprites()
         {

--- a/Assets/Scripts/Gameplay/Combat/ElementTypes.cs
+++ b/Assets/Scripts/Gameplay/Combat/ElementTypes.cs
@@ -1,5 +1,8 @@
 namespace RoguelikeCardBattler.Gameplay.Combat
 {
+    /// <summary>
+    /// Tipos elementales placeholder por color. Se renombrarán a tipos finales.
+    /// </summary>
     public enum ElementType
     {
         None = 0,
@@ -11,6 +14,9 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         Blanco
     }
 
+    /// <summary>
+    /// Resultado de atacar con un elemento contra otro.
+    /// </summary>
     public enum Effectiveness
     {
         PocoEficaz,
@@ -18,6 +24,9 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         SuperEficaz
     }
 
+    /// <summary>
+    /// Matriz de efectividad atacante/defensor. Neutro para None o mismo tipo.
+    /// </summary>
     public static class ElementEffectiveness
     {
         public static Effectiveness GetEffectiveness(ElementType attacker, ElementType defender)

--- a/Assets/Scripts/Gameplay/Combat/EnemyCombatActor.cs
+++ b/Assets/Scripts/Gameplay/Combat/EnemyCombatActor.cs
@@ -3,6 +3,10 @@ using RoguelikeCardBattler.Gameplay.Enemies;
 
 namespace RoguelikeCardBattler.Gameplay.Combat
 {
+    /// <summary>
+    /// Wrapper de stats de enemigo en combate. Usa EnemyDefinition para datos base
+    /// y TurnManager orquesta su turno/acciones.
+    /// </summary>
     public class EnemyCombatActor : ICombatActor
     {
         public EnemyDefinition Definition { get; }

--- a/Assets/Scripts/Gameplay/Combat/IGameAction.cs
+++ b/Assets/Scripts/Gameplay/Combat/IGameAction.cs
@@ -1,5 +1,9 @@
 namespace RoguelikeCardBattler.Gameplay.Combat
 {
+    /// <summary>
+    /// Contrato mínimo para acciones encoladas en la ActionQueue.
+    /// Deben ser puras (sin asumir orden distinto) y tolerar nulls de contexto si aplica.
+    /// </summary>
     public interface IGameAction
     {
         void Execute(ActionContext context);

--- a/Assets/Scripts/Gameplay/Combat/PlayerCombatActor.cs
+++ b/Assets/Scripts/Gameplay/Combat/PlayerCombatActor.cs
@@ -4,6 +4,10 @@ using RoguelikeCardBattler.Gameplay.Cards;
 
 namespace RoguelikeCardBattler.Gameplay.Combat
 {
+    /// <summary>
+    /// Representa al jugador en combate: vida, energía, bloqueo y manejo de mazo/mano/descartes.
+    /// TurnManager dirige su flujo (robar, jugar cartas, descartar, etc.).
+    /// </summary>
     public class PlayerCombatActor : ICombatActor
     {
         private readonly List<CardDeckEntry> _drawPile = new List<CardDeckEntry>();

--- a/Assets/Scripts/Gameplay/Combat/TurnManager.cs
+++ b/Assets/Scripts/Gameplay/Combat/TurnManager.cs
@@ -7,6 +7,11 @@ using RoguelikeCardBattler.Gameplay.Enemies;
 
 namespace RoguelikeCardBattler.Gameplay.Combat
 {
+    /// <summary>
+    /// Orquesta el flujo de combate: fases de turno, jugar cartas, encolar efectos
+    /// en la ActionQueue y aplicar efectividad/Momentum. Gestiona también Change World
+    /// (limitado por combate con override de debug) y expone eventos para feedback UI.
+    /// </summary>
     public class TurnManager : MonoBehaviour
     {
         [Header("Setup")]
@@ -76,6 +81,11 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         public int MaxWorldSwitchesPerCombat => maxWorldSwitchesPerCombat;
         public bool DebugUnlimitedWorldSwitches => debugUnlimitedWorldSwitches;
 
+        /// <summary>
+        /// Evento disparado al aplicar daño de carta del jugador al enemigo.
+        /// Entrega la efectividad (WEAK/RESIST/NEUTRAL) y si se otorgó Momentum (+1 free play).
+        /// Consumido por la UI para mostrar popups/labels.
+        /// </summary>
         public event Action<Effectiveness, bool> PlayerHitEffectiveness;
 
         private void Start()

--- a/Assets/Scripts/Gameplay/Enemies/EnemyDefinition.cs
+++ b/Assets/Scripts/Gameplay/Enemies/EnemyDefinition.cs
@@ -4,6 +4,9 @@ using RoguelikeCardBattler.Gameplay.Combat;
 
 namespace RoguelikeCardBattler.Gameplay.Enemies
 {
+    /// <summary>
+    /// ScriptableObject de enemigo: HP base, patrón de IA (RandomWeighted/Sequence), moves y tipo elemental.
+    /// </summary>
     [CreateAssetMenu(menuName = "Enemies/Enemy Definition", fileName = "EnemyDefinition")]
     public class EnemyDefinition : ScriptableObject
     {

--- a/Assets/Scripts/Gameplay/Enemies/EnemyMove.cs
+++ b/Assets/Scripts/Gameplay/Enemies/EnemyMove.cs
@@ -5,6 +5,9 @@ using UnityEngine;
 
 namespace RoguelikeCardBattler.Gameplay.Enemies
 {
+    /// <summary>
+    /// Tipo de intención mostrado en UI (básico: Attack / Defend / Unknown).
+    /// </summary>
     public enum EnemyIntentType
     {
         Unknown,
@@ -13,6 +16,9 @@ namespace RoguelikeCardBattler.Gameplay.Enemies
     }
 
     [Serializable]
+    /// <summary>
+    /// Movimiento de enemigo con efectos, peso/orden y tipo de intención para UI.
+    /// </summary>
     public class EnemyMove
     {
         [SerializeField] private string id = string.Empty;


### PR DESCRIPTION
Closes #9
- Añade docstrings/comentarios de alto valor en clases clave del combate, UI runtime, cola de acciones, tipos/efectividad, cartas (single/dual) y enemigos.
- Documenta decisiones y “pitfalls” (Momentum vs FreePlays, Change World limitado + debug, UI se reconstruye y captura sprites).
- Sin cambios de gameplay.