### PR TITLE
E5-P03: Save/Load local (meta) con SaveService versionado y backend JSON

### DIFF
--- a/Assets/Scenes/BattleScene.unity
+++ b/Assets/Scenes/BattleScene.unity
@@ -1034,6 +1034,51 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   fallbackCombatConfig: {fileID: 11400000, guid: f1b2c3d4e5f67890abcdef1234567890, type: 2}
+--- !u!1 &2000001000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2000001001}
+  - component: {fileID: 2000001002}
+  m_Layer: 0
+  m_Name: SaveSmokeTestRunner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2000001001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000001000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2000001002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000001000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b2b6e6c9f4a44f84b1b8f55b7e3c9f10, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  runOnStart: 1
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -1043,3 +1088,4 @@ SceneRoots:
   - {fileID: 876543213}
   - {fileID: 1234567891}
   - {fileID: 900000101}
+  - {fileID: 2000001001}

--- a/Assets/Scripts/Save.meta
+++ b/Assets/Scripts/Save.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4d5b9fd20cbb0af4a86bcb7fcfbfd6f8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Save/ISaveService.cs
+++ b/Assets/Scripts/Save/ISaveService.cs
@@ -1,0 +1,14 @@
+namespace RoguelikeCardBattler.Save
+{
+    /// <summary>
+    /// Abstracción para guardado/carga de progreso meta.
+    /// Permite reemplazar implementación (local, cloud, etc).
+    /// </summary>
+    public interface ISaveService
+    {
+        void SaveMeta(SaveData data);
+        bool TryLoadMeta(out SaveData data);
+        bool HasValidSave();
+        void DeleteSave();
+    }
+}

--- a/Assets/Scripts/Save/ISaveService.cs.meta
+++ b/Assets/Scripts/Save/ISaveService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 16540c7737db24943a79e92e2411a220

