### PR TITLE
feat: main menu juice — hover buttons, staggered entrance, animated title (#73)

### DIFF
--- a/Assets/Scripts/Menu/MainMenuController.cs
+++ b/Assets/Scripts/Menu/MainMenuController.cs
@@ -3,7 +3,9 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
+using DG.Tweening;
 using RoguelikeCardBattler.Core;
+using RoguelikeCardBattler.Core.UI;
 using RoguelikeCardBattler.Run;
 
 namespace RoguelikeCardBattler.Menu
@@ -36,6 +38,16 @@ namespace RoguelikeCardBattler.Menu
         private int _resolutionIndex;
         private int _screenModeIndex;
         private bool _scenesValid;
+
+        // ── Juice: CanvasGroups for entry animations ──
+        private CanvasGroup _backgroundGroup;
+        private CanvasGroup _titleGroup;
+        private CanvasGroup _playButtonGroup;
+        private CanvasGroup _continueButtonGroup;
+        private CanvasGroup _settingsButtonGroup;
+        private CanvasGroup _quitButtonGroup;
+        private RectTransform _titleRect;
+        private Sequence _introSequence;
 
         private readonly string[] _resolutionOptions = { "1920x1080", "1280x720" };
         private readonly string[] _screenModeOptions = { "Pantalla completa", "Ventana" };
@@ -208,6 +220,15 @@ namespace RoguelikeCardBattler.Menu
 
             BuildSettingsPanel();
             ShowMainMenuPanel();
+
+            // ── Hover effects on main menu buttons ──
+            AddHoverEffect(_playButton);
+            AddHoverEffect(_continueButton);
+            AddHoverEffect(_settingsButton);
+            AddHoverEffect(_quitButton);
+
+            // ── Entry animation sequence ──
+            PlayIntroSequence(background, title, titleRect);
         }
 
         private void BuildSettingsPanel()
@@ -321,6 +342,145 @@ namespace RoguelikeCardBattler.Menu
             {
                 _mainMenuPanel.gameObject.SetActive(true);
             }
