### PR TITLE
feat(e4-p04): conectar mapa → combate → retorno con resultado (victor…

### DIFF
--- a/Assets/Scenes/BattleScene.unity
+++ b/Assets/Scenes/BattleScene.unity
@@ -456,6 +456,50 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1234567890
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1234567891}
+  - component: {fileID: 1234567892}
+  m_Layer: 0
+  m_Name: BattleFlowController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1234567891
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1234567890}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1234567892
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1234567890}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8f39588a2c6f21b498823d01349c3ccf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -463,3 +507,4 @@ SceneRoots:
   - {fileID: 519420032}
   - {fileID: 619394802}
   - {fileID: 876543213}
+  - {fileID: 1234567891}

--- a/Assets/Scenes/RunScene.unity
+++ b/Assets/Scenes/RunScene.unity
@@ -340,9 +340,54 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2233445500
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2233445501}
+  - component: {fileID: 2233445502}
+  m_Layer: 0
+  m_Name: RunFlowController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2233445501
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2233445500}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2233445502
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2233445500}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9aa59d48ec4881a4fad92bc25e7abf4b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 519420032}
   - {fileID: 619394802}
+  - {fileID: 2233445501}

--- a/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
@@ -142,13 +142,38 @@ namespace RoguelikeCardBattler.Gameplay.Combat
 
         private void EnsureEventSystem()
         {
-            if (EventSystem.current != null)
+            EventSystem existing = Object.FindFirstObjectByType<EventSystem>();
+            GameObject target = existing != null ? existing.gameObject : new GameObject("EventSystem", typeof(EventSystem));
+
+            System.Type inputSystemType = System.Type.GetType("UnityEngine.InputSystem.UI.InputSystemUIInputModule, Unity.InputSystem");
+            if (inputSystemType != null)
             {
+                StandaloneInputModule legacy = target.GetComponent<StandaloneInputModule>();
+                if (legacy != null)
+                {
+                    Destroy(legacy);
+                }
+
+                if (target.GetComponent(inputSystemType) == null)
+                {
+                    target.AddComponent(inputSystemType);
+                }
+
                 return;
             }
 
-            GameObject eventSystemGO = new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
-            DontDestroyOnLoad(eventSystemGO);
+            if (target.GetComponent<StandaloneInputModule>() == null)
+            {
+                foreach (Component component in target.GetComponents<Component>())
+                {
+                    if (component != null && component.GetType().FullName == "UnityEngine.InputSystem.UI.InputSystemUIInputModule")
+                    {
+                        Destroy(component);
+                    }
+                }
+
+                target.AddComponent<StandaloneInputModule>();
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Run/BattleFlowController.cs
+++ b/Assets/Scripts/Run/BattleFlowController.cs
@@ -1,0 +1,106 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using RoguelikeCardBattler.Gameplay.Combat;
+
+namespace RoguelikeCardBattler.Run
+{
+    /// <summary>
+    /// Reporta el resultado del combate a la RunSession y vuelve a RunScene.
+    /// </summary>
+    public class BattleFlowController : MonoBehaviour
+    {
+        private TurnManager _turnManager;
+        private bool _reported;
+
+        private void Awake()
+        {
+#if UNITY_EDITOR
+            Debug.Log("[BattleFlow] Awake");
+#endif
+            BattleFlowController[] all = Object.FindObjectsByType<BattleFlowController>(FindObjectsSortMode.None);
+            if (all.Length > 1)
+            {
+                for (int i = 0; i < all.Length; i++)
+                {
+                    if (all[i] != this)
+                    {
+                        all[i].enabled = false;
+                        Destroy(all[i].gameObject);
+                    }
+                }
+#if UNITY_EDITOR
+                Debug.Log("[BattleFlow] Duplicate detected, destroying extras.");
+#endif
+            }
+        }
+
+        private void Update()
+        {
+            if (_reported)
+            {
+                return;
+            }
+
+            if (_turnManager == null)
+            {
+                _turnManager = Object.FindFirstObjectByType<TurnManager>();
+                if (_turnManager == null)
+                {
+                    return;
+                }
+#if UNITY_EDITOR
+                Debug.Log("[BattleFlow] Found TurnManager");
+#endif
+            }
+
+            bool finished = _turnManager.IsCombatFinished
+                || _turnManager.CurrentPhase == TurnManager.CombatPhase.Victory
+                || _turnManager.CurrentPhase == TurnManager.CombatPhase.Defeat;
+            if (!finished)
+            {
+                return;
+            }
+
+            bool victory = _turnManager.CurrentPhase == TurnManager.CombatPhase.Victory;
+#if UNITY_EDITOR
+            Debug.Log($"[BattleFlow] Phase={_turnManager.CurrentPhase}");
+#endif
+            ReportOutcome(victory);
+        }
+
+        private void ReportOutcome(bool victory)
+        {
+            _reported = true;
+            RunSession session = RunSession.GetOrCreate();
+            session.State.LastNodeOutcome = victory ? RunState.NodeOutcome.Victory : RunState.NodeOutcome.Defeat;
+            session.State.PendingReturnFromBattle = true;
+            session.State.RunFailed = !victory;
+            if (!IsSceneInBuild("RunScene"))
+            {
+#if UNITY_EDITOR
+                Debug.LogError("[BattleFlow] RunScene no está en Build Settings.");
+#endif
+                return;
+            }
+#if UNITY_EDITOR
+            Debug.Log("[BattleFlow] Loading RunScene");
+#endif
+            SceneManager.LoadScene("RunScene");
+        }
+
+        private bool IsSceneInBuild(string sceneName)
+        {
+            int total = SceneManager.sceneCountInBuildSettings;
+            for (int i = 0; i < total; i++)
+            {
+                string path = SceneUtility.GetScenePathByBuildIndex(i);
+                if (path.EndsWith($"/{sceneName}.unity"))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/Run/BattleFlowController.cs.meta
+++ b/Assets/Scripts/Run/BattleFlowController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8f39588a2c6f21b498823d01349c3ccf

--- a/Assets/Scripts/Run/RunState.cs
+++ b/Assets/Scripts/Run/RunState.cs
@@ -7,11 +7,21 @@ namespace RoguelikeCardBattler.Run
     /// </summary>
     public class RunState
     {
+        public enum NodeOutcome
+        {
+            None,
+            Victory,
+            Defeat
+        }
+
         public int CurrentPositionNodeId { get; set; } = -1;
         public int CurrentNodeId { get; set; } = -1;
         public int Gold { get; set; } = 0;
         public HashSet<int> CompletedNodes { get; } = new HashSet<int>();
         public HashSet<int> AvailableNodes { get; } = new HashSet<int>();
+        public bool PendingReturnFromBattle { get; set; }
+        public NodeOutcome LastNodeOutcome { get; set; } = NodeOutcome.None;
+        public bool RunFailed { get; set; }
 
         public void EnsureInitialized(ActMap map)
         {
@@ -29,6 +39,19 @@ namespace RoguelikeCardBattler.Run
             CompletedNodes.Clear();
             AvailableNodes.Add(map.StartNodeId);
             CurrentPositionNodeId = map.StartNodeId;
+        }
+
+        public void Reset(ActMap map)
+        {
+            CompletedNodes.Clear();
+            AvailableNodes.Clear();
+            CurrentNodeId = -1;
+            CurrentPositionNodeId = -1;
+            Gold = 0;
+            PendingReturnFromBattle = false;
+            LastNodeOutcome = NodeOutcome.None;
+            RunFailed = false;
+            EnsureInitialized(map);
         }
 
         public bool IsNodeAvailable(int nodeId) => AvailableNodes.Contains(nodeId);


### PR DESCRIPTION
…ia/derrota)

Closes #25
Flujo real entre escenas: desde RunScene (mapa) al seleccionar un nodo Combat/Elite/Boss available se carga BattleScene, y al terminar el combate se retorna a RunScene. Estado persistente sin PlayerPrefs: el resultado del combate se comunica vía RunSession.State (en memoria) usando flags (CurrentNodeId, PendingReturnFromBattle, LastNodeOutcome, RunFailed). Victoria:
al volver a RunScene se marca el nodo como Completed (✓) y se desbloquean las conexiones siguientes. Derrota:
al volver a RunScene se muestra un overlay “Derrota” que bloquea el mapa, con botones: Reintentar (vuelve a BattleScene)
Volver al mapa (resetea la run con RunState.Reset(map)). Arquitectura profesional (scene-owned controllers): RunFlowController vive en RunScene.unity y BattleFlowController vive en BattleScene.unity. Se eliminaron spawners por RuntimeInitializeOnLoadMethod y se evitó DontDestroyOnLoad en controladores de escena (solo persiste RunSession). Hardening:
deduplicación defensiva de BattleFlowController en runtime. EnsureEventSystem() sin persistencia y compatible con Input System (reflection + fallback). Validación de escenas en Build Settings con mensajes claros. Notas:
Nodos no-combate (Event/Shop/Campfire) mantienen panel placeholder (E4-P05 cubrirá recompensas/contenido real). Sin errores en consola en pruebas de ida/vuelta (victoria y derrota).