### PR TITLE
feat: random map generation with weighted node types and seed support…

### DIFF
--- a/Assets/Scenes/RunScene.unity
+++ b/Assets/Scenes/RunScene.unity
@@ -149,6 +149,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: RoguelikeCardBattler::RoguelikeCardBattler.Run.RunSession
   bossAct1Enemy: {fileID: 11400000, guid: 8f4c2b1a5e3d9f7c6b4a0e9d2f1c5a8b, type: 2}
+  mapConfig: {fileID: 11400000, guid: e7c4d5b6a3f2190834567890abcdef34, type: 2}
 --- !u!4 &239194291
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/ScriptableObjects/Run/Map.meta
+++ b/Assets/ScriptableObjects/Run/Map.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: deee0139f57ffa74d98c93cd2b963dac
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Run/Map/Act1MapConfig.asset
+++ b/Assets/ScriptableObjects/Run/Map/Act1MapConfig.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a8f3b2c1d4e5678901234567abcdef12, type: 3}
+  m_Name: Act1MapConfig
+  m_EditorClassIdentifier: 
+  totalNodes: 8
+  minCombatNodes: 3
+  forcedStartType: 0
+  forcedEndType: 5
+  seed: 0
+  nodeTypeWeights:
+  - type: 0
+    weight: 40
+  - type: 2
+    weight: 20
+  - type: 1
+    weight: 15
+  - type: 3
+    weight: 20
+  - type: 4
+    weight: 5

--- a/Assets/ScriptableObjects/Run/Map/Act1MapConfig.asset.meta
+++ b/Assets/ScriptableObjects/Run/Map/Act1MapConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e7c4d5b6a3f2190834567890abcdef34
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Run/Map/Act1MapConfig.cs
+++ b/Assets/Scripts/Run/Map/Act1MapConfig.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace RoguelikeCardBattler.Run
+{
+    /// <summary>
+    /// Peso para un tipo de nodo en la generación aleatoria del mapa.
+    /// Mayor weight = más probable que aparezca.
+    /// </summary>
+    [Serializable]
+    public struct NodeTypeWeight
+    {
+        public NodeType type;
+        [Min(0f)] public float weight;
+    }
+
+    /// <summary>
+    /// Configuración data-driven para la generación de mapas del Acto 1.
+    /// Controla cantidad de nodos, pesos de tipos, seed y restricciones
+    /// estructurales. Asignable en Inspector para iterar sin tocar código.
+    /// </summary>
+    [CreateAssetMenu(fileName = "Act1MapConfig", menuName = "Run/Map/Act1MapConfig")]
+    public class Act1MapConfig : ScriptableObject
+    {
+        [Header("Structure")]
+        [SerializeField] private int totalNodes = 8;
+        [SerializeField] private int minCombatNodes = 3;
+        [SerializeField] private NodeType forcedStartType = NodeType.Combat;
+        [SerializeField] private NodeType forcedEndType = NodeType.Boss;
+
+        [Header("Randomization")]
+        [Tooltip("0 = random each run, >0 = fixed seed for reproducibility")]
+        [SerializeField] private int seed;
+
+        [Header("Type Weights")]
+        [SerializeField] private List<NodeTypeWeight> nodeTypeWeights = new List<NodeTypeWeight>
+        {
+            new NodeTypeWeight { type = NodeType.Combat, weight = 40f },
+            new NodeTypeWeight { type = NodeType.Event, weight = 20f },
+            new NodeTypeWeight { type = NodeType.Shop, weight = 15f },
+            new NodeTypeWeight { type = NodeType.Campfire, weight = 20f },
+            new NodeTypeWeight { type = NodeType.Elite, weight = 5f },
+        };
+
+        public int TotalNodes => totalNodes;
+        public int MinCombatNodes => minCombatNodes;
+        public NodeType ForcedStartType => forcedStartType;
+        public NodeType ForcedEndType => forcedEndType;
+        public int Seed => seed;
+        public IReadOnlyList<NodeTypeWeight> NodeTypeWeights => nodeTypeWeights;
+    }
+}

