### PR TITLE
E4-P05: Recompensa post-combate (oro + elegir 1 carta) + deck persist…

### DIFF
--- a/Assets/Scenes/BattleScene.unity
+++ b/Assets/Scenes/BattleScene.unity
@@ -500,6 +500,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8f39588a2c6f21b498823d01349c3ccf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  fallbackCombatConfig: {fileID: 11400000, guid: f1b2c3d4e5f67890abcdef1234567890, type: 2}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/RunScene.unity
+++ b/Assets/Scenes/RunScene.unity
@@ -384,6 +384,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9aa59d48ec4881a4fad92bc25e7abf4b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  uiFont: {fileID: 0}
+  runCombatConfig: {fileID: 11400000, guid: f1b2c3d4e5f67890abcdef1234567890, type: 2}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/ScriptableObjects/Run.meta
+++ b/Assets/ScriptableObjects/Run.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5386c610708902c4bb14d7ffe7653bfb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Run/RunCombatConfig_Act1.asset
+++ b/Assets/ScriptableObjects/Run/RunCombatConfig_Act1.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c8147de25f2afda47a5c67aae71f48c0, type: 3}
+  m_Name: RunCombatConfig_Act1
+  m_EditorClassIdentifier: 
+  goldReward: 10
+  choicesCount: 3
+  defaultEnemy: {fileID: 11400000, guid: a5f86b9e5ecb4de5bf5dfbcfbcff3577, type: 2}
+  starterDeck:
+  - singleCard: {fileID: 0}
+    dualCard: {fileID: 11400000, guid: dc5f57a1b1114ca3bce64dbe9843de30, type: 2}
+  - singleCard: {fileID: 0}
+    dualCard: {fileID: 11400000, guid: dc5f57a1b1114ca3bce64dbe9843de30, type: 2}
+  - singleCard: {fileID: 0}
+    dualCard: {fileID: 11400000, guid: dc5f57a1b1114ca3bce64dbe9843de30, type: 2}
+  - singleCard: {fileID: 0}
+    dualCard: {fileID: 11400000, guid: 9adafdc7d3964a2ba54afa9b5740d5af, type: 2}
+  - singleCard: {fileID: 0}
+    dualCard: {fileID: 11400000, guid: 9adafdc7d3964a2ba54afa9b5740d5af, type: 2}
+  - singleCard: {fileID: 0}
+    dualCard: {fileID: 11400000, guid: ce1ce5bd21da4478861f66b51d98d240, type: 2}
+  - singleCard: {fileID: 0}
+    dualCard: {fileID: 11400000, guid: dc5f57a1b1114ca3bce64dbe9843de30, type: 2}
+  rewardPool:
+  - singleCard: {fileID: 0}
+    dualCard: {fileID: 11400000, guid: dc5f57a1b1114ca3bce64dbe9843de30, type: 2}
+  - singleCard: {fileID: 0}
+    dualCard: {fileID: 11400000, guid: 9adafdc7d3964a2ba54afa9b5740d5af, type: 2}
+  - singleCard: {fileID: 0}
+    dualCard: {fileID: 11400000, guid: ce1ce5bd21da4478861f66b51d98d240, type: 2}

--- a/Assets/ScriptableObjects/Run/RunCombatConfig_Act1.asset.meta
+++ b/Assets/ScriptableObjects/Run/RunCombatConfig_Act1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f1b2c3d4e5f67890abcdef1234567890
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Cards/CardDeckEntry.cs
+++ b/Assets/Scripts/Gameplay/Cards/CardDeckEntry.cs
@@ -29,17 +29,51 @@ namespace RoguelikeCardBattler.Gameplay.Cards
             return singleCard;
         }
 
-#if UNITY_EDITOR || UNITY_INCLUDE_TESTS
-        public void SetSingleCard(CardDefinition card)
+        public void SetSingleCardRuntime(CardDefinition card)
         {
             singleCard = card;
             dualCard = null;
         }
 
