### PR TITLE
feat: random enemy selection by depth with weighted pools + fix HP pe…

### DIFF
--- a/Assets/Scenes/RunScene.unity
+++ b/Assets/Scenes/RunScene.unity
@@ -150,6 +150,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: RoguelikeCardBattler::RoguelikeCardBattler.Run.RunSession
   bossAct1Enemy: {fileID: 11400000, guid: 8f4c2b1a5e3d9f7c6b4a0e9d2f1c5a8b, type: 2}
   mapConfig: {fileID: 11400000, guid: e7c4d5b6a3f2190834567890abcdef34, type: 2}
+  enemyPoolConfig: {fileID: 11400000, guid: b1c2d3e4f5a6b7c8d9e0f12345678902, type: 2}
 --- !u!4 &239194291
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/ScriptableObjects/Enemies/DarkMage.asset
+++ b/Assets/ScriptableObjects/Enemies/DarkMage.asset
@@ -1,0 +1,75 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 338b6c04c3364f30af226f884a2d4f1d, type: 3}
+  m_Name: DarkMage
+  m_EditorClassIdentifier: 
+  id: dark_mage
+  enemyName: Dark Mage
+  maxHP: 28
+  baseBlock: 0
+  aiPattern: 0
+  tags:
+  - Mage
+  - Dark
+  moves:
+  - id: darkmage_dark_bolt
+    moveName: Dark Bolt
+    description: Deals 12 damage.
+    effects:
+    - effectType: 0
+      value: 12
+      target: 1
+      statusType: 0
+      extraParams: []
+    weight: 40
+    sequenceIndex: -1
+    intentType: 1
+  - id: darkmage_shadow_blast
+    moveName: Shadow Blast
+    description: Deals 15 damage.
+    effects:
+    - effectType: 0
+      value: 15
+      target: 1
+      statusType: 0
+      extraParams: []
+    weight: 25
+    sequenceIndex: -1
+    intentType: 1
+  - id: darkmage_arcane_shield
+    moveName: Arcane Shield
+    description: Gains 8 Block.
+    effects:
+    - effectType: 1
+      value: 8
+      target: 0
+      statusType: 0
+      extraParams: []
+    weight: 20
+    sequenceIndex: -1
+    intentType: 2
+  - id: darkmage_dark_ritual
+    moveName: Dark Ritual
+    description: Deals 10 damage.
+    effects:
+    - effectType: 0
+      value: 10
+      target: 1
+      statusType: 0
+      extraParams: []
+    weight: 15
+    sequenceIndex: -1
+    intentType: 1
+  avatarScale: 1
+  avatarOffset: {x: 0, y: 0}
+  elementType: 0
+  avatar: {fileID: 0}

--- a/Assets/ScriptableObjects/Enemies/DarkMage.asset.meta
+++ b/Assets/ScriptableObjects/Enemies/DarkMage.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d1e2f3a4b5c6d7e8f901234567890003
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Enemies/Goblin.asset
+++ b/Assets/ScriptableObjects/Enemies/Goblin.asset
@@ -1,0 +1,63 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 338b6c04c3364f30af226f884a2d4f1d, type: 3}
+  m_Name: Goblin
+  m_EditorClassIdentifier: 
+  id: goblin
+  enemyName: Goblin
+  maxHP: 20
+  baseBlock: 0
+  aiPattern: 0
+  tags:
+  - Basic
+  - Goblin
+  moves:
+  - id: goblin_slash
+    moveName: Slash
+    description: Deals 5 damage.
+    effects:
+    - effectType: 0
+      value: 5
+      target: 1
+      statusType: 0
+      extraParams: []
+    weight: 50
+    sequenceIndex: -1
+    intentType: 1
+  - id: goblin_stab
+    moveName: Stab
+    description: Deals 7 damage.
+    effects:
+    - effectType: 0
+      value: 7
+      target: 1
+      statusType: 0
+      extraParams: []
+    weight: 30
+    sequenceIndex: -1
+    intentType: 1
+  - id: goblin_duck
+    moveName: Duck
+    description: Gains 4 Block.
+    effects:
+    - effectType: 1
+      value: 4
+      target: 0
+      statusType: 0
+      extraParams: []
+    weight: 20
+    sequenceIndex: -1
+    intentType: 2
+  avatarScale: 1
+  avatarOffset: {x: 0, y: 0}
+  elementType: 0
+  avatar: {fileID: 0}

