### PR TITLE
E4-P13: Auto-end turn + jugabilidad correcta con Momentum/FreePlays (…

### DIFF
--- a/Assets/Scenes/BattleScene.unity
+++ b/Assets/Scenes/BattleScene.unity
@@ -389,9 +389,9 @@ MonoBehaviour:
   playerDisplayName: Test Pilot
   playerMaxHP: 60
   energyPerTurn: 3
-  startingHandSize: 1
-  cardsPerTurn: 1
-  maxHandSize: 1
+  startingHandSize: 5
+  cardsPerTurn: 4
+  maxHandSize: 7
   maxWorldSwitchesPerCombat: 1
   debugUnlimitedWorldSwitches: 1
   currentWorld: 0
@@ -446,8 +446,11 @@ MonoBehaviour:
   - {fileID: 5321023335126192047, guid: 67ee2dba17c10c74781dfee5d1cd4fd5, type: 3}
   - {fileID: 1819059919184003959, guid: 98ccda914973d7f468ca9f0077bc4a4b, type: 3}
   heroAttackFps: 16
+  hitFeedbackDuration: 0.85
   enemyHitFrames: []
   enemyHitFps: 16
+  handLimitToastDuration: 0.7
+  handLimitToastCooldown: 0.6
 --- !u!4 &876543213
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
@@ -783,12 +783,10 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             }
 
             bool canInteract = turnManager.IsPlayerTurn();
-            int currentEnergy = turnManager.PlayerEnergy;
             foreach (CardButtonBinding binding in _cardButtons)
             {
-                CardDefinition activeCard = turnManager.GetActiveCardDefinition(binding.CardEntry);
-                bool enoughEnergy = activeCard != null && currentEnergy >= activeCard.Cost;
-                binding.Button.interactable = canInteract && enoughEnergy;
+                bool canPlay = turnManager.CanPlayCard(binding.CardEntry);
+                binding.Button.interactable = canInteract && canPlay;
                 binding.Label.text = BuildCardLabel(binding.CardEntry);
                 if (binding.Label != null)
                 {


### PR DESCRIPTION
…anti-softlock)

Implementa auto-end turn en TurnManager cuando no quedan jugadas posibles en PlayerTurn, con guardas para evitar loops y sin cortar acciones/animaciones en curso. Añade HasAnyPlayableCardInHand() sin side effects para evaluar si existe alguna jugada disponible. Fix de edge case: introduce TurnManager.CanPlayCard(CardDeckEntry) como fuente de verdad de jugabilidad, considerando Momentum/FreePlays además de energía. La UI (CombatUIController) usa CanPlayCard para habilitar/deshabilitar cartas, evitando softlocks cuando energía=0 pero hay FreePlays. Verificado en Play Mode: con energía 0 + FreePlays 1 se puede jugar; sin FreePlays se bloquea y auto-end funciona; tras consumir free play auto-end ocurre si no hay más jugadas. Closes #52