-        public void SetDualCard(DualCardDefinition card)
+        public void SetDualCardRuntime(DualCardDefinition card)
         {
             dualCard = card;
             singleCard = null;
+        }
+
+        public static CardDeckEntry CreateSingle(CardDefinition card)
+        {
+            var entry = new CardDeckEntry();
+            entry.SetSingleCardRuntime(card);
+            return entry;
+        }
+
+        public static CardDeckEntry CreateDual(DualCardDefinition card)
+        {
+            var entry = new CardDeckEntry();
+            entry.SetDualCardRuntime(card);
+            return entry;
+        }
+
+        public CardDeckEntry Clone()
+        {
+            if (dualCard != null)
+            {
+                return CreateDual(dualCard);
+            }
+
+            return CreateSingle(singleCard);
+        }
+
+#if UNITY_EDITOR || UNITY_INCLUDE_TESTS
+        public void SetSingleCard(CardDefinition card)
+        {
+            SetSingleCardRuntime(card);
+        }
+
+        public void SetDualCard(DualCardDefinition card)
+        {
+            SetDualCardRuntime(card);
         }
 #endif
     }

--- a/Assets/Scripts/Gameplay/Combat/TurnManager.cs
+++ b/Assets/Scripts/Gameplay/Combat/TurnManager.cs
@@ -39,6 +39,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         private ActionQueue _actionQueue;
         private CombatPhase _phase = CombatPhase.None;
         private bool _initialized;
+        private bool _externalConfigApplied;
         private readonly System.Random _random = new System.Random();
         private int _enemySequenceCursor;
         private EnemyMove _plannedEnemyMove;
@@ -95,6 +96,10 @@ namespace RoguelikeCardBattler.Gameplay.Combat
 
         private void Start()
         {
+            if (_externalConfigApplied)
+            {
+                return;
+            }
             InitializeCombat();
         }
 
@@ -158,6 +163,33 @@ namespace RoguelikeCardBattler.Gameplay.Combat
 
             PlanNextEnemyMove();
             BeginPlayerTurn(useStartingHand: true);
+        }
+
+        /// <summary>
+        /// Configura el combate con un deck y enemigo específicos antes de inicializar.
+        /// </summary>
+        public void ConfigureCombat(List<CardDeckEntry> deck, EnemyDefinition enemy, bool initializeImmediately = true)
+        {
+            if (deck == null || deck.Count == 0)
+            {
+                Debug.LogError("ConfigureCombat: deck inválido.");
+                return;
+            }
+
+            if (enemy == null)
+            {
+                Debug.LogError("ConfigureCombat: enemy inválido.");
+                return;
+            }
+
+            starterDeck = new List<CardDeckEntry>(deck);
+            enemyDefinition = enemy;
+            _externalConfigApplied = true;
+
+            if (initializeImmediately)
+            {
+                InitializeCombat();
+            }
         }
 
         public bool PlayCard(CardDeckEntry cardEntry, ICombatActor explicitTarget = null)

--- a/Assets/Scripts/Run/BattleFlowController.cs
+++ b/Assets/Scripts/Run/BattleFlowController.cs
@@ -9,8 +9,12 @@ namespace RoguelikeCardBattler.Run
     /// </summary>
     public class BattleFlowController : MonoBehaviour
     {
+        private const string RunSceneName = "RunScene";
         private TurnManager _turnManager;
         private bool _reported;
+        private bool _configured;
+        private bool _configErrorLogged;
+        [SerializeField] private RunCombatConfig fallbackCombatConfig;
 
         private void Awake()
         {
@@ -32,6 +36,8 @@ namespace RoguelikeCardBattler.Run
                 Debug.Log("[BattleFlow] Duplicate detected, destroying extras.");
 #endif
             }
+
+            TryConfigureCombat();
         }
 
         private void Update()
@@ -39,6 +45,11 @@ namespace RoguelikeCardBattler.Run
             if (_reported)
             {
                 return;
+            }
+
+            if (!_configured)
+            {
+                TryConfigureCombat();
             }
 
             if (_turnManager == null)