--- a/Assets/ScriptableObjects/Enemies/Goblin.asset.meta
+++ b/Assets/ScriptableObjects/Enemies/Goblin.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d1e2f3a4b5c6d7e8f901234567890001
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Enemies/SkeletonWarrior.asset
+++ b/Assets/ScriptableObjects/Enemies/SkeletonWarrior.asset
@@ -1,0 +1,63 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 338b6c04c3364f30af226f884a2d4f1d, type: 3}
+  m_Name: SkeletonWarrior
+  m_EditorClassIdentifier: 
+  id: skeleton_warrior
+  enemyName: Skeleton Warrior
+  maxHP: 35
+  baseBlock: 0
+  aiPattern: 1
+  tags:
+  - Undead
+  - Skeleton
+  moves:
+  - id: skeleton_bone_strike
+    moveName: Bone Strike
+    description: Deals 8 damage.
+    effects:
+    - effectType: 0
+      value: 8
+      target: 1
+      statusType: 0
+      extraParams: []
+    weight: 1
+    sequenceIndex: 0
+    intentType: 1
+  - id: skeleton_shield_bones
+    moveName: Shield Bones
+    description: Gains 5 Block.
+    effects:
+    - effectType: 1
+      value: 5
+      target: 0
+      statusType: 0
+      extraParams: []
+    weight: 1
+    sequenceIndex: 1
+    intentType: 2
+  - id: skeleton_heavy_slash
+    moveName: Heavy Slash
+    description: Deals 10 damage.
+    effects:
+    - effectType: 0
+      value: 10
+      target: 1
+      statusType: 0
+      extraParams: []
+    weight: 1
+    sequenceIndex: 2
+    intentType: 1
+  avatarScale: 1
+  avatarOffset: {x: 0, y: 0}
+  elementType: 0
+  avatar: {fileID: 0}

--- a/Assets/ScriptableObjects/Enemies/SkeletonWarrior.asset.meta
+++ b/Assets/ScriptableObjects/Enemies/SkeletonWarrior.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d1e2f3a4b5c6d7e8f901234567890002
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Run/Map/EnemyPoolConfig_Act1.asset
+++ b/Assets/ScriptableObjects/Run/Map/EnemyPoolConfig_Act1.asset
@@ -1,0 +1,42 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1c2d3e4f5a6b7c8d9e0f12345678901, type: 3}
+  m_Name: EnemyPoolConfig_Act1
+  m_EditorClassIdentifier: 
+  depthPools:
+  - label: Early
+    minDepth: 0
+    maxDepth: 1
+    entries:
+    - enemy: {fileID: 11400000, guid: a5f86b9e5ecb4de5bf5dfbcfbcff3577, type: 2}
+      weight: 60
+    - enemy: {fileID: 11400000, guid: d1e2f3a4b5c6d7e8f901234567890001, type: 2}
+      weight: 40
+  - label: Mid
+    minDepth: 2
+    maxDepth: 3
+    entries:
+    - enemy: {fileID: 11400000, guid: a5f86b9e5ecb4de5bf5dfbcfbcff3577, type: 2}
+      weight: 20
+    - enemy: {fileID: 11400000, guid: d1e2f3a4b5c6d7e8f901234567890001, type: 2}
+      weight: 30
+    - enemy: {fileID: 11400000, guid: d1e2f3a4b5c6d7e8f901234567890002, type: 2}
+      weight: 50
+  - label: Late
+    minDepth: 4
+    maxDepth: 99
+    entries:
+    - enemy: {fileID: 11400000, guid: d1e2f3a4b5c6d7e8f901234567890002, type: 2}
+      weight: 30
+    - enemy: {fileID: 11400000, guid: d1e2f3a4b5c6d7e8f901234567890003, type: 2}
+      weight: 70
+  fallbackEnemy: {fileID: 11400000, guid: a5f86b9e5ecb4de5bf5dfbcfbcff3577, type: 2}

--- a/Assets/ScriptableObjects/Run/Map/EnemyPoolConfig_Act1.asset.meta
+++ b/Assets/ScriptableObjects/Run/Map/EnemyPoolConfig_Act1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b1c2d3e4f5a6b7c8d9e0f12345678902
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Run/BattleFlowController.cs
+++ b/Assets/Scripts/Run/BattleFlowController.cs
@@ -99,6 +99,12 @@ namespace RoguelikeCardBattler.Run
 #endif
             }
 
