### PR TITLE
feat: replace map list with visual 2D branching map (#60)

### DIFF
--- a/Assets/Scripts/Run/Map/UI.meta
+++ b/Assets/Scripts/Run/Map/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bcbedffc45b4b4f44ad56510866b4b04
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Run/Map/UI/RunMapEdgeView.cs
+++ b/Assets/Scripts/Run/Map/UI/RunMapEdgeView.cs
@@ -1,0 +1,54 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace RoguelikeCardBattler.Run
+{
+    /// <summary>
+    /// Dibuja una línea UI entre dos puntos del mapa usando un Image estirado y rotado.
+    /// No recibe input (raycastTarget = false).
+    /// </summary>
+    public class RunMapEdgeView
+    {
+        private static readonly Color EdgeColor = new Color(0.4f, 0.5f, 0.6f, 0.5f);
+
+        public RectTransform Rect { get; }
+
+        private readonly Image _image;
+
+        public static RunMapEdgeView Create(RectTransform parent, Vector2 from, Vector2 to,
+            float thickness, Sprite whiteSprite)
+        {
+            return new RunMapEdgeView(parent, from, to, thickness, whiteSprite);
+        }
+
+        private RunMapEdgeView(RectTransform parent, Vector2 from, Vector2 to,
+            float thickness, Sprite whiteSprite)
+        {
+            Vector2 diff = to - from;
+            float distance = diff.magnitude;
+            float angle = Mathf.Atan2(diff.y, diff.x) * Mathf.Rad2Deg;
+
+            GameObject go = new GameObject("Edge", typeof(RectTransform), typeof(Image));
+            go.transform.SetParent(parent, false);
+
+            Rect = go.GetComponent<RectTransform>();
+            Rect.anchorMin = new Vector2(0.5f, 1f);
+            Rect.anchorMax = new Vector2(0.5f, 1f);
+            Rect.pivot = new Vector2(0.5f, 0.5f);
+            Rect.anchoredPosition = (from + to) / 2f;
+            Rect.sizeDelta = new Vector2(distance, thickness);
+            Rect.localRotation = Quaternion.Euler(0f, 0f, angle);
+
+            _image = go.GetComponent<Image>();
+            _image.sprite = whiteSprite;
+            _image.type = Image.Type.Simple;
+            _image.color = EdgeColor;
+            _image.raycastTarget = false;
+        }
+
+        public void SetColor(Color color)
+        {
+            _image.color = color;
+        }
+    }
+}

--- a/Assets/Scripts/Run/Map/UI/RunMapEdgeView.cs.meta
+++ b/Assets/Scripts/Run/Map/UI/RunMapEdgeView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9e99037610c9d2245a628bc0e782c7ed

--- a/Assets/Scripts/Run/Map/UI/RunMapNodeView.cs
+++ b/Assets/Scripts/Run/Map/UI/RunMapNodeView.cs
@@ -1,0 +1,123 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace RoguelikeCardBattler.Run
+{
+    /// <summary>
+    /// Vista individual de un nodo en el mapa de run.
+    /// Crea un botón UI posicionado manualmente y aplica estado visual
+    /// (Locked/Available/Completed) leyendo NodeState.
+    /// </summary>
+    public class RunMapNodeView
+    {
+        private static readonly Color LockedBg = new Color(0.18f, 0.18f, 0.22f, 0.6f);
+        private static readonly Color AvailableBg = new Color(0.15f, 0.3f, 0.55f, 1f);
+        private static readonly Color CompletedBg = new Color(0.2f, 0.45f, 0.25f, 1f);
+        private static readonly Color BossAvailableBg = new Color(0.55f, 0.12f, 0.12f, 1f);
+        private static readonly Color BossLockedBg = new Color(0.3f, 0.1f, 0.1f, 0.6f);
+
+        public int NodeId { get; }
+        public NodeType Type { get; }
+        public RectTransform Rect { get; }
+
+        private readonly Button _button;
+        private readonly Image _bgImage;
+        private readonly Text _label;
+
+        public RunMapNodeView(int nodeId, NodeType type, RectTransform parent,
+            Vector2 position, Vector2 size, Font font, Sprite whiteSprite,
+            Action<int> onClick)
+        {
+            NodeId = nodeId;
+            Type = type;
+
+            GameObject go = new GameObject($"MapNode_{nodeId}",
+                typeof(RectTransform), typeof(Image), typeof(Button));
+            go.transform.SetParent(parent, false);
+
+            Rect = go.GetComponent<RectTransform>();
+            Rect.anchorMin = new Vector2(0.5f, 1f);
+            Rect.anchorMax = new Vector2(0.5f, 1f);
+            Rect.pivot = new Vector2(0.5f, 0.5f);
+            Rect.anchoredPosition = position;
+            Rect.sizeDelta = size;
+
+            _bgImage = go.GetComponent<Image>();
+            _bgImage.sprite = whiteSprite;
+            _bgImage.type = Image.Type.Simple;
+            _bgImage.raycastTarget = true;
+
+            _button = go.GetComponent<Button>();
+            int capturedId = nodeId;
+            _button.onClick.AddListener(() => onClick?.Invoke(capturedId));
+
+            GameObject textGo = new GameObject("Label",
+                typeof(RectTransform), typeof(Text));
+            textGo.transform.SetParent(go.transform, false);
+            RectTransform textRect = textGo.GetComponent<RectTransform>();
+            textRect.anchorMin = Vector2.zero;
+            textRect.anchorMax = Vector2.one;
+            textRect.offsetMin = new Vector2(4f, 2f);
+            textRect.offsetMax = new Vector2(-4f, -2f);
+
+            _label = textGo.GetComponent<Text>();
+            _label.font = font;
+            _label.fontSize = type == NodeType.Boss ? 18 : 16;
+            _label.alignment = TextAnchor.MiddleCenter;
+            _label.color = Color.white;
+            _label.raycastTarget = false;
+
+            Outline outline = textGo.AddComponent<Outline>();
+            outline.effectColor = new Color(0f, 0f, 0f, 0.7f);
+            outline.effectDistance = new Vector2(1f, -1f);
+        }
+
+        public void ApplyState(NodeState state)
+        {
+            bool isBoss = Type == NodeType.Boss;
+            bool completed = state == NodeState.Completed;
+            bool available = state == NodeState.Available;
+
+            if (completed)
+            {
+                _bgImage.color = CompletedBg;
+                _label.color = new Color(0.8f, 0.9f, 0.8f, 1f);
+                _button.interactable = false;
+            }
+            else if (available)
+            {
+                _bgImage.color = isBoss ? BossAvailableBg : AvailableBg;
+                _label.color = Color.white;
+                _button.interactable = true;
+            }
+            else
+            {
+                _bgImage.color = isBoss ? BossLockedBg : LockedBg;
+                _label.color = new Color(0.5f, 0.5f, 0.5f, 1f);
+                _button.interactable = false;
+            }
+
+            _label.text = FormatLabel(completed);
+        }
+
+        private string FormatLabel(bool completed)
+        {
+            string icon = Type switch
+            {
+                NodeType.Combat => "\u2694",
+                NodeType.Event => "?",
+                NodeType.Shop => "$",
+                NodeType.Campfire => "\u25b3",
+                NodeType.Elite => "\u2694\u2694",
+                NodeType.Boss => "\u2620 BOSS",
+                _ => "\u2022"
+            };
+
+            string check = completed ? " \u2713" : "";
+            return Type == NodeType.Boss
+                ? $"{icon}{check}"
+                : $"{icon} {NodeId + 1}{check}";
+        }
+    }
+}

--- a/Assets/Scripts/Run/Map/UI/RunMapNodeView.cs.meta
+++ b/Assets/Scripts/Run/Map/UI/RunMapNodeView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b7d240abfa476c94287d7f00a631f03b

--- a/Assets/Scripts/Run/Map/UI/RunMapView.cs
+++ b/Assets/Scripts/Run/Map/UI/RunMapView.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace RoguelikeCardBattler.Run
+{
+    /// <summary>
+    /// Construye y gestiona el mapa visual 2D ramificado dentro de RunScene.
+    /// Posiciona nodos automáticamente por profundidad BFS y dibuja edges
+    /// entre nodos conectados. RunFlowController delega la presentación aquí.
+    /// </summary>
+    public class RunMapView
+    {
+        private const float RowSpacing = 130f;
+        private const float HorizontalSpacing = 200f;
+        private const float TopPadding = 50f;
+        private const float BottomPadding = 50f;
+        private const float NodeWidth = 130f;
+        private const float NodeHeight = 50f;
+        private const float EdgeThickness = 3f;
+
+        public event Action<int> OnNodeClicked;
+
+        private readonly Dictionary<int, RunMapNodeView> _nodeViews =
+            new Dictionary<int, RunMapNodeView>();
+        private readonly List<RunMapEdgeView> _edgeViews =
+            new List<RunMapEdgeView>();
+
+        /// <summary>
+        /// Construye todo el mapa visual: calcula layout, crea edges y nodos.
+        /// </summary>
+        public RunMapView(RectTransform parent, ActMap map, RunState state,
+            Font font, Sprite whiteSprite)
+        {
+            RectTransform content = CreateScrollView(parent, whiteSprite);
+
+            Dictionary<int, int> depthMap = ComputeDepths(map);
+            int maxDepth = 0;
+            Dictionary<int, List<int>> depthBuckets = new Dictionary<int, List<int>>();
+
+            foreach (KeyValuePair<int, int> kvp in depthMap)
+            {
+                if (kvp.Value > maxDepth)
+                {
+                    maxDepth = kvp.Value;
+                }
+
+                if (!depthBuckets.ContainsKey(kvp.Value))
+                {
+                    depthBuckets[kvp.Value] = new List<int>();
+                }
+
+                depthBuckets[kvp.Value].Add(kvp.Key);
+            }
+
+            float contentHeight = TopPadding + (maxDepth + 1) * RowSpacing + BottomPadding;
+            content.sizeDelta = new Vector2(0f, contentHeight);
+
+            foreach (MapNode node in map.Nodes)
+            {
+                if (!depthMap.ContainsKey(node.Id))
+                {
+                    continue;
+                }
+
+                Vector2 fromPos = GetNodePosition(node.Id, depthMap, depthBuckets);
+                foreach (int connId in node.Connections)
+                {
+                    if (!depthMap.ContainsKey(connId))
+                    {
+                        continue;
+                    }
+
+                    Vector2 toPos = GetNodePosition(connId, depthMap, depthBuckets);
+                    RunMapEdgeView edge = RunMapEdgeView.Create(
+                        content, fromPos, toPos, EdgeThickness, whiteSprite);
+                    _edgeViews.Add(edge);
+                }
+            }
+
+            foreach (MapNode node in map.Nodes)
+            {
+                if (!depthMap.ContainsKey(node.Id))
+                {
+                    continue;
+                }
+
+                Vector2 pos = GetNodePosition(node.Id, depthMap, depthBuckets);
+                RunMapNodeView nodeView = new RunMapNodeView(
+                    node.Id, node.Type, content, pos,
+                    new Vector2(NodeWidth, NodeHeight), font, whiteSprite,
+                    id => OnNodeClicked?.Invoke(id));
+                _nodeViews[node.Id] = nodeView;
+            }
+
+            Refresh(state);
+        }
+
+        /// <summary>
+        /// Actualiza los estados visuales de todos los nodos sin reconstruir el mapa.
+        /// Se llama cada vez que el mapa se muestra (ShowMap) o tras completar un nodo.
+        /// </summary>
+        public void Refresh(RunState state)
+        {
+            foreach (KeyValuePair<int, RunMapNodeView> kvp in _nodeViews)
+            {
+                NodeState vs;
+                if (state.IsNodeCompleted(kvp.Key))
+                {
+                    vs = NodeState.Completed;
+                }
+                else if (state.IsNodeAvailable(kvp.Key))
+                {
+                    vs = NodeState.Available;
+                }
+                else
+                {
+                    vs = NodeState.Locked;
+                }
+
+                kvp.Value.ApplyState(vs);
+            }
+        }
+
+        /// <summary>
+        /// BFS desde startNode para calcular la profundidad de cada nodo.
+        /// Se usa para posicionar nodos en filas (Y) por profundidad.
+        /// </summary>
+        private static Dictionary<int, int> ComputeDepths(ActMap map)
+        {
+            Dictionary<int, int> depths = new Dictionary<int, int>();
+            Queue<int> queue = new Queue<int>();
+
+            depths[map.StartNodeId] = 0;
+            queue.Enqueue(map.StartNodeId);
+
+            while (queue.Count > 0)
+            {
+                int current = queue.Dequeue();
+                MapNode node = map.GetNode(current);
+                if (node == null)
+                {
+                    continue;
+                }
+
+                int nextDepth = depths[current] + 1;
+                foreach (int conn in node.Connections)
+                {
+                    if (!depths.ContainsKey(conn))
+                    {
+                        depths[conn] = nextDepth;
+                        queue.Enqueue(conn);
+                    }
+                }
+            }
+
+            return depths;
+        }
+
+        /// <summary>
+        /// Calcula la posición de un nodo en coordenadas del content (anchor 0.5, 1).
+        /// X=0 es el centro horizontal; Y negativo va hacia abajo.
+        /// Nodos del mismo depth se distribuyen simétricamente alrededor del centro.
+        /// </summary>
+        private static Vector2 GetNodePosition(int nodeId,
+            Dictionary<int, int> depthMap, Dictionary<int, List<int>> depthBuckets)
+        {
+            int depth = depthMap[nodeId];
+            List<int> bucket = depthBuckets[depth];
+            int index = bucket.IndexOf(nodeId);
+            int count = bucket.Count;
+
+            float x = (index - (count - 1) / 2f) * HorizontalSpacing;
+            float y = -(TopPadding + depth * RowSpacing);
+
+            return new Vector2(x, y);
+        }
+
+        private static RectTransform CreateScrollView(RectTransform parent,
+            Sprite whiteSprite)
+        {
+            GameObject scrollGO = new GameObject("MapScrollView",
+                typeof(RectTransform), typeof(Image), typeof(ScrollRect));
+            scrollGO.transform.SetParent(parent, false);
+
+            RectTransform scrollRect = scrollGO.GetComponent<RectTransform>();
+            scrollRect.anchorMin = new Vector2(0.02f, 0.02f);
+            scrollRect.anchorMax = new Vector2(0.98f, 0.78f);
+            scrollRect.offsetMin = Vector2.zero;
+            scrollRect.offsetMax = Vector2.zero;
+
+            Image bg = scrollGO.GetComponent<Image>();
+            bg.sprite = whiteSprite;
+            bg.type = Image.Type.Simple;
+            bg.color = new Color(0.03f, 0.04f, 0.07f, 0.35f);
+
+            ScrollRect scroll = scrollGO.GetComponent<ScrollRect>();
+            scroll.horizontal = false;
+            scroll.vertical = true;
+            scroll.movementType = ScrollRect.MovementType.Clamped;
+
+            GameObject viewportGO = new GameObject("Viewport",
+                typeof(RectTransform), typeof(RectMask2D), typeof(Image));
+            viewportGO.transform.SetParent(scrollGO.transform, false);
+            RectTransform viewportRect = viewportGO.GetComponent<RectTransform>();
+            viewportRect.anchorMin = Vector2.zero;
+            viewportRect.anchorMax = Vector2.one;
+            viewportRect.offsetMin = Vector2.zero;
+            viewportRect.offsetMax = Vector2.zero;
+
+            Image viewportImage = viewportGO.GetComponent<Image>();
+            viewportImage.color = new Color(0f, 0f, 0f, 0f);
+            viewportImage.raycastTarget = true;
+
+            GameObject contentGO = new GameObject("Content", typeof(RectTransform));
+            contentGO.transform.SetParent(viewportGO.transform, false);
+            RectTransform contentRect = contentGO.GetComponent<RectTransform>();
+            contentRect.anchorMin = new Vector2(0f, 1f);
+            contentRect.anchorMax = new Vector2(1f, 1f);
+            contentRect.pivot = new Vector2(0.5f, 1f);
+            contentRect.anchoredPosition = Vector2.zero;
+            contentRect.sizeDelta = new Vector2(0f, 800f);
+
+            scroll.viewport = viewportRect;
+            scroll.content = contentRect;
+
+            return contentRect;
+        }
+    }
+}

--- a/Assets/Scripts/Run/Map/UI/RunMapView.cs.meta
+++ b/Assets/Scripts/Run/Map/UI/RunMapView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3a9067587a8709d47ae94495f8ea6b49

--- a/Assets/Scripts/Run/RunFlowController.cs
+++ b/Assets/Scripts/Run/RunFlowController.cs
@@ -31,7 +31,7 @@ namespace RoguelikeCardBattler.Run
         private RectTransform _actoCompletedPanel;
         private Text _statusText;
         private Text _titleText;
-        private readonly List<Button> _nodeButtons = new List<Button>();
+        private RunMapView _mapView;
         private Text _resolveTitleText;
         private Text _resolveBodyText;
         private Button _resolveCompleteButton;
@@ -124,19 +124,12 @@ namespace RoguelikeCardBattler.Run
             statusRect.anchorMin = new Vector2(0.1f, 0.8f);
             statusRect.anchorMax = new Vector2(0.9f, 0.88f);
 
-            CreateNodeButtons(CreateNodeScrollView(_mapPanel));
+            _mapView = new RunMapView(_mapPanel, _map, _state, uiFont, GetWhiteSprite());
+            _mapView.OnNodeClicked += EnterNode;
             BuildResolvePanel();
             BuildDefeatPanel();
             BuildRewardPanel();
             BuildActoCompletedPanel();
-
-#if UNITY_EDITOR
-            RectTransform contentRect = _mapPanel.transform.Find("NodeScrollView/Viewport/Content") as RectTransform;
-            if (contentRect != null)
-            {
-                Debug.Log($"[RunUI Debug] Content height: {contentRect.rect.height}, children: {contentRect.childCount}");
-            }
-#endif
         }
 
         private void EnsureEventSystem()
