### PR TITLE
feat: audio placeholder with programmatic SFX clips (#76)

### DIFF
--- a/Assets/Scripts/Core/Audio.meta
+++ b/Assets/Scripts/Core/Audio.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 892e27971e7bbbb4cb1895977a161993
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/Audio/AudioManager.cs
+++ b/Assets/Scripts/Core/Audio/AudioManager.cs
@@ -1,0 +1,186 @@
+using UnityEngine;
+
+namespace RoguelikeCardBattler.Core.Audio
+{
+    /// <summary>
+    /// Singleton audio manager that persists across scenes (DontDestroyOnLoad).
+    /// Provides SFX and music playback with configurable volumes.
+    ///
+    /// <para><b>Onboarding:</b> Auto-instantiated by <see cref="AudioManagerBootstrap"/>
+    /// before any scene loads — no manual setup required. Access via
+    /// <c>AudioManager.Instance</c>. All placeholder clips are generated
+    /// programmatically in Awake (no external audio files needed).</para>
+    /// </summary>
+    public class AudioManager : MonoBehaviour
+    {
+        private static AudioManager _instance;
+
+        /// <summary>Returns the singleton instance (null if not yet created).</summary>
+        public static AudioManager Instance => _instance;
+
+        [Tooltip("Volume for one-shot sound effects.")]
+        [Range(0f, 1f)]
+        [SerializeField] private float sfxVolume = 0.7f;
+
+        [Tooltip("Volume for looping background music.")]
+        [Range(0f, 1f)]
+        [SerializeField] private float musicVolume = 0.5f;
+
+        private AudioSource _sfxSource;
+        private AudioSource _musicSource;
+
+        // ── Placeholder clips (generated programmatically) ──
+
+        /// <summary>Short high-pitched click (menu buttons).</summary>
+        public AudioClip ClickSFX { get; private set; }
+        /// <summary>Medium tone for playing a card.</summary>
+        public AudioClip CardPlaySFX { get; private set; }
+        /// <summary>Short noise burst for hit feedback.</summary>
+        public AudioClip HitSFX { get; private set; }
+        /// <summary>Ascending sweep for victory.</summary>
+        public AudioClip VictorySFX { get; private set; }
+        /// <summary>Descending sweep for defeat.</summary>
+        public AudioClip DefeatSFX { get; private set; }
+        /// <summary>Double-pulse tone for world change.</summary>
+        public AudioClip WorldChangeSFX { get; private set; }
+
+        // ──────────────────────────────────────────────
+        // Lifecycle
+        // ──────────────────────────────────────────────
+
+        private void Awake()
+        {
+            if (_instance != null && _instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            _instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            // Create AudioSources
+            _sfxSource = gameObject.AddComponent<AudioSource>();
+            _sfxSource.playOnAwake = false;
+
+            _musicSource = gameObject.AddComponent<AudioSource>();
+            _musicSource.playOnAwake = false;
+            _musicSource.loop = true;
+
+            // Generate placeholder clips
+            ClickSFX = GenerateTone("ClickSFX", 800f, 0.05f, ToneType.Sine);
+            CardPlaySFX = GenerateTone("CardPlaySFX", 400f, 0.1f, ToneType.Sine);
+            HitSFX = GenerateTone("HitSFX", 0f, 0.08f, ToneType.Noise);
+            VictorySFX = GenerateTone("VictorySFX", 400f, 0.3f, ToneType.SweepUp);
+            DefeatSFX = GenerateTone("DefeatSFX", 400f, 0.4f, ToneType.SweepDown);
+            WorldChangeSFX = GenerateTone("WorldChangeSFX", 600f, 0.15f, ToneType.DoublePulse);
+        }
+
+        // ──────────────────────────────────────────────
+        // Public API
+        // ──────────────────────────────────────────────
+
+        /// <summary>Plays a one-shot sound effect at the current SFX volume.</summary>
+        public void PlaySFX(AudioClip clip)
+        {
+            if (clip == null) return;
+            _sfxSource.PlayOneShot(clip, sfxVolume);
+        }
+
+        /// <summary>Starts playing a music clip (optionally looping).</summary>
+        public void PlayMusic(AudioClip clip, bool loop = true)
+        {
+            if (clip == null) return;
+            _musicSource.clip = clip;
+            _musicSource.loop = loop;
+            _musicSource.volume = musicVolume;
+            _musicSource.Play();
+        }
+
+        /// <summary>Stops the currently playing music.</summary>
+        public void StopMusic()
+        {
+            _musicSource.Stop();
+        }
+
+        /// <summary>Updates the SFX volume (0–1).</summary>
+        public void SetSFXVolume(float vol)
+        {
+            sfxVolume = Mathf.Clamp01(vol);
+        }
+
+        /// <summary>Updates the music volume (0–1) and applies it immediately.</summary>
+        public void SetMusicVolume(float vol)
+        {
+            musicVolume = Mathf.Clamp01(vol);
+            _musicSource.volume = musicVolume;
+        }
+
+        // ──────────────────────────────────────────────
+        // Tone generation
+        // ──────────────────────────────────────────────
+
+        private enum ToneType
+        {
+            Sine,
+            Noise,
+            SweepUp,
+            SweepDown,
+            DoublePulse
+        }
+
+        /// <summary>
+        /// Generates a short AudioClip programmatically using simple waveforms.
+        /// <paramref name="frequency"/> is the base frequency in Hz (ignored for Noise).
+        /// </summary>
+        private AudioClip GenerateTone(string clipName, float frequency, float duration, ToneType type)
+        {
+            const int sampleRate = 44100;
+            int sampleCount = Mathf.CeilToInt(sampleRate * duration);
+            float[] samples = new float[sampleCount];
+
+            for (int i = 0; i < sampleCount; i++)
+            {
+                float t = (float)i / sampleRate;
+                float normalizedT = (float)i / sampleCount; // 0..1 over clip duration
+
+                switch (type)
+                {
+                    case ToneType.Sine:
+                        samples[i] = Mathf.Sin(2f * Mathf.PI * frequency * t);
+                        break;
+
+                    case ToneType.Noise:
+                        samples[i] = Random.Range(-1f, 1f);
+                        break;
+
+                    case ToneType.SweepUp:
+                        // Sweep from frequency to frequency*2
+                        float freqUp = Mathf.Lerp(frequency, frequency * 2f, normalizedT);
+                        samples[i] = Mathf.Sin(2f * Mathf.PI * freqUp * t);
+                        break;
+
+                    case ToneType.SweepDown:
+                        // Sweep from frequency to frequency*0.5
+                        float freqDown = Mathf.Lerp(frequency, frequency * 0.5f, normalizedT);
+                        samples[i] = Mathf.Sin(2f * Mathf.PI * freqDown * t);
+                        break;
+
+                    case ToneType.DoublePulse:
+                        // Two pulses: first half and second half each have a sine burst
+                        bool inPulse = normalizedT < 0.4f || (normalizedT > 0.6f && normalizedT < 1f);
+                        samples[i] = inPulse ? Mathf.Sin(2f * Mathf.PI * frequency * t) : 0f;
+                        break;
+                }
+
+                // Apply a simple fade-out envelope to avoid clicks
+                float envelope = 1f - normalizedT;
+                samples[i] *= envelope * 0.5f; // 0.5 to keep volume moderate
+            }
+
+            AudioClip clip = AudioClip.Create(clipName, sampleCount, 1, sampleRate, false);
+            clip.SetData(samples, 0);
+            return clip;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Audio/AudioManager.cs.meta
+++ b/Assets/Scripts/Core/Audio/AudioManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8d5443d5425d02249990d0090c337572

--- a/Assets/Scripts/Core/Audio/AudioManagerBootstrap.cs
+++ b/Assets/Scripts/Core/Audio/AudioManagerBootstrap.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+namespace RoguelikeCardBattler.Core.Audio
+{
+    /// <summary>
+    /// Auto-instantiates <see cref="AudioManager"/> before any scene loads using
+    /// [RuntimeInitializeOnLoadMethod]. No manual setup in the editor required.
+    ///
+    /// <para><b>Onboarding:</b> This class runs automatically at game start.
+    /// It checks whether an AudioManager already exists and creates one if needed.
+    /// The AudioManager persists across scenes via DontDestroyOnLoad.</para>
+    /// </summary>
+    public static class AudioManagerBootstrap
+    {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void Initialize()
+        {
+            if (AudioManager.Instance != null)
+            {
+                return;
+            }
+
+            GameObject go = new GameObject("AudioManager");
+            go.AddComponent<AudioManager>();
+        }
+    }
+}

--- a/Assets/Scripts/Core/Audio/AudioManagerBootstrap.cs.meta
+++ b/Assets/Scripts/Core/Audio/AudioManagerBootstrap.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 82bb4843ac5d8464ba62f2860bc3c057

--- a/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 using DG.Tweening;
+using RoguelikeCardBattler.Core.Audio;
 using RoguelikeCardBattler.Core.UI;
 using RoguelikeCardBattler.Gameplay.Cards;
 using RoguelikeCardBattler.Gameplay.Enemies;
@@ -697,6 +698,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
 
         private void OnCardButtonClicked(CardDeckEntry entry)
         {
+            AudioManager.Instance?.PlaySFX(AudioManager.Instance.CardPlaySFX);
             if (turnManager == null || entry == null || _isPlayingAttack)
             {
                 return;
@@ -891,7 +893,8 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             _hitFeedbackText.gameObject.SetActive(true);
             _hitFeedbackTimer = hitFeedbackDuration;
 
-            // ── Juice: player avatar shake + HP label red flash ──
+            // ── Juice: player avatar shake + HP label red flash + SFX ──
+            AudioManager.Instance?.PlaySFX(AudioManager.Instance.HitSFX);
             if (_playerAvatarImage != null)
             {
                 UIAnimationHelper.Punch(_playerAvatarImage.transform, 0.15f, 0.3f);
@@ -911,6 +914,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
 
         private void OnEnemyTookDamage(int damage)
         {
+            AudioManager.Instance?.PlaySFX(AudioManager.Instance.HitSFX);
             if (damage <= 0)
             {
                 return;
@@ -1135,6 +1139,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
 
         private void OnChangeWorldButtonClicked()
         {
+            AudioManager.Instance?.PlaySFX(AudioManager.Instance.WorldChangeSFX);
             if (turnManager == null)
             {
                 return;
@@ -1393,6 +1398,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         /// </summary>
         public void ShowVictoryText()
         {
+            AudioManager.Instance?.PlaySFX(AudioManager.Instance.VictorySFX);
             ShowCombatResultText("VICTORY", new Color(0.2f, 1f, 0.4f));
         }
 
@@ -1402,6 +1408,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         /// </summary>
         public void ShowDefeatText()
         {
+            AudioManager.Instance?.PlaySFX(AudioManager.Instance.DefeatSFX);
             ShowCombatResultText("DEFEAT", new Color(1f, 0.3f, 0.3f));
         }
 

--- a/Assets/Scripts/Menu/MainMenuController.cs
+++ b/Assets/Scripts/Menu/MainMenuController.cs
@@ -5,6 +5,7 @@ using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using DG.Tweening;
 using RoguelikeCardBattler.Core;
+using RoguelikeCardBattler.Core.Audio;
 using RoguelikeCardBattler.Core.UI;
 using RoguelikeCardBattler.Run;
 
@@ -72,6 +73,7 @@ namespace RoguelikeCardBattler.Menu
         /// </summary>
         public void OnPlayClicked()
         {
+            AudioManager.Instance?.PlaySFX(AudioManager.Instance.ClickSFX);
             if (!_scenesValid)
             {
                 Debug.LogError("RunScene or BattleScene not in Build Settings. Add them in File > Build Settings.");
@@ -88,6 +90,7 @@ namespace RoguelikeCardBattler.Menu
         /// </summary>
         public void OnContinueClicked()
         {
+            AudioManager.Instance?.PlaySFX(AudioManager.Instance.ClickSFX);
             SetMessage(ContinuePlaceholder);
         }
 
@@ -96,6 +99,7 @@ namespace RoguelikeCardBattler.Menu
         /// </summary>
         public void OnSettingsClicked()
         {
+            AudioManager.Instance?.PlaySFX(AudioManager.Instance.ClickSFX);
             ShowSettingsPanel();
         }
 
@@ -104,6 +108,7 @@ namespace RoguelikeCardBattler.Menu
         /// </summary>
         public void OnQuitClicked()
         {
+            AudioManager.Instance?.PlaySFX(AudioManager.Instance.ClickSFX);
 #if UNITY_EDITOR
             Debug.Log("[MainMenu] Quit requested (no-op in editor).");
 #endif


### PR DESCRIPTION
Add AudioManager singleton (DontDestroyOnLoad) with 6 procedurally generated audio clips (click, card play, hit, victory, defeat, world change). Auto-bootstraps via RuntimeInitializeOnLoadMethod — no manual editor setup. Integrate SFX calls in MainMenuController and CombatUIController.

Closes #76