--- a/Assets/Scripts/Run/Map/Act1MapConfig.cs.meta
+++ b/Assets/Scripts/Run/Map/Act1MapConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8f3b2c1d4e5678901234567abcdef12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Run/Map/RunMapGenerator.cs
+++ b/Assets/Scripts/Run/Map/RunMapGenerator.cs
@@ -1,36 +1,185 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
 namespace RoguelikeCardBattler.Run
 {
+    /// <summary>
+    /// Genera mapas de acto para el run. Soporta generación aleatoria con pesos
+    /// para tipos de nodo y múltiples templates de topología.
+    /// Seed-based: misma seed produce el mismo mapa (para debug/reproducibilidad).
+    /// </summary>
     public static class RunMapGenerator
     {
-        public static ActMap GenerateAct1()
+        /// <summary>
+        /// Templates de topología: cada uno es un array de aristas dirigidas {from, to}.
+        /// Todos garantizan: 8 nodos (0-7), DAG, al menos 1 bifurcación + 1 convergencia,
+        /// nodo 0 = start (sin entrantes), nodo 7 = end (sin salientes).
+        /// </summary>
+        private static readonly int[][][] Topologies =
         {
-            var map = new ActMap(startNodeId: 0);
+            // A: doble diamante — 0→(1,2)→3→(4,5)→6→7
+            new[]
+            {
+                new[] { 0, 1 }, new[] { 0, 2 }, new[] { 1, 3 }, new[] { 2, 3 },
+                new[] { 3, 4 }, new[] { 3, 5 }, new[] { 4, 6 }, new[] { 5, 6 },
+                new[] { 6, 7 }
+            },
+            // B: split tardío — 0→1→(2,3)→4→(5,6)→7
+            new[]
+            {
+                new[] { 0, 1 }, new[] { 1, 2 }, new[] { 1, 3 }, new[] { 2, 4 },
+                new[] { 3, 4 }, new[] { 4, 5 }, new[] { 4, 6 }, new[] { 5, 7 },
+                new[] { 6, 7 }
+            },
+            // C: triple temprano — 0→(1,2,3)→(4,5)→6→7
+            new[]
+            {
+                new[] { 0, 1 }, new[] { 0, 2 }, new[] { 0, 3 }, new[] { 1, 4 },
+                new[] { 2, 4 }, new[] { 3, 5 }, new[] { 4, 6 }, new[] { 5, 6 },
+                new[] { 6, 7 }
+            },
+        };
 
-            // 8 nodos con bifurcación y convergencia:
-            // 0 -> (1,2) -> 3 -> (4,5) -> 6 -> 7
-            map.Nodes.Add(new MapNode(0, NodeType.Combat));
-            map.Nodes.Add(new MapNode(1, NodeType.Event));
-            map.Nodes.Add(new MapNode(2, NodeType.Shop));
-            map.Nodes.Add(new MapNode(3, NodeType.Combat));
-            map.Nodes.Add(new MapNode(4, NodeType.Campfire));
-            map.Nodes.Add(new MapNode(5, NodeType.Combat));
-            map.Nodes.Add(new MapNode(6, NodeType.Event));
-            
-            // Nodo Boss - el enemigo específico será asignado desde RunSession
-            MapNode bossNode = new MapNode(7, NodeType.Boss);
-            map.Nodes.Add(bossNode);
+        /// <summary>
+        /// Genera un mapa usando la configuración data-driven (pesos, seed, constraints).
+        /// Si seed es 0, genera uno distinto cada run.
+        /// </summary>
+        public static ActMap Generate(Act1MapConfig config, int? seedOverride = null)
+        {
+            int seed = seedOverride ?? config.Seed;
+            if (seed == 0)
+            {
+                seed = Environment.TickCount;
+            }
 
-            map.GetNode(0).Connections.Add(1);
-            map.GetNode(0).Connections.Add(2);
-            map.GetNode(1).Connections.Add(3);
-            map.GetNode(2).Connections.Add(3);
-            map.GetNode(3).Connections.Add(4);
-            map.GetNode(3).Connections.Add(5);
-            map.GetNode(4).Connections.Add(6);
-            map.GetNode(5).Connections.Add(6);
-            map.GetNode(6).Connections.Add(7);
+            System.Random rng = new System.Random(seed);
+            ActMap map = new ActMap(startNodeId: 0);
+
+            int templateIndex = rng.Next(Topologies.Length);
+            int[][] edges = Topologies[templateIndex];
+
+            NodeType[] types = AssignNodeTypes(config, rng);
+
+            for (int i = 0; i < config.TotalNodes; i++)
+            {
+                map.Nodes.Add(new MapNode(i, types[i]));
+            }
+
+            foreach (int[] edge in edges)
+            {
+                MapNode from = map.GetNode(edge[0]);
+                if (from != null)
+                {
+                    from.Connections.Add(edge[1]);
+                }
+            }
+
+#if UNITY_EDITOR
+            Debug.Log($"[MapGen] seed={seed}, template={templateIndex}, types=[{string.Join(",", types)}]");
+#endif
 
             return map;
+        }
+
+        /// <summary>
+        /// Backward compatible: genera un mapa con defaults si no hay config asignado.
+        /// </summary>
+        public static ActMap GenerateAct1()
+        {
+            Act1MapConfig config = ScriptableObject.CreateInstance<Act1MapConfig>();
+            ActMap map = Generate(config);
+            UnityEngine.Object.DestroyImmediate(config);
+            return map;
+        }
+
+        /// <summary>
+        /// Asigna tipos a los nodos respetando tipos forzados (start/end)
+        /// y la restricción de mínimo de nodos Combat.
+        /// </summary>
+        private static NodeType[] AssignNodeTypes(Act1MapConfig config, System.Random rng)
+        {
+            int total = config.TotalNodes;
+            NodeType[] types = new NodeType[total];
+
+            types[0] = config.ForcedStartType;
+            types[total - 1] = config.ForcedEndType;
+
+            List<NodeTypeWeight> pool = new List<NodeTypeWeight>();
+            float totalWeight = 0f;
+            foreach (NodeTypeWeight nw in config.NodeTypeWeights)
+            {
+                if (nw.type == NodeType.Boss)
+                {
+                    continue;
+                }
+
+                pool.Add(nw);
+                totalWeight += nw.weight;
+            }
+
+            for (int i = 1; i < total - 1; i++)
+            {
+                types[i] = WeightedRandom(pool, totalWeight, rng);
+            }
+
+            int combatCount = 0;
+            for (int i = 0; i < total; i++)
+            {
+                if (types[i] == NodeType.Combat)
+                {
+                    combatCount++;
+                }
+            }
+
+            int needed = config.MinCombatNodes - combatCount;
+            if (needed > 0)
+            {
+                List<int> candidates = new List<int>();
+                for (int i = 1; i < total - 1; i++)
+                {
+                    if (types[i] != NodeType.Combat)
+                    {
+                        candidates.Add(i);
+                    }
+                }
+
+                Shuffle(candidates, rng);
+                for (int j = 0; j < needed && j < candidates.Count; j++)
+                {
+                    types[candidates[j]] = NodeType.Combat;
+                }
+            }
+
+            return types;
+        }
+
+        private static NodeType WeightedRandom(List<NodeTypeWeight> pool,
+            float totalWeight, System.Random rng)
+        {
+            float roll = (float)(rng.NextDouble() * totalWeight);
+            float cumulative = 0f;
+            foreach (NodeTypeWeight nw in pool)
+            {
+                cumulative += nw.weight;
+                if (roll <= cumulative)
+                {
+                    return nw.type;
+                }
+            }
+
+            return pool.Count > 0 ? pool[pool.Count - 1].type : NodeType.Combat;
+        }
+
+        private static void Shuffle<T>(List<T> list, System.Random rng)
+        {
+            for (int i = list.Count - 1; i > 0; i--)
+            {
+                int j = rng.Next(i + 1);
+                T temp = list[i];
+                list[i] = list[j];
+                list[j] = temp;
+            }
         }
     }
 }