+        }
+
+        // ────────────────────────────────────────────────────────
+        // Juice: entry animation, hover feedback, title bob loop
+        // ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Orchestrates the staggered entry animation: background fade → title scale+fade → buttons slide in.
+        /// Called once at the end of <see cref="BuildUI"/>.
+        /// </summary>
+        private void PlayIntroSequence(RectTransform background, Text title, RectTransform titleRect)
+        {
+            _titleRect = titleRect;
+
+            // Prepare CanvasGroups — elements start invisible
+            _backgroundGroup = background.gameObject.AddComponent<CanvasGroup>();
+            _backgroundGroup.alpha = 0f;
+
+            _titleGroup = title.gameObject.AddComponent<CanvasGroup>();
+            _titleGroup.alpha = 0f;
+            titleRect.localScale = Vector3.zero;
+
+            _playButtonGroup = _playButton.gameObject.AddComponent<CanvasGroup>();
+            _playButtonGroup.alpha = 0f;
+            _continueButtonGroup = _continueButton.gameObject.AddComponent<CanvasGroup>();
+            _continueButtonGroup.alpha = 0f;
+            _settingsButtonGroup = _settingsButton.gameObject.AddComponent<CanvasGroup>();
+            _settingsButtonGroup.alpha = 0f;
+            _quitButtonGroup = _quitButton.gameObject.AddComponent<CanvasGroup>();
+            _quitButtonGroup.alpha = 0f;
+
+            CanvasGroup[] buttonGroups = { _playButtonGroup, _continueButtonGroup, _settingsButtonGroup, _quitButtonGroup };
+            RectTransform[] buttonRects =
+            {
+                _playButton.GetComponent<RectTransform>(),
+                _continueButton.GetComponent<RectTransform>(),
+                _settingsButton.GetComponent<RectTransform>(),
+                _quitButton.GetComponent<RectTransform>()
+            };
+
+            // Build DOTween Sequence
+            _introSequence = DOTween.Sequence().SetUpdate(true);
+
+            // 1) Background fade in (0.3s)
+            _introSequence.Append(UIAnimationHelper.FadeIn(_backgroundGroup, 0.3f));
+
+            // 2) Title fade + scale in parallel (after 0.2s delay from background start → total offset 0.2s into sequence)
+            _introSequence.AppendInterval(0.2f);
+            _introSequence.Append(UIAnimationHelper.FadeIn(_titleGroup, 0.2f));
+            _introSequence.Join(UIAnimationHelper.ScaleIn(titleRect.transform, 0.2f));
+
+            // 3) Buttons staggered: 0.1s apart, each with fade + slide in parallel
+            for (int i = 0; i < buttonGroups.Length; i++)
+            {
+                if (i > 0)
+                {
+                    _introSequence.AppendInterval(0.1f);
+                }
+                _introSequence.Append(UIAnimationHelper.FadeIn(buttonGroups[i], 0.25f));
+                _introSequence.Join(UIAnimationHelper.SlideIn(buttonRects[i], new Vector2(0, -60f), 0.25f));
+            }
+
+            // After intro completes, start the infinite title bob
+            _introSequence.OnComplete(() => StartTitleBob(titleRect));
+        }
+
+        /// <summary>
+        /// Adds pointer-enter/exit hover scale feedback to a button using EventTrigger.
+        /// Scales to 1.05x on hover, back to 1.0x on exit.
+        /// </summary>
+        private void AddHoverEffect(Button button)
+        {
+            RectTransform target = button.GetComponent<RectTransform>();
+            EventTrigger trigger = button.gameObject.AddComponent<EventTrigger>();
+
+            // PointerEnter → scale up to 1.05
+            EventTrigger.Entry enterEntry = new EventTrigger.Entry();
+            enterEntry.eventID = EventTriggerType.PointerEnter;
+            enterEntry.callback.AddListener(_ =>
+            {
+                DOTween.Kill(target);
+                DOTween.To(() => target.localScale, x => target.localScale = x,
+                    new Vector3(1.05f, 1.05f, 1.05f), 0.1f)
+                    .SetTarget(target)
+                    .SetEase(Ease.OutQuad)
+                    .SetUpdate(true);
+            });
+            trigger.triggers.Add(enterEntry);
+
+            // PointerExit → scale back to 1.0
+            EventTrigger.Entry exitEntry = new EventTrigger.Entry();
+            exitEntry.eventID = EventTriggerType.PointerExit;
+            exitEntry.callback.AddListener(_ =>
+            {
+                DOTween.Kill(target);
+                DOTween.To(() => target.localScale, x => target.localScale = x,
+                    Vector3.one, 0.1f)
+                    .SetTarget(target)
+                    .SetEase(Ease.OutQuad)
+                    .SetUpdate(true);
+            });
+            trigger.triggers.Add(exitEntry);
+        }
+
+        /// <summary>
+        /// Starts an infinite vertical bob on the title (±3px, 2s full cycle, InOutSine yoyo).
+        /// Runs unscaled so it works even at timeScale 0.
+        /// </summary>
+        private void StartTitleBob(RectTransform titleRect)
+        {
+            Vector2 restPosition = titleRect.anchoredPosition;
+            DOTween.To(
+                    () => titleRect.anchoredPosition,
+                    x => titleRect.anchoredPosition = x,
+                    new Vector2(restPosition.x, restPosition.y + 3f),
+                    1f) // 1s per half-cycle = 2s full cycle
+                .SetTarget(titleRect)
+                .SetEase(Ease.InOutSine)
+                .SetLoops(-1, LoopType.Yoyo)
+                .SetUpdate(true);
+        }
+
+        /// <summary>
+        /// Cleanup: kill all DOTween tweens owned by this controller's UI elements.
+        /// </summary>
+        private void OnDestroy()
+        {
+            _introSequence?.Kill();
+            if (_titleRect != null) DOTween.Kill(_titleRect);
+            if (_backgroundGroup != null) DOTween.Kill(_backgroundGroup);
+            if (_titleGroup != null) DOTween.Kill(_titleGroup);
+            if (_playButton != null) DOTween.Kill(_playButton.GetComponent<RectTransform>());
+            if (_continueButton != null) DOTween.Kill(_continueButton.GetComponent<RectTransform>());
+            if (_settingsButton != null) DOTween.Kill(_settingsButton.GetComponent<RectTransform>());
+            if (_quitButton != null) DOTween.Kill(_quitButton.GetComponent<RectTransform>());
+            if (_playButtonGroup != null) DOTween.Kill(_playButtonGroup);
+            if (_continueButtonGroup != null) DOTween.Kill(_continueButtonGroup);
+            if (_settingsButtonGroup != null) DOTween.Kill(_settingsButtonGroup);
+            if (_quitButtonGroup != null) DOTween.Kill(_quitButtonGroup);
         }
 
         private Canvas CreateCanvas(string name)

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -3,6 +3,7 @@
 - Onboarding dev: `Docs/dev/DEV_ONBOARDING.md`
 - Combat architecture: `Docs/dev/COMBAT_ARCHITECTURE.md`
 - Glossary: `Docs/dev/GLOSSARY.md`