+            if (_turnManager != null)
+            {
+                session.State.PlayerCurrentHP = _turnManager.PlayerHP;
+                session.State.PlayerMaxHP = _turnManager.PlayerMaxHP;
+            }
+
             if (!IsSceneInBuild(RunSceneName))
             {
 #if UNITY_EDITOR
@@ -107,7 +113,7 @@ namespace RoguelikeCardBattler.Run
                 return;
             }
 #if UNITY_EDITOR
-            Debug.Log("[BattleFlow] Loading RunScene");
+            Debug.Log($"[BattleFlow] Loading RunScene (HP saved: {session.State.PlayerCurrentHP}/{session.State.PlayerMaxHP})");
 #endif
             SceneManager.LoadScene(RunSceneName);
         }
@@ -161,10 +167,14 @@ namespace RoguelikeCardBattler.Run
             // Detecta si es una batalla de boss basado en el tipo de nodo
             _isBossBattle = IsCurrentNodeBoss(session);
 
+            session.State.EnsurePlayerHpInitialized(_turnManager.PlayerMaxHP);
+            int currentHp = session.State.PlayerCurrentHP;
+            int maxHp = session.State.PlayerMaxHP;
+
 #if UNITY_EDITOR
-            Debug.Log($"[BattleFlow] Deck size: {deck.Count}, Enemy: {enemyToUse.EnemyName}, IsBoss: {_isBossBattle}");
+            Debug.Log($"[BattleFlow] Deck size: {deck.Count}, Enemy: {enemyToUse.EnemyName}, IsBoss: {_isBossBattle}, HP: {currentHp}/{maxHp}");
 #endif
-            _turnManager.ConfigureCombat(deck, enemyToUse);
+            _turnManager.ConfigureCombat(deck, enemyToUse, currentHp, maxHp);
             _configured = true;
         }
 