@@ -199,121 +192,6 @@ namespace RoguelikeCardBattler.Run
 #endif
         }
 
-        private RectTransform CreateNodeScrollView(RectTransform parent)
-        {
-            GameObject scrollGO = new GameObject("NodeScrollView", typeof(RectTransform), typeof(Image), typeof(ScrollRect));
-            scrollGO.transform.SetParent(parent, false);
-
-            RectTransform scrollRect = scrollGO.GetComponent<RectTransform>();
-            scrollRect.anchorMin = new Vector2(0.1f, 0.25f);
-            scrollRect.anchorMax = new Vector2(0.9f, 0.78f);
-            scrollRect.offsetMin = Vector2.zero;
-            scrollRect.offsetMax = Vector2.zero;
-
-            Image bg = scrollGO.GetComponent<Image>();
-            bg.sprite = GetWhiteSprite();
-            bg.type = Image.Type.Simple;
-            bg.color = new Color(0.05f, 0.05f, 0.08f, 0.3f);
-
-            ScrollRect scroll = scrollGO.GetComponent<ScrollRect>();
-            scroll.horizontal = false;
-            scroll.vertical = true;
-            scroll.movementType = ScrollRect.MovementType.Clamped;
-
-            GameObject viewportGO = new GameObject("Viewport", typeof(RectTransform), typeof(RectMask2D), typeof(Image));
-            viewportGO.transform.SetParent(scrollGO.transform, false);
-            RectTransform viewportRect = viewportGO.GetComponent<RectTransform>();
-            viewportRect.anchorMin = Vector2.zero;
-            viewportRect.anchorMax = Vector2.one;
-            viewportRect.offsetMin = Vector2.zero;
-            viewportRect.offsetMax = Vector2.zero;
-
-            Image viewportImage = viewportGO.GetComponent<Image>();
-            viewportImage.color = new Color(0f, 0f, 0f, 0f);
-            viewportImage.raycastTarget = true;
-
-            GameObject contentGO = new GameObject("Content", typeof(RectTransform), typeof(VerticalLayoutGroup), typeof(ContentSizeFitter));
-            contentGO.transform.SetParent(viewportGO.transform, false);
-            RectTransform contentRect = contentGO.GetComponent<RectTransform>();
-            contentRect.anchorMin = new Vector2(0f, 0f);
-            contentRect.anchorMax = new Vector2(1f, 1f);
-            contentRect.pivot = new Vector2(0.5f, 1f);
-            contentRect.anchoredPosition = Vector2.zero;
-            contentRect.sizeDelta = Vector2.zero;
-
-            VerticalLayoutGroup layout = contentGO.GetComponent<VerticalLayoutGroup>();
-            layout.spacing = 10f;
-            layout.childAlignment = TextAnchor.UpperCenter;
-            layout.childForceExpandHeight = false;
-            layout.childControlHeight = true;
-            layout.childForceExpandWidth = true;
-            layout.childControlWidth = true;
-
-            ContentSizeFitter fitter = contentGO.GetComponent<ContentSizeFitter>();
-            fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
-
-            scroll.viewport = viewportRect;
-            scroll.content = contentRect;
-
-            return contentRect;
-        }
-
-        private void CreateNodeButtons(RectTransform parent)
-        {
-            for (int i = 0; i < _map.Nodes.Count; i++)
-            {
-                MapNode node = _map.Nodes[i];
-                int nodeId = node.Id;
-                Button button = CreateNodeButton(parent, $"Node_{nodeId}", $"Nodo {nodeId + 1}");
-                button.onClick.AddListener(() => EnterNode(nodeId));
-                _nodeButtons.Add(button);
-            }
-        }
-
-        private Button CreateNodeButton(RectTransform parent, string name, string label)
-        {
-            GameObject buttonGO = new GameObject(name, typeof(RectTransform), typeof(Image), typeof(Button), typeof(LayoutElement));
-            buttonGO.transform.SetParent(parent, false);
-            RectTransform rect = buttonGO.GetComponent<RectTransform>();
-            rect.anchorMin = new Vector2(0f, 0f);
-            rect.anchorMax = new Vector2(1f, 0f);
-            rect.pivot = new Vector2(0.5f, 0.5f);
-            rect.offsetMin = Vector2.zero;
-            rect.offsetMax = Vector2.zero;
-
-            LayoutElement layout = buttonGO.GetComponent<LayoutElement>();
-            layout.preferredHeight = 70f;
-            layout.minHeight = 60f;
-
-            Image image = buttonGO.GetComponent<Image>();
-            image.sprite = GetWhiteSprite();
-            image.type = Image.Type.Simple;
-            image.color = new Color(0.15f, 0.15f, 0.2f, 1f);
-            image.raycastTarget = true;
-
-            GameObject textGO = new GameObject("Label", typeof(RectTransform), typeof(Text));
-            textGO.transform.SetParent(buttonGO.transform, false);
-            RectTransform textRect = textGO.GetComponent<RectTransform>();
-            textRect.anchorMin = Vector2.zero;
-            textRect.anchorMax = Vector2.one;
-            textRect.offsetMin = Vector2.zero;
-            textRect.offsetMax = Vector2.zero;
-
-            Text text = textGO.GetComponent<Text>();
-            text.font = uiFont;
-            text.fontSize = 20;
-            text.alignment = TextAnchor.MiddleCenter;
-            text.color = Color.white;
-            text.text = label;
-            text.raycastTarget = false;
-
-            Outline outline = textGO.AddComponent<Outline>();
-            outline.effectColor = new Color(0f, 0f, 0f, 0.6f);
-            outline.effectDistance = new Vector2(1f, -1f);
-
-            return buttonGO.GetComponent<Button>();
-        }
-
         private void ShowMap()
         {
             _resolvePanel.gameObject.SetActive(false);
@@ -321,7 +199,7 @@ namespace RoguelikeCardBattler.Run
             _rewardPanel.gameObject.SetActive(false);
             _actoCompletedPanel.gameObject.SetActive(false);
             _mapPanel.gameObject.SetActive(true);
-            _titleText.text = "Mapa Acto 1 (placeholder)";
+            _titleText.text = "Mapa Acto 1";
 
             int completed = 0;
             foreach (MapNode node in _map.Nodes)
@@ -333,44 +211,7 @@ namespace RoguelikeCardBattler.Run
             }
 
             _statusText.text = $"Gold: {_state.Gold} | Completados: {completed}/{_map.Nodes.Count}";