--- a/Assets/Scripts/Save/LocalFileSaveService.cs
+++ b/Assets/Scripts/Save/LocalFileSaveService.cs
@@ -1,0 +1,110 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+namespace RoguelikeCardBattler.Save
+{
+    /// <summary>
+    /// Implementación local en JSON (Application.persistentDataPath).
+    /// No usa PlayerPrefs para evitar acoplar lógica de gameplay.
+    /// </summary>
+    public class LocalFileSaveService : ISaveService
+    {
+        private const string FileName = "save_v1.json";
+        private const string TempFileName = "save_v1.tmp";
+
+        private static string GetSavePath()
+        {
+            return Path.Combine(Application.persistentDataPath, FileName);
+        }
+
+        private static string GetTempPath()
+        {
+            return Path.Combine(Application.persistentDataPath, TempFileName);
+        }
+
+        public void SaveMeta(SaveData data)
+        {
+            if (data == null)
+            {
+                Debug.LogWarning("[Save] SaveMeta called with null data.");
+                return;
+            }
+
+            data.version = SaveData.CurrentVersion;
+            data.TouchTimestampUtc();
+
+            string json = JsonUtility.ToJson(data, true);
+            string path = GetSavePath();
+            string tempPath = GetTempPath();
+
+            try
+            {
+                // Escritura segura: escribimos a temp y luego reemplazamos.
+                File.WriteAllText(tempPath, json);
+                File.Copy(tempPath, path, true);
+                File.Delete(tempPath);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[Save] Failed to write save file. {ex.Message}");
+            }
+        }
+
+        public bool TryLoadMeta(out SaveData data)
+        {
+            data = null;
+            string path = GetSavePath();
+            if (!File.Exists(path))
+            {
+                return false;
+            }
+
+            try
+            {
+                string json = File.ReadAllText(path);
+                SaveData loaded = JsonUtility.FromJson<SaveData>(json);
+                if (loaded == null)
+                {
+                    Debug.LogWarning("[Save] Save file is empty or invalid JSON.");
+                    return false;
+                }
+
+                if (loaded.version != SaveData.CurrentVersion)
+                {
+                    Debug.LogWarning($"[Save] Save version mismatch. Expected {SaveData.CurrentVersion}, got {loaded.version}.");
+                    return false;
+                }
+
+                data = loaded;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[Save] Failed to load save file. {ex.Message}");
+                return false;
+            }
+        }
+
+        public bool HasValidSave()
+        {
+            return TryLoadMeta(out _);
+        }
+
+        public void DeleteSave()
+        {
+            string path = GetSavePath();
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[Save] Failed to delete save file. {ex.Message}");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Save/LocalFileSaveService.cs.meta
+++ b/Assets/Scripts/Save/LocalFileSaveService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 06ff2637b288e5540a39d27b268cf0a1

--- a/Assets/Scripts/Save/SaveData.cs
+++ b/Assets/Scripts/Save/SaveData.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace RoguelikeCardBattler.Save
+{
+    /// <summary>
+    /// Datos persistidos a disco para progreso meta (no gameplay activo).
+    /// Versionado explícito para migraciones futuras.
+    /// </summary>
+    [Serializable]
+    public class SaveData
+    {
+        public const int CurrentVersion = 1;
+
+        public int version = CurrentVersion;
+        public string lastSavedUtc;
+        public MetaProgress meta = new MetaProgress();
+
+        public void TouchTimestampUtc()
+        {
+            lastSavedUtc = DateTime.UtcNow.ToString("o");
+        }
+    }
+
+    /// <summary>
+    /// Progreso meta mínimo. Placeholder para desbloqueos y contadores.
+    /// </summary>
+    [Serializable]
+    public class MetaProgress
+    {
+        public int totalRuns = 0;
+        public int totalVictories = 0;
+        public List<string> unlockedCards = new List<string>();
+        public List<string> unlockedCharacters = new List<string>();
+    }
+}

--- a/Assets/Scripts/Save/SaveData.cs.meta
+++ b/Assets/Scripts/Save/SaveData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3db9b72b99dc952429a862f7e987982a

--- a/Assets/Scripts/Save/SaveService.cs
+++ b/Assets/Scripts/Save/SaveService.cs
@@ -1,0 +1,24 @@
+namespace RoguelikeCardBattler.Save
+{
+    /// <summary>
+    /// Punto único de acceso al sistema de guardado.
+    /// Clase pura: se usa desde controllers cuando se necesite.
+    /// </summary>
+    public static class SaveService
+    {
+        private static ISaveService _instance;
+
+        public static ISaveService Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new LocalFileSaveService();
+                }
+
+                return _instance;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Save/SaveService.cs.meta
+++ b/Assets/Scripts/Save/SaveService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cf2e60f302870ad4cb1858da46c64099

--- a/Assets/Scripts/Save/SaveSmokeTest.cs
+++ b/Assets/Scripts/Save/SaveSmokeTest.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+
+namespace RoguelikeCardBattler.Save
+{
+    /// <summary>
+    /// Debug only, remove after verification.
+    /// Ejecuta un smoke test simple de guardado/carga en Play Mode.
+    /// </summary>
+    public class SaveSmokeTest : MonoBehaviour
+    {
+        [SerializeField] private bool runOnStart = true;
+
+        private void Start()
+        {
+            if (!runOnStart)
+            {
+                return;
+            }
+
+            SaveData save = new SaveData();
+            save.meta.totalRuns = 3;
+            SaveService.Instance.SaveMeta(save);
+
+            if (SaveService.Instance.TryLoadMeta(out SaveData loaded))
+            {
+                Debug.Log($"[SaveSmokeTest] Loaded runs: {loaded.meta.totalRuns}");
+            }
+            else
+            {
+                Debug.LogError("[SaveSmokeTest] Load failed");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Save/SaveSmokeTest.cs.meta
+++ b/Assets/Scripts/Save/SaveSmokeTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b2b6e6c9f4a44f84b1b8f55b7e3c9f10


### PR DESCRIPTION
Implementa guardado/carga local para progreso meta (perfil) usando JSON en Application.persistentDataPath, sin PlayerPrefs para lógica. Define SaveData versionado (CurrentVersion) con timestamp UTC y estructura meta (ej. totalRuns, totalVictories, unlockedCards, unlockedCharacters). Crea abstracción ISaveService y backend LocalFileSaveService: Escritura “safe-ish” (temp file + replace).
Carga robusta: JSON inválido/corrupto falla controlado (log claro, sin crashear). Expone acceso simple vía SaveService.Instance para que controllers/menú lo consuman sin acoplar escenas. Añade smoke test en Play Mode para verificación rápida: SaveSmokeTestRunner en BattleScene ejecuta Save→Load y loguea [SaveSmokeTest] Loaded runs: 3. Archivos añadidos/modificados
Assets/Scripts/Save/SaveData.cs
Assets/Scripts/Save/ISaveService.cs
Assets/Scripts/Save/LocalFileSaveService.cs
Assets/Scripts/Save/SaveService.cs
Assets/Scripts/Save/SaveSmokeTest.cs
Assets/Scenes/BattleScene.unity (agrega SaveSmokeTestRunner) Closes #59