--- a/Assets/Scripts/Run/Map/EnemyPoolConfig.cs
+++ b/Assets/Scripts/Run/Map/EnemyPoolConfig.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using RoguelikeCardBattler.Gameplay.Enemies;
+using UnityEngine;
+
+namespace RoguelikeCardBattler.Run
+{
+    /// <summary>
+    /// Weighted entry pairing an EnemyDefinition with a selection weight.
+    /// Used inside <see cref="DepthPool"/> to control spawn probability.
+    /// </summary>
+    [Serializable]
+    public struct EnemyWeightEntry
+    {
+        public EnemyDefinition enemy;
+        [Min(0f)] public float weight;
+    }
+
+    /// <summary>
+    /// Pool of enemies for a depth range. Nodes whose BFS depth falls within
+    /// [minDepth, maxDepth] draw from this pool's weighted entries.
+    /// </summary>
+    [Serializable]
+    public class DepthPool
+    {
+        public string label;
+        public int minDepth;
+        public int maxDepth;
+        public List<EnemyWeightEntry> entries = new List<EnemyWeightEntry>();
+    }
+
+    /// <summary>
+    /// Data-driven configuration for enemy selection per map node.
+    /// Depth pools map BFS distance from the start node to weighted enemy lists,
+    /// allowing early nodes to spawn easier enemies and late nodes harder ones.
+    /// </summary>
+    [CreateAssetMenu(fileName = "EnemyPoolConfig", menuName = "Run/Map/EnemyPoolConfig")]
+    public class EnemyPoolConfig : ScriptableObject
+    {
+        [SerializeField] private List<DepthPool> depthPools = new List<DepthPool>();
+
+        [Tooltip("Used when a node's depth doesn't match any pool")]
+        [SerializeField] private EnemyDefinition fallbackEnemy;
+
+        public IReadOnlyList<DepthPool> DepthPools => depthPools;
+        public EnemyDefinition FallbackEnemy => fallbackEnemy;
+
+        /// <summary>
+        /// Returns the first pool whose depth range contains <paramref name="depth"/>, or null.
+        /// </summary>
+        public DepthPool GetPoolForDepth(int depth)
+        {
+            foreach (DepthPool pool in depthPools)
+            {
+                if (depth >= pool.minDepth && depth <= pool.maxDepth)
+                {
+                    return pool;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Assets/Scripts/Run/Map/EnemyPoolConfig.cs.meta
+++ b/Assets/Scripts/Run/Map/EnemyPoolConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1c2d3e4f5a6b7c8d9e0f12345678901
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Run/Map/RunMapGenerator.cs
+++ b/Assets/Scripts/Run/Map/RunMapGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using RoguelikeCardBattler.Gameplay.Enemies;
 using UnityEngine;
 
 namespace RoguelikeCardBattler.Run
@@ -7,7 +8,8 @@ namespace RoguelikeCardBattler.Run
     /// <summary>
     /// Genera mapas de acto para el run. Soporta generación aleatoria con pesos
     /// para tipos de nodo y múltiples templates de topología.
-    /// Seed-based: misma seed produce el mismo mapa (para debug/reproducibilidad).
+    /// También asigna enemigos a nodos Combat/Elite basándose en profundidad BFS.
+    /// Seed-based: misma seed produce el mismo mapa y mismos enemigos.
     /// </summary>
     public static class RunMapGenerator
     {
@@ -181,5 +183,122 @@ namespace RoguelikeCardBattler.Run
                 list[j] = temp;
             }
         }
+
+        /// <summary>
+        /// Assigns enemies to Combat/Elite nodes based on BFS depth and weighted pools.
+        /// Boss nodes are skipped (handled by RunSession.AssignBossAct1).
+        /// Uses its own System.Random from the provided seed for determinism
+        /// independent of the map topology generator.
+        /// </summary>
+        public static void AssignEnemies(ActMap map, EnemyPoolConfig pool, int seed)
+        {
+            if (pool == null || map == null)
+            {
+                return;
+            }
+
+            System.Random rng = new System.Random(seed);
+            Dictionary<int, int> depths = ComputeNodeDepths(map);
+
+            foreach (MapNode node in map.Nodes)
+            {
+                if (node.Type == NodeType.Boss)
+                {
+                    continue;
+                }
+
+                if (node.Type != NodeType.Combat && node.Type != NodeType.Elite)
+                {
+                    continue;
+                }
+
+                int depth = depths.ContainsKey(node.Id) ? depths[node.Id] : 0;
+                DepthPool dp = pool.GetPoolForDepth(depth);
+
+                if (dp != null && dp.entries.Count > 0)
+                {
+                    node.SpecificEnemy = WeightedRandomEnemy(dp.entries, rng);
+                }
+                else if (pool.FallbackEnemy != null)
+                {
+                    node.SpecificEnemy = pool.FallbackEnemy;
+                }
+            }
+
+#if UNITY_EDITOR
+            Debug.Log($"[MapGen] AssignEnemies seed={seed}, depths=[{FormatDepths(depths)}]");
+#endif
+        }
+
+        /// <summary>
+        /// BFS from StartNodeId to compute each node's depth (distance from start).
+        /// Same algorithm as RunMapView.ComputeDepths, duplicated here to keep
+        /// the generator independent of UI code.
+        /// </summary>
+        private static Dictionary<int, int> ComputeNodeDepths(ActMap map)
+        {
+            Dictionary<int, int> depths = new Dictionary<int, int>();
+            Queue<int> queue = new Queue<int>();
+            depths[map.StartNodeId] = 0;
+            queue.Enqueue(map.StartNodeId);
+
+            while (queue.Count > 0)
+            {
+                int current = queue.Dequeue();
+                MapNode node = map.GetNode(current);
+                if (node == null)
+                {
+                    continue;
+                }
+
+                int nextDepth = depths[current] + 1;
+                foreach (int conn in node.Connections)
+                {
+                    if (!depths.ContainsKey(conn))
+                    {
+                        depths[conn] = nextDepth;
+                        queue.Enqueue(conn);
+                    }
+                }
+            }
+
+            return depths;
+        }
+
+        private static EnemyDefinition WeightedRandomEnemy(
+            List<EnemyWeightEntry> entries, System.Random rng)
+        {
+            float totalWeight = 0f;
+            foreach (EnemyWeightEntry e in entries)
+            {
+                totalWeight += e.weight;
+            }
+
+            float roll = (float)(rng.NextDouble() * totalWeight);
+            float cumulative = 0f;
+            foreach (EnemyWeightEntry e in entries)
+            {
+                cumulative += e.weight;
+                if (roll <= cumulative)
+                {
+                    return e.enemy;
+                }
+            }
+
+            return entries.Count > 0 ? entries[entries.Count - 1].enemy : null;
+        }
+
+#if UNITY_EDITOR
+        private static string FormatDepths(Dictionary<int, int> depths)
+        {
+            List<string> parts = new List<string>();
+            foreach (KeyValuePair<int, int> kv in depths)
+            {
+                parts.Add($"{kv.Key}:d{kv.Value}");
+            }
+
+            return string.Join(",", parts);
+        }
+#endif
     }
 }

--- a/Assets/Scripts/Run/RunSession.cs
+++ b/Assets/Scripts/Run/RunSession.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using RoguelikeCardBattler.Gameplay.Enemies;
 
@@ -15,6 +16,7 @@ namespace RoguelikeCardBattler.Run
         public RunCombatConfig CombatConfig { get; private set; }
         [SerializeField] private EnemyDefinition bossAct1Enemy;
         [SerializeField] private Act1MapConfig mapConfig;
+        [SerializeField] private EnemyPoolConfig enemyPoolConfig;
 
         public static RunSession GetOrCreate()
         {
@@ -23,7 +25,7 @@ namespace RoguelikeCardBattler.Run
                 return Instance;
             }
 
-            var existing = Object.FindFirstObjectByType<RunSession>();
+            var existing = UnityEngine.Object.FindFirstObjectByType<RunSession>();
             if (existing != null)
             {
                 Instance = existing;
@@ -48,13 +50,9 @@ namespace RoguelikeCardBattler.Run
             DontDestroyOnLoad(gameObject);
             if (Map == null)
             {
-                Map = mapConfig != null
-                    ? RunMapGenerator.Generate(mapConfig)
-                    : RunMapGenerator.GenerateAct1();
+                Map = GenerateMap();
             }
             State.EnsureInitialized(Map);
-
-            // Asigna BossAct1 al nodo jefe si está configurado
             AssignBossAct1();
         }
 
@@ -63,12 +61,34 @@ namespace RoguelikeCardBattler.Run
         /// </summary>
         public void ResetForNewRun()
         {
-            Map = mapConfig != null
-                ? RunMapGenerator.Generate(mapConfig)
-                : RunMapGenerator.GenerateAct1();
+            Map = GenerateMap();
             State.Reset(Map);
             CombatConfig = null;
             AssignBossAct1();
+        }
+
+        /// <summary>
+        /// Generates the map and assigns enemies using a shared seed for determinism.
+        /// The same seed produces the same topology + types AND the same enemy placement.
+        /// </summary>
+        private ActMap GenerateMap()
+        {
+            int seed = mapConfig != null ? mapConfig.Seed : 0;
+            if (seed == 0)
+            {
+                seed = Environment.TickCount;
+            }
+
+            ActMap map = mapConfig != null
+                ? RunMapGenerator.Generate(mapConfig, seed)
+                : RunMapGenerator.GenerateAct1();
+
+            if (enemyPoolConfig != null)
+            {
+                RunMapGenerator.AssignEnemies(map, enemyPoolConfig, seed);
+            }
+
+            return map;
         }
 
         private void AssignBossAct1()
@@ -104,6 +124,11 @@ namespace RoguelikeCardBattler.Run
             if (mapConfig == null && source.mapConfig != null)
             {
                 mapConfig = source.mapConfig;
+            }
+
+            if (enemyPoolConfig == null && source.enemyPoolConfig != null)
+            {
+                enemyPoolConfig = source.enemyPoolConfig;
             }
         }
 


### PR DESCRIPTION
…rsistence (#63)

Add depth-based weighted enemy selection for Combat/Elite nodes. Three new placeholder enemies (Goblin, SkeletonWarrior, DarkMage) distributed across Early/Mid/Late depth pools via EnemyPoolConfig ScriptableObject. Same seed as map generation ensures determinism.

Fix: restore HP persistence between combats. BattleFlowController now saves player HP to RunState after combat and passes HP overrides when configuring the next fight, so damage carries across nodes.

Files created:
- Assets/Scripts/Run/Map/EnemyPoolConfig.cs
- Assets/ScriptableObjects/Run/Map/EnemyPoolConfig_Act1.asset
- Assets/ScriptableObjects/Enemies/Goblin.asset
- Assets/ScriptableObjects/Enemies/SkeletonWarrior.asset
- Assets/ScriptableObjects/Enemies/DarkMage.asset

Files modified:
- Assets/Scripts/Run/Map/RunMapGenerator.cs
- Assets/Scripts/Run/RunSession.cs
- Assets/Scripts/Run/BattleFlowController.cs

Closes #63