+- Prompt Master y Programming Master: `Docs/dev/PROMPT_MASTER_AND_PROGRAMMING.md`
 - Diseño base (Proyecto C): `Docs/design/Proyecto C.pdf`
 - Project status: `Docs/design/PROJECT_STATUS.md`
 - Próximos (placeholder):

--- a/Docs/dev/PROMPT_MASTER_AND_PROGRAMMING.md
+++ b/Docs/dev/PROMPT_MASTER_AND_PROGRAMMING.md
@@ -1,0 +1,117 @@
+# Prompt Master y Programming Master — Workflow de desarrollo
+
+Este documento describe cómo está organizado el proceso de desarrollo del proyecto: la arquitectura de software que seguimos, la separación de roles entre **Prompt Master** y **Programming Master**, y las reglas que garantizan consistencia y calidad.
+
+---
+
+## 1. Arquitectura de software
+
+### Principios generales
+
+El proyecto sigue una arquitectura clara para mantener el código mantenible, escalable y fácil de onboardear:
+
+| Principio | Descripción |
+|-----------|-------------|
+| **Scene-owned controllers** | Cada escena tiene su controlador principal (RunFlowController, BattleFlowController, MainMenuController). No hay "managers" globales flotantes salvo RunSession (DontDestroyOnLoad para estado entre escenas). |
+| **Data-driven** | Tipos, enemigos, cartas y configuración viven en ScriptableObjects. La lógica lee datos, no los hardcodea. |
+| **Separación de responsabilidades** | **RunState** = datos. **Controllers** = flujo y decisiones. **UI/VFX** = presentación que se suscribe a eventos o lee estado. No mezclar lógica de gameplay en prefabs o UI. |
+| **Persistence mínima** | Solo RunSession persiste entre escenas. El save/load meta (stats, desbloqueos) usa ISaveService con JSON en `Application.persistentDataPath`. |
+| **Comunicación entre escenas** | Exclusivamente vía RunSession.State: flags como `PendingReturnFromBattle`, `LastNodeOutcome`, `CurrentNodeId`, `RunFailed`, `ActoCompleted`. |
+
+### Flujo de datos (Run)
+
+```text
+MainMenu → RunScene (mapa) → BattleScene (combate) → RunScene (resultado) → ...
+                ↓                      ↓
+          RunState (nodos, gold,      RunState (HP, outcome)
+          deck, available/completed)
+```
+
+### Archivos y responsabilidades
+
+- **No tocar on-chain**: Nunca modificar contratos Anchor, IDL, ni lógica que interactúe directamente con la blockchain.
+- **No tocar lógica de bids/combate core**: TurnManager, ActionQueue, PlayerCombatActor manejan la mecánica. Los controllers orquestan, no implementan.
+- **Helpers reutilizables**: Funciones como `isAuctionClosed`, `getAuctionStatusLabel` en `lib/utils` deben usarse en vez de duplicar lógica.
+
+---
+
+## 2. Prompt Master y Programming Master
+
+### ¿Qué es cada uno?
+
+| Rol | Responsabilidad | Herramienta típica |
+|-----|-----------------|--------------------|
+| **Prompt Master** | Escribir prompts detallados, definir issues, revisar arquitectura, dar criterios de aceptación, validar que los cambios respeten las reglas. | Cursor (este chat), GitHub Issues |
+| **Programming Master** | Implementar el código según el prompt: crear/modificar archivos, mantener la arquitectura, entregar diffs revisables. | Codex u otro agente de código |
+
+El **Prompt Master** no escribe código directamente; el **Programming Master** no toma decisiones de diseño. Cada uno tiene un rol claro.
+
+### Ventajas de esta separación
+
+1. **Consistencia**: Los prompts incluyen restricciones explícitas (qué archivos tocar, qué no tocar), evitando desvíos.
+2. **Onboarding**: Cualquier desarrollador puede ser Prompt Master con solo leer este doc y los issues; el Programming Master recibe instrucciones autocontenidas.
+3. **Calidad**: El Prompt Master valida que el resultado cumpla criterios de aceptación antes de cerrar el issue.
+4. **Reproducibilidad**: Prompts reutilizables para fixes o features similares.
+
+---
+
+## 3. Formato de prompts para el Programming Master
+
+Todo prompt debe incluir:
+
+### 3.1 Contexto existente
+- Descripción breve de lo que ya existe y no debe romperse.
+- Referencias a archivos clave y flujos de datos.
+
+### 3.2 Restricciones (no negociables)
+- **NO tocar**: lista explícita de archivos/carpetas que no se deben modificar.
+- Reglas de arquitectura: scene-owned, data-driven, no lógica en UI.
+
+### 3.3 Objetivo claro
+- Una o más oraciones que expliquen qué debe hacer el código.
+
+### 3.4 Alcance (archivos a crear/modificar)
+- Lista concreta: crear X, modificar Y, opcionalmente Z.
+
+### 3.5 Regla CS0104 (ambiguidad Object)
+- Si el archivo usa tanto `using System;` como `using UnityEngine;`, **siempre** usar `UnityEngine.Object` (no solo `Object`) para evitar el error de referencia ambigua.
+
+### 3.6 Criterios de aceptación
+- Lista de comprobaciones que el Prompt Master usará para validar.
+- Incluir "Cero errores en consola".
+
+### 3.7 Formato de entrega
+- Indicar que el diff debe ser revisable, con comentarios de onboarding.
+- No incluir "Closes #X" en el primer commit si el issue se cierra después.
+
+---
+
+## 4. Flujo típico de un issue
+
+```text
+1. Prompt Master crea issue en GitHub (objetivo, alcance, criterios).
+2. Prompt Master escribe prompt completo siguiendo la plantilla.
+3. Programming Master implementa según prompt.
+4. Prompt Master revisa: criterios de aceptación, arquitectura, reglas.
+5. Si hay errores: Prompt Master devuelve feedback específico (qué falló, cómo corregirlo).
+6. Si todo OK: commit con summary/description, merge, cierre del issue.
+```
+
+---
+
+## 5. Checklist para el Prompt Master antes de cerrar un issue
+
+- [ ] ¿Los archivos tocados respetan las restricciones (no se tocó lo prohibido)?
+- [ ] ¿Se mantiene la separación datos / lógica / presentación?
+- [ ] ¿Se reutilizaron helpers existentes cuando aplica?
+- [ ] ¿Los criterios de aceptación se cumplen?
+- [ ] ¿Hay comentarios de onboarding en código nuevo?
+- [ ] ¿Cero errores en consola durante el flujo de prueba?
+
+---
+
+## 6. Referencias
+
+- Arquitectura de combate: `Docs/dev/COMBAT_ARCHITECTURE.md`
+- Onboarding: `Docs/dev/DEV_ONBOARDING.md`
+- Glosario: `Docs/dev/GLOSSARY.md`


### PR DESCRIPTION


## Summary
- Add staggered intro sequence: background fade → title scale+fade → buttons slide-in from below
- Add hover feedback on menu buttons (scale to 1.05x on mouse enter, back to 1.0x on exit)
- Add infinite bob animation on title (±3px vertical float loop)
- Add DOTween cleanup in OnDestroy()

## Files changed
- `Assets/Scripts/Menu/MainMenuController.cs`

## Test plan
- [ ] MainMenuScene loads with staggered entrance animation
- [ ] Buttons scale on hover and return on exit
- [ ] Title floats up/down after intro completes
- [ ] Settings/Back navigation still works
- [ ] Zero console errors

Closes #73