### PR TITLE
feat: enemy hit reaction (flash/shake + optional hit frames)

### DIFF
--- a/Assets/Scripts/Gameplay/Combat/Actions/DamageAction.cs
+++ b/Assets/Scripts/Gameplay/Combat/Actions/DamageAction.cs
@@ -7,12 +7,14 @@ namespace RoguelikeCardBattler.Gameplay.Combat.Actions
         private readonly ICombatActor _source;
         private readonly ICombatActor _target;
         private readonly int _amount;
+        private readonly Action<int> _onDamageApplied;
 
-        public DamageAction(ICombatActor source, ICombatActor target, int amount)
+        public DamageAction(ICombatActor source, ICombatActor target, int amount, Action<int> onDamageApplied = null)
         {
             _source = source;
             _target = target;
             _amount = Math.Max(0, amount);
+            _onDamageApplied = onDamageApplied;
         }
 
         public void Execute(ActionContext context)
@@ -22,7 +24,13 @@ namespace RoguelikeCardBattler.Gameplay.Combat.Actions
                 return;
             }
 
+            int hpBefore = _target.CurrentHP;
             _target.TakeDamage(_amount, _source);
+            int damageApplied = Math.Max(0, hpBefore - (_target?.CurrentHP ?? hpBefore));
+            if (damageApplied > 0)
+            {
+                _onDamageApplied?.Invoke(damageApplied);
+            }
         }
 
         public override string ToString() =>

--- a/Assets/Scripts/Gameplay/Combat/TurnManager.cs
+++ b/Assets/Scripts/Gameplay/Combat/TurnManager.cs
@@ -88,6 +88,11 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         /// </summary>
         public event Action<Effectiveness, bool> PlayerHitEffectiveness;
 
+        /// <summary>
+        /// Evento disparado cuando el enemigo recibe daño > 0. Valor es el daño final aplicado a HP.
+        /// </summary>
+        public event Action<int> EnemyTookDamage;
+
         private void Start()
         {
             InitializeCombat();
@@ -308,7 +313,18 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             {
                 case EffectType.Damage:
                     int adjustedDamage = AdjustDamageForEffectiveness(source, target, sourceElementType, amount);
-                    return new DamageAction(source, target, adjustedDamage);
+                    Action<int> onEnemyDamage = null;
+                    if (source == _player && target == _enemy)
+                    {
+                        onEnemyDamage = dmg =>
+                        {
+                            if (dmg > 0)
+                            {
+                                EnemyTookDamage?.Invoke(dmg);
+                            }
+                        };
+                    }
+                    return new DamageAction(source, target, adjustedDamage, onEnemyDamage);
                 case EffectType.Block:
                     return new BlockAction(target, amount);
                 case EffectType.DrawCards:


### PR DESCRIPTION
Closes #18
- Añade evento de daño real al enemigo (solo si daño aplicado > 0) para disparar feedback visual en el momento correcto.
- CombatUIController: reacción de hit del slime al recibir daño (flash + shake) y soporte opcional de animación Hit por frames (2–4 sprites) usando SpriteFrameAnimatorUI.
- Mantiene timing coherente con el attack del héroe (reacción ocurre cuando el daño se aplica, no al click).
- Sin cambios de reglas; tests EditMode siguen en verde.