@@ -75,7 +86,7 @@ namespace RoguelikeCardBattler.Run
             session.State.LastNodeOutcome = victory ? RunState.NodeOutcome.Victory : RunState.NodeOutcome.Defeat;
             session.State.PendingReturnFromBattle = true;
             session.State.RunFailed = !victory;
-            if (!IsSceneInBuild("RunScene"))
+            if (!IsSceneInBuild(RunSceneName))
             {
 #if UNITY_EDITOR
                 Debug.LogError("[BattleFlow] RunScene no está en Build Settings.");
@@ -85,7 +96,57 @@ namespace RoguelikeCardBattler.Run
 #if UNITY_EDITOR
             Debug.Log("[BattleFlow] Loading RunScene");
 #endif
-            SceneManager.LoadScene("RunScene");
+            SceneManager.LoadScene(RunSceneName);
+        }
+
+        private void TryConfigureCombat()
+        {
+            RunSession session = RunSession.GetOrCreate();
+            if (session.CombatConfig == null && fallbackCombatConfig != null)
+            {
+                session.ConfigureCombat(fallbackCombatConfig);
+            }
+
+            RunCombatConfig config = session.CombatConfig;
+            if (config == null || config.DefaultEnemy == null)
+            {
+#if UNITY_EDITOR
+                if (!_configErrorLogged)
+                {
+                    Debug.LogError("[BattleFlow] RunCombatConfig o enemigo default no asignado.");
+                    _configErrorLogged = true;
+                }
+#endif
+                return;
+            }
+
+            if (_turnManager == null)
+            {
+                _turnManager = Object.FindFirstObjectByType<TurnManager>();
+                if (_turnManager == null)
+                {
+                    return;
+                }
+            }
+
+            var deck = session.State.GetDeckSnapshot();
+            if (deck.Count == 0)
+            {
+#if UNITY_EDITOR
+                if (!_configErrorLogged)
+                {
+                    Debug.LogError("[BattleFlow] Deck de run vacío.");
+                    _configErrorLogged = true;
+                }
+#endif
+                return;
+            }
+
+#if UNITY_EDITOR
+            Debug.Log($"[BattleFlow] Deck size: {deck.Count}");
+#endif
+            _turnManager.ConfigureCombat(deck, config.DefaultEnemy);
+            _configured = true;
         }
 
         private bool IsSceneInBuild(string sceneName)

--- a/Assets/Scripts/Run/RunCombatConfig.cs
+++ b/Assets/Scripts/Run/RunCombatConfig.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using UnityEngine;
+using RoguelikeCardBattler.Gameplay.Cards;
+using RoguelikeCardBattler.Gameplay.Enemies;
+
+namespace RoguelikeCardBattler.Run
+{
+    [CreateAssetMenu(menuName = "Run/Combat Config", fileName = "RunCombatConfig")]
+    public class RunCombatConfig : ScriptableObject
+    {
+        [SerializeField] private int goldReward = 10;
+        [SerializeField] private int choicesCount = 3;
+        [SerializeField] private EnemyDefinition defaultEnemy;
+        [SerializeField] private List<CardDeckEntry> starterDeck = new List<CardDeckEntry>();
+        [SerializeField] private List<CardDeckEntry> rewardPool = new List<CardDeckEntry>();
+
+        public int GoldReward => Mathf.Max(0, goldReward);
+        public int ChoicesCount => Mathf.Max(1, choicesCount);
+        public EnemyDefinition DefaultEnemy => defaultEnemy;
+        public IReadOnlyList<CardDeckEntry> StarterDeck => starterDeck;
+        public IReadOnlyList<CardDeckEntry> RewardPool => rewardPool;
+    }
+}

--- a/Assets/Scripts/Run/RunCombatConfig.cs.meta
+++ b/Assets/Scripts/Run/RunCombatConfig.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c8147de25f2afda47a5c67aae71f48c0

--- a/Assets/Scripts/Run/RunSession.cs
+++ b/Assets/Scripts/Run/RunSession.cs
@@ -11,6 +11,7 @@ namespace RoguelikeCardBattler.Run
 
         public RunState State { get; } = new RunState();
         public ActMap Map { get; private set; }
