### PR TITLE
E5-P02 feat: Main Menu básico (Play / Continue / Settings mínimo / Quit)

### DIFF
--- a/Assets/Scenes/MainMenuScene.unity
+++ b/Assets/Scenes/MainMenuScene.unity
@@ -1,0 +1,309 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &519420028
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 519420032}
+  - component: {fileID: 519420031}
+  - component: {fileID: 519420029}
+  - component: {fileID: 519420030}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &519420029
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+--- !u!114 &519420030
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+  m_Version: 2
+--- !u!20 &519420031
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 34
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 0
+  m_HDR: 1
+  m_AllowMSAA: 0
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 0
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &519420032
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.0025216092, y: 0.042718094, z: -0.00045344207, w: 0.99908394}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: -0.286, y: 4.897, z: -0.064}
+--- !u!1 &1777777000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1777777002}
+  - component: {fileID: 1777777001}
+  m_Layer: 0
+  m_Name: MainMenuController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1777777001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1777777000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a7b4b6f5f1b4f4f9d2f3a8a5c1d7e3b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uiFont: {fileID: 0}
+--- !u!4 &1777777002
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1777777000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 519420032}
+  - {fileID: 1777777002}

--- a/Assets/Scenes/MainMenuScene.unity.meta
+++ b/Assets/Scenes/MainMenuScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2c8a7f8a6d0c4a6aa1d0cbe2b4c0e21f
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Menu.meta
+++ b/Assets/Scripts/Menu.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7d1b193f160bb254ab51e406e27143d9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Menu/MainMenuController.cs
+++ b/Assets/Scripts/Menu/MainMenuController.cs
@@ -1,0 +1,529 @@
+using System;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+using RoguelikeCardBattler.Run;
+
+namespace RoguelikeCardBattler.Menu
+{
+    /// <summary>
+    /// Controlador scene-owned del Main Menu. Solo navega entre escenas.
+    /// </summary>
+    public class MainMenuController : MonoBehaviour
+    {
+        private const string SceneRun = "RunScene";
+        private const string SceneBattle = "BattleScene";
+        private const string ContinuePlaceholder = "Coming in E5-P03";
+
+        [SerializeField] private Font uiFont;
+
+        private Canvas _canvas;
+        private Text _messageText;
+        private Button _playButton;
+        private Button _continueButton;
+        private Button _settingsButton;
+        private Button _quitButton;
+        private RectTransform _mainMenuPanel;
+        private RectTransform _settingsPanel;
+        private Slider _masterVolumeSlider;
+        private Text _masterVolumeValueText;
+        private Slider _musicVolumeSlider;
+        private Text _musicVolumeValueText;
+        private Text _resolutionValueText;
+        private Text _screenModeValueText;
+        private int _resolutionIndex;
+        private int _screenModeIndex;
+        private bool _scenesValid;
+
+        private readonly string[] _resolutionOptions = { "1920x1080", "1280x720" };
+        private readonly string[] _screenModeOptions = { "Pantalla completa", "Ventana" };
+        private const int ResolutionDefaultIndex = 0;
+        private const int ScreenModeDefaultIndex = 0;
+
+        private void Awake()
+        {
+            if (uiFont == null)
+            {
+                uiFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            }
+
+            EnsureEventSystem();
+            BuildUI();
+            _scenesValid = ValidateScenesInBuildSettings();
+            ApplyValidationState();
+        }
+
+        /// <summary>
+        /// Play inicia una nueva run y carga RunScene.
+        /// </summary>
+        public void OnPlayClicked()
+        {
+            if (!_scenesValid)
+            {
+                Debug.LogError("RunScene or BattleScene not in Build Settings. Add them in File > Build Settings.");
+                return;
+            }
+
+            RunSession session = RunSession.GetOrCreate();
+            session.ResetForNewRun();
+            SceneManager.LoadScene(SceneRun);
+        }
+
+        /// <summary>
+        /// Continue placeholder (sin funcionalidad en esta fase).
+        /// </summary>
+        public void OnContinueClicked()
+        {
+            SetMessage(ContinuePlaceholder);
+        }
+
+        /// <summary>
+        /// Settings placeholder visual.
+        /// </summary>
+        public void OnSettingsClicked()
+        {
+            ShowSettingsPanel();
+        }
+
+        /// <summary>
+        /// Quit cierra la aplicación en build.
+        /// </summary>
+        public void OnQuitClicked()
+        {
+#if UNITY_EDITOR
+            Debug.Log("[MainMenu] Quit requested (no-op in editor).");
+#endif
+            Application.Quit();
+        }
+
+        /// <summary>
+        /// Vuelve al panel principal desde Settings.
+        /// </summary>
+        public void OnBackFromSettingsClicked()
+        {
+            ShowMainMenuPanel();
+        }
+
+        private bool ValidateScenesInBuildSettings()
+        {
+            bool runExists = Application.CanStreamedLevelBeLoaded(SceneRun);
+            bool battleExists = Application.CanStreamedLevelBeLoaded(SceneBattle);
+            if (!runExists || !battleExists)
+            {
+                Debug.LogError("RunScene or BattleScene not in Build Settings. Add them in File > Build Settings.");
+                return false;
+            }
+
+            return true;
+        }
+
+        private void ApplyValidationState()
+        {
+            if (_playButton == null)
+            {
+                return;
+            }
+
+            if (!_scenesValid)
+            {
+                _playButton.interactable = false;
+                SetMessage("Missing RunScene/BattleScene in Build Settings.");
+            }
+        }
+
+        private void SetMessage(string message)
+        {
+            if (_messageText != null)
+            {
+                _messageText.text = message;
+            }
+        }
+
+        private void EnsureEventSystem()
+        {
+            EventSystem existing = UnityEngine.Object.FindFirstObjectByType<EventSystem>();
+            if (existing != null)
+            {
+                return;
+            }
+
+            GameObject eventSystemObject = new GameObject("EventSystem", typeof(EventSystem));
+            Type inputSystemType = Type.GetType("UnityEngine.InputSystem.UI.InputSystemUIInputModule, Unity.InputSystem");
+            if (inputSystemType != null)
+            {
+                eventSystemObject.AddComponent(inputSystemType);
+            }
+            else
+            {
+                eventSystemObject.AddComponent<StandaloneInputModule>();
+            }
+        }
+
+        private void BuildUI()
+        {
+            _canvas = CreateCanvas("MainMenuCanvas");
+            RectTransform root = _canvas.GetComponent<RectTransform>();
+
+            RectTransform background = CreatePanel("Background", root, new Color(0.08f, 0.08f, 0.1f, 1f));
+            background.anchorMin = Vector2.zero;
+            background.anchorMax = Vector2.one;
+            background.offsetMin = Vector2.zero;
+            background.offsetMax = Vector2.zero;
+
+            Text title = CreateText("Title", background, "Roguelike Card Battler", 40, TextAnchor.UpperCenter);
+            RectTransform titleRect = title.GetComponent<RectTransform>();
+            titleRect.anchorMin = new Vector2(0.1f, 0.85f);
+            titleRect.anchorMax = new Vector2(0.9f, 0.98f);
+
+            _messageText = CreateText("Message", background, string.Empty, 20, TextAnchor.LowerCenter);
+            RectTransform messageRect = _messageText.GetComponent<RectTransform>();
+            messageRect.anchorMin = new Vector2(0.1f, 0.05f);
+            messageRect.anchorMax = new Vector2(0.9f, 0.15f);
+
+            _mainMenuPanel = CreatePanel("MainMenuPanel", background, new Color(0f, 0f, 0f, 0f));
+            _mainMenuPanel.anchorMin = new Vector2(0.2f, 0.2f);
+            _mainMenuPanel.anchorMax = new Vector2(0.8f, 0.78f);
+            _mainMenuPanel.offsetMin = Vector2.zero;
+            _mainMenuPanel.offsetMax = Vector2.zero;
+
+            _settingsPanel = CreatePanel("SettingsPanel", background, new Color(0f, 0f, 0f, 0f));
+            _settingsPanel.anchorMin = new Vector2(0.15f, 0.15f);
+            _settingsPanel.anchorMax = new Vector2(0.85f, 0.8f);
+            _settingsPanel.offsetMin = Vector2.zero;
+            _settingsPanel.offsetMax = Vector2.zero;
+
+            _playButton = CreateButton("PlayButton", _mainMenuPanel, "Play", new Vector2(0.5f, 0.68f));
+            _continueButton = CreateButton("ContinueButton", _mainMenuPanel, "Continue", new Vector2(0.5f, 0.5f));
+            _settingsButton = CreateButton("SettingsButton", _mainMenuPanel, "Settings", new Vector2(0.5f, 0.32f));
+            _quitButton = CreateButton("QuitButton", _mainMenuPanel, "Quit", new Vector2(0.5f, 0.14f));
+
+            _playButton.onClick.AddListener(OnPlayClicked);
+            _continueButton.onClick.AddListener(OnContinueClicked);
+            _settingsButton.onClick.AddListener(OnSettingsClicked);
+            _quitButton.onClick.AddListener(OnQuitClicked);
+
+            _continueButton.interactable = false;
+
+            BuildSettingsPanel();
+            ShowMainMenuPanel();
+        }
+
+        private void BuildSettingsPanel()
+        {
+            Text settingsTitle = CreateText("SettingsTitle", _settingsPanel, "Settings", 32, TextAnchor.UpperCenter);
+            RectTransform titleRect = settingsTitle.GetComponent<RectTransform>();
+            titleRect.anchorMin = new Vector2(0.1f, 0.82f);
+            titleRect.anchorMax = new Vector2(0.9f, 0.98f);
+
+            _masterVolumeSlider = CreateLabeledSlider("MasterVolume", _settingsPanel, "Volumen general", new Vector2(0.2f, 0.65f), out _masterVolumeValueText);
+            _musicVolumeSlider = CreateLabeledSlider("MusicVolume", _settingsPanel, "Música", new Vector2(0.2f, 0.5f), out _musicVolumeValueText);
+
+            CreateOptionSelector("Resolution", _settingsPanel, "Resolución", new Vector2(0.2f, 0.35f), _resolutionOptions, out _resolutionValueText,
+                OnResolutionPrevClicked, OnResolutionNextClicked);
+            CreateOptionSelector("ScreenMode", _settingsPanel, "Modo de pantalla", new Vector2(0.2f, 0.2f), _screenModeOptions, out _screenModeValueText,
+                OnScreenModePrevClicked, OnScreenModeNextClicked);
+
+            Button backButton = CreateButton("BackButton", _settingsPanel, "Back", new Vector2(0.5f, 0.06f));
+            backButton.onClick.AddListener(OnBackFromSettingsClicked);
+
+            _masterVolumeSlider.onValueChanged.AddListener(OnMasterVolumeChanged);
+            _musicVolumeSlider.onValueChanged.AddListener(OnMusicVolumeChanged);
+
+            _masterVolumeSlider.value = 80f;
+            _musicVolumeSlider.value = 80f;
+            _resolutionIndex = ResolutionDefaultIndex;
+            _screenModeIndex = ScreenModeDefaultIndex;
+            UpdateVolumeLabel(_masterVolumeValueText, _masterVolumeSlider.value);
+            UpdateVolumeLabel(_musicVolumeValueText, _musicVolumeSlider.value);
+            UpdateOptionLabel(_resolutionValueText, _resolutionOptions, _resolutionIndex);
+            UpdateOptionLabel(_screenModeValueText, _screenModeOptions, _screenModeIndex);
+
+            ApplyDisplaySettings();
+        }
+
+        private void OnMasterVolumeChanged(float value)
+        {
+            UpdateVolumeLabel(_masterVolumeValueText, value);
+            AudioListener.volume = Mathf.Clamp01(value / 100f);
+        }
+
+        private void OnMusicVolumeChanged(float value)
+        {
+            UpdateVolumeLabel(_musicVolumeValueText, value);
+            SetMessage("Música: placeholder (sin sistema de audio aún)");
+        }
+
+        private void ApplyDisplaySettings()
+        {
+            int width = 1920;
+            int height = 1080;
+            if (_resolutionIndex == 1)
+            {
+                width = 1280;
+                height = 720;
+            }
+
+            bool fullscreen = _screenModeIndex == 0;
+            Screen.SetResolution(width, height, fullscreen);
+        }
+
+        private void OnResolutionPrevClicked()
+        {
+            _resolutionIndex = Mathf.Clamp(_resolutionIndex - 1, 0, _resolutionOptions.Length - 1);
+            UpdateOptionLabel(_resolutionValueText, _resolutionOptions, _resolutionIndex);
+            ApplyDisplaySettings();
+        }
+
+        private void OnResolutionNextClicked()
+        {
+            _resolutionIndex = Mathf.Clamp(_resolutionIndex + 1, 0, _resolutionOptions.Length - 1);
+            UpdateOptionLabel(_resolutionValueText, _resolutionOptions, _resolutionIndex);
+            ApplyDisplaySettings();
+        }
+
+        private void OnScreenModePrevClicked()
+        {
+            _screenModeIndex = Mathf.Clamp(_screenModeIndex - 1, 0, _screenModeOptions.Length - 1);
+            UpdateOptionLabel(_screenModeValueText, _screenModeOptions, _screenModeIndex);
+            ApplyDisplaySettings();
+        }
+
+        private void OnScreenModeNextClicked()
+        {
+            _screenModeIndex = Mathf.Clamp(_screenModeIndex + 1, 0, _screenModeOptions.Length - 1);
+            UpdateOptionLabel(_screenModeValueText, _screenModeOptions, _screenModeIndex);
+            ApplyDisplaySettings();
+        }
+
+        private void ShowSettingsPanel()
+        {
+            if (_mainMenuPanel != null)
+            {
+                _mainMenuPanel.gameObject.SetActive(false);
+            }
+
+            if (_settingsPanel != null)
+            {
+                _settingsPanel.gameObject.SetActive(true);
+            }
+        }
+
+        private void ShowMainMenuPanel()
+        {
+            if (_settingsPanel != null)
+            {
+                _settingsPanel.gameObject.SetActive(false);
+            }
+
+            if (_mainMenuPanel != null)
+            {
+                _mainMenuPanel.gameObject.SetActive(true);
+            }
+        }
+
+        private Canvas CreateCanvas(string name)
+        {
+            GameObject go = new GameObject(name, typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+            Canvas canvas = go.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+
+            CanvasScaler scaler = go.GetComponent<CanvasScaler>();
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = new Vector2(1920, 1080);
+            scaler.matchWidthOrHeight = 0.5f;
+
+            return canvas;
+        }
+
+        private RectTransform CreatePanel(string name, RectTransform parent, Color color)
+        {
+            GameObject panel = new GameObject(name, typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            panel.transform.SetParent(parent, false);
+            Image image = panel.GetComponent<Image>();
+            image.color = color;
+            return panel.GetComponent<RectTransform>();
+        }
+
+        private Text CreateText(string name, RectTransform parent, string content, int fontSize, TextAnchor anchor)
+        {
+            GameObject textObject = new GameObject(name, typeof(RectTransform), typeof(CanvasRenderer), typeof(Text));
+            textObject.transform.SetParent(parent, false);
+            Text text = textObject.GetComponent<Text>();
+            text.font = uiFont;
+            text.fontSize = fontSize;
+            text.alignment = anchor;
+            text.text = content;
+            text.color = Color.white;
+            RectTransform rect = text.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0.1f, 0.1f);
+            rect.anchorMax = new Vector2(0.9f, 0.2f);
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+            return text;
+        }
+
+        private Button CreateButton(string name, RectTransform parent, string label, Vector2 anchor)
+        {
+            GameObject buttonObject = new GameObject(name, typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button));
+            buttonObject.transform.SetParent(parent, false);
+
+            RectTransform rect = buttonObject.GetComponent<RectTransform>();
+            rect.anchorMin = anchor;
+            rect.anchorMax = anchor;
+            rect.sizeDelta = new Vector2(320f, 70f);
+            rect.anchoredPosition = Vector2.zero;
+
+            Image image = buttonObject.GetComponent<Image>();
+            image.color = new Color(0.2f, 0.2f, 0.2f, 0.95f);
+
+            Button button = buttonObject.GetComponent<Button>();
+
+            Text text = CreateText("Text", rect, label, 24, TextAnchor.MiddleCenter);
+            RectTransform textRect = text.GetComponent<RectTransform>();
+            textRect.anchorMin = Vector2.zero;
+            textRect.anchorMax = Vector2.one;
+            textRect.offsetMin = Vector2.zero;
+            textRect.offsetMax = Vector2.zero;
+
+            return button;
+        }
+
+        private Slider CreateLabeledSlider(string name, RectTransform parent, string label, Vector2 anchor, out Text valueText)
+        {
+            RectTransform container = CreatePanel(name, parent, new Color(0f, 0f, 0f, 0f));
+            container.anchorMin = new Vector2(anchor.x, anchor.y);
+            container.anchorMax = new Vector2(anchor.x + 0.6f, anchor.y + 0.1f);
+            container.offsetMin = Vector2.zero;
+            container.offsetMax = Vector2.zero;
+
+            Text labelText = CreateText("Label", container, label, 20, TextAnchor.MiddleLeft);
+            RectTransform labelRect = labelText.GetComponent<RectTransform>();
+            labelRect.anchorMin = new Vector2(0f, 0f);
+            labelRect.anchorMax = new Vector2(0.4f, 1f);
+
+            GameObject sliderObject = new GameObject("Slider", typeof(RectTransform), typeof(Slider), typeof(Image));
+            sliderObject.transform.SetParent(container, false);
+            Image backgroundImage = sliderObject.GetComponent<Image>();
+            backgroundImage.color = new Color(0.2f, 0.2f, 0.2f, 0.9f);
+
+            RectTransform sliderRect = sliderObject.GetComponent<RectTransform>();
+            sliderRect.anchorMin = new Vector2(0.42f, 0.2f);
+            sliderRect.anchorMax = new Vector2(0.85f, 0.8f);
+            sliderRect.offsetMin = Vector2.zero;
+            sliderRect.offsetMax = Vector2.zero;
+
+            Slider slider = sliderObject.GetComponent<Slider>();
+            slider.minValue = 0f;
+            slider.maxValue = 100f;
+
+            GameObject fillArea = new GameObject("Fill Area", typeof(RectTransform));
+            fillArea.transform.SetParent(sliderObject.transform, false);
+            RectTransform fillAreaRect = fillArea.GetComponent<RectTransform>();
+            fillAreaRect.anchorMin = new Vector2(0f, 0f);
+            fillAreaRect.anchorMax = new Vector2(1f, 1f);
+            fillAreaRect.offsetMin = new Vector2(10f, 0f);
+            fillAreaRect.offsetMax = new Vector2(-10f, 0f);
+
+            GameObject fill = new GameObject("Fill", typeof(RectTransform), typeof(Image));
+            fill.transform.SetParent(fillArea.transform, false);
+            Image fillImage = fill.GetComponent<Image>();
+            fillImage.color = new Color(0.6f, 0.8f, 1f, 1f);
+            RectTransform fillRect = fill.GetComponent<RectTransform>();
+            fillRect.anchorMin = new Vector2(0f, 0f);
+            fillRect.anchorMax = new Vector2(1f, 1f);
+            fillRect.offsetMin = Vector2.zero;
+            fillRect.offsetMax = Vector2.zero;
+            slider.fillRect = fillRect;
+
+            GameObject handle = new GameObject("Handle", typeof(RectTransform), typeof(Image));
+            handle.transform.SetParent(sliderObject.transform, false);
+            Image handleImage = handle.GetComponent<Image>();
+            handleImage.color = new Color(1f, 1f, 1f, 1f);
+            RectTransform handleRect = handle.GetComponent<RectTransform>();
+            handleRect.sizeDelta = new Vector2(20f, 20f);
+            slider.handleRect = handleRect;
+            slider.targetGraphic = handleImage;
+
+            valueText = CreateText("Value", container, "0", 18, TextAnchor.MiddleRight);
+            RectTransform valueRect = valueText.GetComponent<RectTransform>();
+            valueRect.anchorMin = new Vector2(0.86f, 0f);
+            valueRect.anchorMax = new Vector2(1f, 1f);
+
+            return slider;
+        }
+
+        private void CreateOptionSelector(string name, RectTransform parent, string label, Vector2 anchor, string[] options, out Text valueText, Action onPrev, Action onNext)
+        {
+            RectTransform container = CreatePanel(name, parent, new Color(0f, 0f, 0f, 0f));
+            container.anchorMin = new Vector2(anchor.x, anchor.y);
+            container.anchorMax = new Vector2(anchor.x + 0.6f, anchor.y + 0.1f);
+            container.offsetMin = Vector2.zero;
+            container.offsetMax = Vector2.zero;
+
+            Text labelText = CreateText("Label", container, label, 20, TextAnchor.MiddleLeft);
+            RectTransform labelRect = labelText.GetComponent<RectTransform>();
+            labelRect.anchorMin = new Vector2(0f, 0f);
+            labelRect.anchorMax = new Vector2(0.4f, 1f);
+
+            Button prevButton = CreateSmallButton("Prev", container, "<", new Vector2(0.44f, 0.5f));
+            Button nextButton = CreateSmallButton("Next", container, ">", new Vector2(0.92f, 0.5f));
+            prevButton.onClick.AddListener(() => onPrev?.Invoke());
+            nextButton.onClick.AddListener(() => onNext?.Invoke());
+
+            valueText = CreateText("Value", container, options.Length > 0 ? options[0] : string.Empty, 18, TextAnchor.MiddleCenter);
+            RectTransform valueRect = valueText.GetComponent<RectTransform>();
+            valueRect.anchorMin = new Vector2(0.5f, 0f);
+            valueRect.anchorMax = new Vector2(0.88f, 1f);
+        }
+
+        private Button CreateSmallButton(string name, RectTransform parent, string label, Vector2 anchor)
+        {
+            GameObject buttonObject = new GameObject(name, typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button));
+            buttonObject.transform.SetParent(parent, false);
+
+            RectTransform rect = buttonObject.GetComponent<RectTransform>();
+            rect.anchorMin = anchor;
+            rect.anchorMax = anchor;
+            rect.sizeDelta = new Vector2(40f, 36f);
+            rect.anchoredPosition = Vector2.zero;
+
+            Image image = buttonObject.GetComponent<Image>();
+            image.color = new Color(0.25f, 0.25f, 0.25f, 0.95f);
+
+            Button button = buttonObject.GetComponent<Button>();
+
+            Text text = CreateText("Text", rect, label, 18, TextAnchor.MiddleCenter);
+            RectTransform textRect = text.GetComponent<RectTransform>();
+            textRect.anchorMin = Vector2.zero;
+            textRect.anchorMax = Vector2.one;
+            textRect.offsetMin = Vector2.zero;
+            textRect.offsetMax = Vector2.zero;
+
+            return button;
+        }
+
+        private void UpdateVolumeLabel(Text target, float value)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            int rounded = Mathf.RoundToInt(value);
+            target.text = rounded.ToString();
+        }
+
+        private void UpdateOptionLabel(Text target, string[] options, int index)
+        {
+            if (target == null || options == null || options.Length == 0)
+            {
+                return;
+            }
+
+            int safeIndex = Mathf.Clamp(index, 0, options.Length - 1);
+            target.text = options[safeIndex];
+        }
+
+    }
+}