-
-            for (int i = 0; i < _nodeButtons.Count; i++)
-            {
-                Button button = _nodeButtons[i];
-                int nodeId = _map.Nodes[i].Id;
-                bool completedNode = _state.IsNodeCompleted(nodeId);
-                bool available = _state.IsNodeAvailable(nodeId);
-
-                button.gameObject.SetActive(true);
-                button.interactable = available && !_state.RunFailed;
-
-                Text label = button.GetComponentInChildren<Text>();
-                if (label != null)
-                {
-                    NodeType type = _map.Nodes[i].Type;
-                    string typeLabel = $"{type}";
-                    label.text = completedNode
-                        ? $"Nodo {nodeId + 1} ({typeLabel}) ✓"
-                        : $"Nodo {nodeId + 1} ({typeLabel})";
-                }
-
-                Image image = button.GetComponent<Image>();
-                if (image != null)
-                {
-                    if (completedNode)
-                    {
-                        image.color = new Color(0.2f, 0.5f, 0.25f, 1f);
-                    }
-                    else if (available)
-                    {
-                        image.color = new Color(0.2f, 0.35f, 0.6f, 1f);
-                    }
-                    else
-                    {
-                        image.color = new Color(0.2f, 0.2f, 0.2f, 0.7f);
-                    }
-                }
-            }
+            _mapView?.Refresh(_state);
         }
 
         private void EnterNode(int index)


### PR DESCRIPTION
Replace the vertical button list with a 2D node graph using BFS-based depth layout. Nodes show type icons and visual states (locked/available/ completed). Edges drawn as stretched/rotated UI Images between connected nodes. RunFlowController delegates all map rendering to RunMapView while preserving existing flow logic (EnterNode, overlays, rewards).

Files created:
- Assets/Scripts/Run/Map/UI/RunMapView.cs
- Assets/Scripts/Run/Map/UI/RunMapNodeView.cs
- Assets/Scripts/Run/Map/UI/RunMapEdgeView.cs

Files modified:
- Assets/Scripts/Run/RunFlowController.cs

Closes #60