--- a/Assets/Scripts/Run/RunSession.cs
+++ b/Assets/Scripts/Run/RunSession.cs
@@ -14,6 +14,7 @@ namespace RoguelikeCardBattler.Run
         public ActMap Map { get; private set; }
         public RunCombatConfig CombatConfig { get; private set; }
         [SerializeField] private EnemyDefinition bossAct1Enemy;
+        [SerializeField] private Act1MapConfig mapConfig;
 
         public static RunSession GetOrCreate()
         {
@@ -47,7 +48,9 @@ namespace RoguelikeCardBattler.Run
             DontDestroyOnLoad(gameObject);
             if (Map == null)
             {
-                Map = RunMapGenerator.GenerateAct1();
+                Map = mapConfig != null
+                    ? RunMapGenerator.Generate(mapConfig)
+                    : RunMapGenerator.GenerateAct1();
             }
             State.EnsureInitialized(Map);
 
@@ -60,7 +63,9 @@ namespace RoguelikeCardBattler.Run
         /// </summary>
         public void ResetForNewRun()
         {
-            Map = RunMapGenerator.GenerateAct1();
+            Map = mapConfig != null
+                ? RunMapGenerator.Generate(mapConfig)
+                : RunMapGenerator.GenerateAct1();
             State.Reset(Map);
             CombatConfig = null;
             AssignBossAct1();
@@ -68,12 +73,17 @@ namespace RoguelikeCardBattler.Run
 
         private void AssignBossAct1()
         {
-            if (bossAct1Enemy != null && Map != null && Map.Nodes.Count > 7)
+            if (bossAct1Enemy == null || Map == null)
             {
-                MapNode bossNode = Map.GetNode(7);
-                if (bossNode != null && bossNode.Type == NodeType.Boss)
+                return;
+            }
+
+            foreach (MapNode node in Map.Nodes)
+            {
+                if (node.Type == NodeType.Boss)
                 {
-                    bossNode.SpecificEnemy = bossAct1Enemy;
+                    node.SpecificEnemy = bossAct1Enemy;
+                    break;
                 }
             }
         }
@@ -89,6 +99,11 @@ namespace RoguelikeCardBattler.Run
             {
                 bossAct1Enemy = source.bossAct1Enemy;
                 AssignBossAct1();
+            }
+
+            if (mapConfig == null && source.mapConfig != null)
+            {
+                mapConfig = source.mapConfig;
             }
         }
 


### PR DESCRIPTION
… (#62)

Replace hardcoded 8-node map with seed-based random generation. Three topology templates (double diamond, late split, wide triple) are selected randomly per run. Node types assigned via weighted random from a data-driven Act1MapConfig ScriptableObject, enforcing minimum Combat count. Same seed always reproduces the same map.

Files created:
- Assets/Scripts/Run/Map/Act1MapConfig.cs
- Assets/ScriptableObjects/Run/Map/Act1MapConfig.asset

Files modified:
- Assets/Scripts/Run/Map/RunMapGenerator.cs
- Assets/Scripts/Run/RunSession.cs

Closes #62