--- a/Assets/Scripts/Menu/MainMenuController.cs.meta
+++ b/Assets/Scripts/Menu/MainMenuController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4a7b4b6f5f1b4f4f9d2f3a8a5c1d7e3b

--- a/Assets/Scripts/Run/RunSession.cs
+++ b/Assets/Scripts/Run/RunSession.cs
@@ -38,6 +38,7 @@ namespace RoguelikeCardBattler.Run
         {
             if (Instance != null && Instance != this)
             {
+                Instance.TryInheritBossFrom(this);
                 Destroy(gameObject);
                 return;
             }
@@ -49,8 +50,24 @@ namespace RoguelikeCardBattler.Run
                 Map = RunMapGenerator.GenerateAct1();
             }
             State.EnsureInitialized(Map);
-            
+
             // Asigna BossAct1 al nodo jefe si está configurado
+            AssignBossAct1();
+        }
+
+        /// <summary>
+        /// Reinicia la run en memoria para comenzar desde cero.
+        /// </summary>
+        public void ResetForNewRun()
+        {
+            Map = RunMapGenerator.GenerateAct1();
+            State.Reset(Map);
+            CombatConfig = null;
+            AssignBossAct1();
+        }
+
+        private void AssignBossAct1()
+        {
             if (bossAct1Enemy != null && Map != null && Map.Nodes.Count > 7)
             {
                 MapNode bossNode = Map.GetNode(7);
@@ -58,6 +75,20 @@ namespace RoguelikeCardBattler.Run
                 {
                     bossNode.SpecificEnemy = bossAct1Enemy;
                 }
+            }
+        }
+
+        private void TryInheritBossFrom(RunSession source)
+        {
+            if (source == null)
+            {
+                return;
+            }
+
+            if (bossAct1Enemy == null && source.bossAct1Enemy != null)
+            {
+                bossAct1Enemy = source.bossAct1Enemy;
+                AssignBossAct1();
             }
         }
 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,6 +6,12 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
+    path: Assets/Scenes/MainMenuScene.unity
+    guid: 2c8a7f8a6d0c4a6aa1d0cbe2b4c0e21f
+  - enabled: 1
+    path: Assets/Scenes/RunScene.unity
+    guid: 5b1542b6449efb74f803c91475d191f5
+  - enabled: 1
     path: Assets/Scenes/BattleScene.unity
     guid: 62a8bd5227024be79aabcee05d9f38b1
   m_configObjects:


### PR DESCRIPTION
Se creó un Main Menu con UI mínima y navegación básica (Play, Continue placeholder, Settings, Quit), validación de escenas y botones conectados por código en MainMenuController.cs. Se agregó soporte de Settings básicos (volumen general y música con sliders, resolución y modo de pantalla con selectors) y aplicación de cambios de display en tiempo real (en build) dentro de MainMenuController.cs. Se creó la escena MainMenuScene y se configuró el orden de Build Settings para que sea la escena 0 y RunScene/BattleScene queden en 1/2, respectivamente, en MainMenuScene.unity y EditorBuildSettings.asset. Se añadió un método de reset de run para iniciar nuevas partidas sin duplicar estado en RunSession.cs.