+        public RunCombatConfig CombatConfig { get; private set; }
 
         public static RunSession GetOrCreate()
         {
@@ -46,6 +47,17 @@ namespace RoguelikeCardBattler.Run
                 Map = RunMapGenerator.GenerateAct1();
             }
             State.EnsureInitialized(Map);
+        }
+
+        public void ConfigureCombat(RunCombatConfig config)
+        {
+            if (config == null)
+            {
+                return;
+            }
+
+            CombatConfig = config;
+            State.InitializeDeck(config.StarterDeck);
         }
     }
 }

--- a/Assets/Scripts/Run/RunState.cs
+++ b/Assets/Scripts/Run/RunState.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using RoguelikeCardBattler.Gameplay.Cards;
 
 namespace RoguelikeCardBattler.Run
 {
@@ -19,6 +20,7 @@ namespace RoguelikeCardBattler.Run
         public int Gold { get; set; } = 0;
         public HashSet<int> CompletedNodes { get; } = new HashSet<int>();
         public HashSet<int> AvailableNodes { get; } = new HashSet<int>();
+        public List<CardDeckEntry> Deck { get; } = new List<CardDeckEntry>();
         public bool PendingReturnFromBattle { get; set; }
         public NodeOutcome LastNodeOutcome { get; set; } = NodeOutcome.None;
         public bool RunFailed { get; set; }
@@ -48,6 +50,7 @@ namespace RoguelikeCardBattler.Run
             CurrentNodeId = -1;
             CurrentPositionNodeId = -1;
             Gold = 0;
+            Deck.Clear();
             PendingReturnFromBattle = false;
             LastNodeOutcome = NodeOutcome.None;
             RunFailed = false;
@@ -56,5 +59,48 @@ namespace RoguelikeCardBattler.Run
 
         public bool IsNodeAvailable(int nodeId) => AvailableNodes.Contains(nodeId);
         public bool IsNodeCompleted(int nodeId) => CompletedNodes.Contains(nodeId);
+
+        public void InitializeDeck(IReadOnlyList<CardDeckEntry> starterDeck)
+        {
+            if (starterDeck == null || starterDeck.Count == 0 || Deck.Count > 0)
+            {
+                return;
+            }
+
+            foreach (CardDeckEntry entry in starterDeck)
+            {
+                if (entry == null || !entry.IsValid)
+                {
+                    continue;
+                }
+
+                Deck.Add(entry.Clone());
+            }
+        }
+
+        public void AddCardToDeck(CardDeckEntry entry)
+        {
+            if (entry == null || !entry.IsValid)
+            {
+                return;
+            }
+
+            Deck.Add(entry.Clone());
+        }
+
+        public void AddCardToDeck(CardDefinition card)
+        {
+            if (card == null)
+            {
+                return;
+            }
+
+            AddCardToDeck(CardDeckEntry.CreateSingle(card));
+        }
+
+        public List<CardDeckEntry> GetDeckSnapshot()
+        {
+            return new List<CardDeckEntry>(Deck);
+        }
     }
 }


### PR DESCRIPTION
…ente, sin spam de consola

Implementa recompensa tras victoria: overlay “Recompensa” en RunScene con +oro y 3 opciones de carta; al elegir 1 se añade al mazo de la run. Añade deck persistente en memoria vía RunSession/RunState (sin PlayerPrefs) y lo usa en combates siguientes. Introduce RunCombatConfig (ScriptableObject) data-driven: starterDeck, rewardPool, defaultEnemy, goldReward, choicesCount. Fix “out of the box”: assets/escenas referencian un RunCombatConfig_Act1 por defecto y BattleScene tiene fallback para inicializar RunSession si entra directo. Robustez: validaciones con errores claros y anti-spam en logs; RunFlowController usa RunSession.CombatConfig como fuente de verdad si el campo serializado viene null. Verificado en Play Mode: RunScene → Combat → Victoria → RewardPanel aparece; elegir carta persiste (ej. duplicado de Battle Focus confirmado en deck).