### PR TITLE
refactor: extract CombatFeedbackView + CardHandView from CombatUIController

### DIFF
--- a/Assets/ScriptableObjects/Enemies/BossAct1.asset
+++ b/Assets/ScriptableObjects/Enemies/BossAct1.asset
@@ -59,9 +59,9 @@ MonoBehaviour:
     intentType: 2
   - id: boss_recover
     moveName: Regenerate
-    description: Recovers 10 HP.
+    description: Gains 10 Block and recovers.
     effects:
-    - effectType: 2
+    - effectType: 1
       value: 10
       target: 0
       statusType: 0

--- a/Assets/Scripts/Gameplay/Combat/CLAUDE.md
+++ b/Assets/Scripts/Gameplay/Combat/CLAUDE.md
@@ -1,0 +1,44 @@
+# Combat Directory Rules
+
+## Protected Files (DO NOT MODIFY without explicit user approval)
+
+- `TurnManager.cs` (~735 loc) — orquesta turnos, juego de cartas, cambio de mundo, momentum, calculo de efectividad
+- `ActionQueue.cs` (~85 loc) — cola de acciones determinista FIFO
+- `PlayerCombatActor.cs` (~236 loc) — HP, bloqueo, aplicacion de dano del jugador
+
+Si una tarea requiere modificar estos archivos, PARAR y pedir aprobacion explicita.
+
+## CombatUIController.cs — Architectural Debt
+
+Este archivo tiene 1400+ lineas y 47 metodos. Es un monolito conocido. Reglas:
+
+1. **NO agregar metodos ni responsabilidades nuevas.**
+2. **UI nueva** = MonoBehaviours separados conectados via BattleFlowController, NO dentro de CombatUIController.
+3. Si se modifica un metodo existente: cambiar SOLO ese metodo. No reorganizar ni refactorizar codigo circundante a menos que se pida explicitamente.
+4. Todo el codigo en este archivo es **solo presentacion**. Nunca mutar estado de gameplay.
+5. **Plan de extraccion en progreso** (ver `Docs/dev/COMBAT_ARCHITECTURE.md`):
+   - `CombatFeedbackView` — popups WEAK/RESIST/MOMENTUM, shake de dano **(Fase 1 — en progreso)**
+   - `CardHandView` — mano de cartas, seleccion, animaciones de juego (Fase 2)
+   - `CombatHudView` — paneles de HP, energia, momentum, mundo (Fase 3)
+   - `CombatBackgroundView` — fondos de mundo A/B, parallax (Fase 4)
+
+## Turn Flow (NO alterar orden)
+
+1. Turno jugador: robar cartas → jugar cartas → fin de turno
+2. Turno enemigo: limpiar bloqueo → ejecutar movimiento → planear siguiente → verificar fin
+3. Efectos se resuelven via `ActionQueue.ProcessAll()` (deterministico, secuencial)
+
+## Key Patterns
+
+- **Efectividad**: SOLO aplica a dano de carta del jugador vs tipo del enemigo. NUNCA a dano del enemigo, bloqueo, robo ni otro efecto.
+- **Momentum**: se otorga en hit SuperEficaz con dano > 0. Se consume al jugar la siguiente carta (gratis). Nunca al seleccionar.
+- **Cambio de mundo**: limitado por combate (configurable). Afecta lado activo de cartas duales.
+- **Acciones**: `DamageAction`, `BlockAction`, `DrawCardsAction` implementan `IGameAction`. Nuevos tipos siguen este patron.
+
+## Adding New Combat Features
+
+1. Leer `Docs/dev/COMBAT_ARCHITECTURE.md` para diagramas y flujo de datos.
+2. **Nuevas acciones**: crear en `Actions/` implementando `IGameAction`.
+3. **Nueva UI de combate**: crear MonoBehaviour separado. NO extender CombatUIController.
+4. **Nuevos datos**: agregar campos en ScriptableObjects. Nunca hardcodear valores.
+5. **Nuevos enemigos/patrones**: definir en `EnemyDefinition` SO. IA en `EnemyEnums.AiPattern`.

--- a/Assets/Scripts/Gameplay/Combat/CLAUDE.md.meta
+++ b/Assets/Scripts/Gameplay/Combat/CLAUDE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b5384fa3c6661914e8097797e6885cde
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Combat/CardHandView.cs
+++ b/Assets/Scripts/Gameplay/Combat/CardHandView.cs
@@ -1,0 +1,400 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using DG.Tweening;
+using RoguelikeCardBattler.Core.Audio;
+using RoguelikeCardBattler.Core.UI;
+using RoguelikeCardBattler.Gameplay.Cards;
+
+namespace RoguelikeCardBattler.Gameplay.Combat
+{
+    /// <summary>
+    /// Maneja la mano de cartas del jugador: creación de botones, sincronización
+    /// con el estado de TurnManager, layout adaptivo, y click para jugar cartas.
+    ///
+    /// Extraído de CombatUIController como parte de la descomposición en componentes
+    /// independientes (ver Docs/dev/COMBAT_ARCHITECTURE.md — Fase 2).
+    ///
+    /// Este componente es SOLO presentación — la lógica de jugar cartas se delega
+    /// a TurnManager via TryPrepareCardPlay/ResolvePreparedCardPlay.
+    /// </summary>
+    public class CardHandView : MonoBehaviour
+    {
+        // ── Referencias inyectadas por CombatUIController.InitializeCardHandView() ──
+        private TurnManager _turnManager;
+        private RectTransform _handContainer;
+        private SpriteFrameAnimatorUI _playerAnimator;
+        private CombatFeedbackView _feedbackView;
+        private Image _energyPanelImage;
+        private Font _uiFont;
+
+        // ── Estado interno ──
+        private bool _initialized;
+        private bool _isPlayingAttack;
+        private float _lastHandWidth;
+        private int _lastHandCount = -1;
+
+        private readonly List<CardButtonBinding> _cardButtons = new List<CardButtonBinding>();
+        private readonly List<CardDeckEntry> _handCache = new List<CardDeckEntry>();
+
+        // Clase interna que vincula un CardDeckEntry con su botón UI.
+        private class CardButtonBinding
+        {
+            public CardDeckEntry CardEntry;
+            public Button Button;
+            public Text Label;
+            public CanvasGroup Group;
+        }
+
+        // ── Constantes de layout ──
+        // Tamaños base y mínimos para escalar la mano cuando hay muchas cartas.
+        private const float HandCardWidthBase = 230f;
+        private const float HandCardHeightBase = 130f;
+        private const float HandCardWidthMin = 150f;
+        private const float HandCardHeightMin = 96f;
+        private const float HandSpacingBase = 12f;
+        private const float HandSpacingMin = 4f;
+
+        // ── Colores de cartas ──
+        private static readonly Color CardButtonNormalColor = new Color(0.18f, 0.18f, 0.25f, 0.95f);
+        private static readonly Color CardButtonDisabledColor = new Color(0.1f, 0.1f, 0.14f, 0.6f);
+        private static readonly Color DisabledLabelColor = new Color(0.75f, 0.75f, 0.75f, 0.7f);
+
+        /// <summary>
+        /// Inyecta todas las referencias necesarias. Llamado por CombatUIController
+        /// después de BuildUI(). Sin esta llamada, el componente no hace nada.
+        /// </summary>
+        public void Initialize(
+            TurnManager turnManager,
+            RectTransform handContainer,
+            SpriteFrameAnimatorUI playerAnimator,
+            CombatFeedbackView feedbackView,
+            Image energyPanelImage,
+            Font uiFont)
+        {
+            _turnManager = turnManager;
+            _handContainer = handContainer;
+            _playerAnimator = playerAnimator;
+            _feedbackView = feedbackView;
+            _energyPanelImage = energyPanelImage;
+            _uiFont = uiFont;
+            _initialized = true;
+        }
+
+        // ────────────────────────────────────────────────────────
+        // Sync: llamado cada frame por CombatUIController.Update()
+        // ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Sincroniza los botones de la mano con el estado actual del TurnManager.
+        /// Reconstruye si cambió la composición de la mano; actualiza interactividad
+        /// y labels si solo cambió el estado.
+        /// </summary>
+        public void SyncHandButtons(bool forceRebuild = false)
+        {
+            if (!_initialized || _turnManager == null) return;
+
+            if (forceRebuild || !IsHandCacheValid())
+            {
+                RebuildHandButtons();
+            }
+
+            bool canInteract = _turnManager.IsPlayerTurn();
+            foreach (CardButtonBinding binding in _cardButtons)
+            {
+                bool canPlay = _turnManager.CanPlayCard(binding.CardEntry);
+                binding.Button.interactable = canInteract && canPlay;
+                binding.Label.text = BuildCardLabel(binding.CardEntry);
+                if (binding.Label != null)
+                {
+                    binding.Label.color = binding.Button.interactable ? Color.white : DisabledLabelColor;
+                }
+                Image image = binding.Button.GetComponent<Image>();
+                if (image != null)
+                {
+                    image.color = binding.Button.interactable ? CardButtonNormalColor : CardButtonDisabledColor;
+                }
+            }
+
+            UpdateHandLayout();
+        }
+
+        /// <summary>
+        /// Indica si hay una animación de ataque en curso. CombatUIController
+        /// puede consultar esto para evitar acciones concurrentes.
+        /// </summary>
+        public bool IsPlayingAttack => _isPlayingAttack;
+
+        // ────────────────────────────────────────────────────────
+        // Card click handler
+        // ────────────────────────────────────────────────────────
+
+        private void OnCardButtonClicked(CardDeckEntry entry)
+        {
+            AudioManager.Instance?.PlaySFX(AudioManager.Instance.CardPlaySFX);
+            if (_turnManager == null || entry == null || _isPlayingAttack) return;
+
+            if (!_turnManager.TryPrepareCardPlay(entry, out PreparedCardPlay prepared))
+            {
+                _feedbackView?.FlashPanel(_energyPanelImage);
+                return;
+            }
+
+            SyncHandButtons(forceRebuild: true);
+
+            if (prepared.IsAttackCard && _playerAnimator != null)
+            {
+                _isPlayingAttack = true;
+                SetCardButtonsInteractable(false);
+                _playerAnimator.PlayAttackOnce(() =>
+                {
+                    _turnManager.ResolvePreparedCardPlay(prepared);
+                    _isPlayingAttack = false;
+                    SyncHandButtons(forceRebuild: true);
+                });
+            }
+            else
+            {
+                _turnManager.ResolvePreparedCardPlay(prepared);
+                SyncHandButtons(forceRebuild: true);
+            }
+        }
+
+        // ────────────────────────────────────────────────────────
+        // Hand cache validation + rebuild
+        // ────────────────────────────────────────────────────────
+
+        private bool IsHandCacheValid()
+        {
+            if (_turnManager == null) return false;
+
+            IReadOnlyList<CardDeckEntry> hand = _turnManager.PlayerHand;
+            if (hand.Count != _handCache.Count) return false;
+
+            for (int i = 0; i < hand.Count; i++)
+            {
+                if (hand[i] != _handCache[i]) return false;
+            }
+
+            return true;
+        }
+
+        private void RebuildHandButtons()
+        {
+            foreach (CardButtonBinding binding in _cardButtons)
+            {
+                if (binding?.Button != null)
+                {
+                    DOTween.Kill(binding.Button.GetComponent<RectTransform>());
+                    if (binding.Group != null) DOTween.Kill(binding.Group);
+                    Destroy(binding.Button.gameObject);
+                }
+            }
+
+            _cardButtons.Clear();
+            _handCache.Clear();
+
+            IReadOnlyList<CardDeckEntry> hand = _turnManager.PlayerHand;
+            for (int i = 0; i < hand.Count; i++)
+            {
+                CardDeckEntry entry = hand[i];
+                Button button = CreateCardButton(entry, _handContainer);
+                Text label = button.GetComponentInChildren<Text>();
+
+                // Juice: staggered fade-in (LayoutGroup controla posición y escala).
+                CanvasGroup cardGroup = button.gameObject.AddComponent<CanvasGroup>();
+                cardGroup.alpha = 0f;
+                float delay = i * 0.05f;
+                UIAnimationHelper.FadeIn(cardGroup, 0.2f).SetDelay(delay);
+
+                _cardButtons.Add(new CardButtonBinding
+                {
+                    CardEntry = entry,
+                    Button = button,
+                    Label = label,
+                    Group = cardGroup
+                });
+                _handCache.Add(entry);
+            }
+        }
+
+        // ────────────────────────────────────────────────────────
+        // Card button creation
+        // ────────────────────────────────────────────────────────
+
+        private Button CreateCardButton(CardDeckEntry entry, Transform parent)
+        {
+            CardDefinition activeCard = _turnManager.GetActiveCardDefinition(entry);
+            string label = activeCard != null ? activeCard.name : "Card";
+
+            GameObject buttonGO = new GameObject(label + "_Button", typeof(RectTransform), typeof(Image), typeof(Button), typeof(LayoutElement));
+            buttonGO.transform.SetParent(parent, false);
+
+            RectTransform rect = buttonGO.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(HandCardWidthBase, HandCardHeightBase);
+
+            Image image = buttonGO.GetComponent<Image>();
+            image.color = CardButtonNormalColor;
+
+            LayoutElement layout = buttonGO.GetComponent<LayoutElement>();
+            layout.preferredWidth = HandCardWidthBase;
+            layout.preferredHeight = HandCardHeightBase;
+
+            Button button = buttonGO.GetComponent<Button>();
+
+            // Texto de la carta: nombre, tipo, costo, descripción.
+            Text labelText = CreateText("Label", rect, BuildCardLabel(entry), 20, TextAnchor.MiddleCenter);
+            labelText.fontStyle = FontStyle.Bold;
+
+            button.onClick.AddListener(() => OnCardButtonClicked(entry));
+
+            return button;
+        }
+
+        /// <summary>
+        /// Crea un elemento Text dentro de un parent. Helper local para no depender
+        /// de CombatUIController.CreateText() (que es private).
+        /// </summary>
+        private Text CreateText(string name, RectTransform parent, string initialText, int fontSize, TextAnchor alignment)
+        {
+            GameObject textGO = new GameObject(name, typeof(RectTransform), typeof(Text));
+            textGO.transform.SetParent(parent, false);
+
+            RectTransform rect = textGO.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0, 0);
+            rect.anchorMax = new Vector2(1, 1);
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+
+            Text text = textGO.GetComponent<Text>();
+            text.font = _uiFont;
+            text.fontSize = fontSize;
+            text.alignment = alignment;
+            text.color = Color.white;
+            text.text = initialText;
+
+            return text;
+        }
+
+        // ────────────────────────────────────────────────────────
+        // Card label + interactability helpers
+        // ────────────────────────────────────────────────────────
+
+        private string BuildCardLabel(CardDeckEntry entry)
+        {
+            if (entry == null) return "Unknown Card";
+
+            CardDefinition activeCard = _turnManager != null ? _turnManager.GetActiveCardDefinition(entry) : null;
+            if (activeCard == null) return "Unknown Card";
+
+            string prefix = string.Empty;
+            if (entry.DualCard != null)
+            {
+                prefix = _turnManager.CurrentWorld == TurnManager.WorldSide.A ? "[A] " : "[B] ";
+            }
+
+            string typePrefix = activeCard.ElementType != ElementType.None ? $"[{activeCard.ElementType}] " : string.Empty;
+            string title = string.IsNullOrEmpty(prefix)
+                ? $"{typePrefix}{activeCard.CardName}"
+                : $"{prefix}{typePrefix}{activeCard.CardName}";
+            return $"{title} (Cost {activeCard.Cost})\n{activeCard.Description}";
+        }
+
+        private void SetCardButtonsInteractable(bool interactable)
+        {
+            foreach (CardButtonBinding binding in _cardButtons)
+            {
+                if (binding?.Button != null)
+                {
+                    binding.Button.interactable = interactable;
+                }
+            }
+        }
+
+        // ────────────────────────────────────────────────────────
+        // Layout adaptivo: escala cartas si la mano es grande
+        // ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Ajusta tamaño y espaciado de la mano para mantenerla centrada y visible.
+        /// Usa preferredWidth/Height (no sizeDelta) porque HorizontalLayoutGroup se guía por LayoutElement.
+        /// Se fuerza un rebuild para evitar que el layout quede desplazado.
+        /// </summary>
+        private void UpdateHandLayout()
+        {
+            if (_handContainer == null) return;
+
+            int count = _cardButtons.Count;
+            float availableWidth = _handContainer.rect.width;
+            if (count <= 0 || availableWidth <= 0f) return;
+
+            if (Mathf.Abs(availableWidth - _lastHandWidth) < 1f && count == _lastHandCount) return;
+
+            _lastHandWidth = availableWidth;
+            _lastHandCount = count;
+
+            float padding = 32f;
+            float targetWidth = Mathf.Max(0f, availableWidth - padding);
+            float spacing = HandSpacingBase;
+            float cardWidth = HandCardWidthBase;
+
+            float totalWidth = (count * cardWidth) + ((count - 1) * spacing);
+            if (totalWidth > targetWidth)
+            {
+                float scale = targetWidth / totalWidth;
+                cardWidth = Mathf.Max(HandCardWidthMin, cardWidth * scale);
+                spacing = Mathf.Max(HandSpacingMin, spacing * scale);
+            }
+
+            float cardHeight = Mathf.Max(HandCardHeightMin, HandCardHeightBase * (cardWidth / HandCardWidthBase));
+
+            HorizontalLayoutGroup layout = _handContainer.GetComponent<HorizontalLayoutGroup>();
+            if (layout != null)
+            {
+                layout.spacing = spacing;
+            }
+
+            bool layoutChanged = false;
+            foreach (CardButtonBinding binding in _cardButtons)
+            {
+                if (binding?.Button == null) continue;
+
+                LayoutElement element = binding.Button.GetComponent<LayoutElement>();
+                if (element != null)
+                {
+                    if (!Mathf.Approximately(element.preferredWidth, cardWidth)
+                        || !Mathf.Approximately(element.preferredHeight, cardHeight))
+                    {
+                        element.preferredWidth = cardWidth;
+                        element.preferredHeight = cardHeight;
+                        layoutChanged = true;
+                    }
+                }
+            }
+
+            if (layoutChanged)
+            {
+                LayoutRebuilder.ForceRebuildLayoutImmediate(_handContainer);
+            }
+        }
+
+        // ────────────────────────────────────────────────────────
+        // Cleanup
+        // ────────────────────────────────────────────────────────
+
+        private void OnDestroy()
+        {
+            foreach (CardButtonBinding binding in _cardButtons)
+            {
+                if (binding?.Button != null)
+                {
+                    DOTween.Kill(binding.Button.GetComponent<RectTransform>());
+                }
+                if (binding?.Group != null)
+                {
+                    DOTween.Kill(binding.Group);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Combat/CardHandView.cs.meta
+++ b/Assets/Scripts/Gameplay/Combat/CardHandView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7d56f45b2c7e98c40bde2ce7f2160712

--- a/Assets/Scripts/Gameplay/Combat/CombatFeedbackView.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatFeedbackView.cs
@@ -1,0 +1,357 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.UI;
+using DG.Tweening;
+using RoguelikeCardBattler.Core.Audio;
+using RoguelikeCardBattler.Core.UI;
+
+namespace RoguelikeCardBattler.Gameplay.Combat
+{
+    /// <summary>
+    /// Maneja toda la retroalimentación visual de combate: popups de efectividad
+    /// (WEAK/RESIST/MOMENTUM), shake de enemigos al recibir daño, flash de paneles,
+    /// toast de límite de mano, y textos de victoria/derrota.
+    ///
+    /// Extraído de CombatUIController como parte de la descomposición en componentes
+    /// independientes (ver Docs/dev/COMBAT_ARCHITECTURE.md — Fase 1).
+    ///
+    /// Este componente es SOLO presentación — nunca muta estado de gameplay.
+    /// Se suscribe directamente a eventos de TurnManager en OnEnable/OnDisable.
+    /// </summary>
+    public class CombatFeedbackView : MonoBehaviour
+    {
+        // ── Referencias inyectadas por CombatUIController.InitializeFeedbackView() ──
+        private TurnManager _turnManager;
+        private Text _hitFeedbackText;
+        private Text _handLimitText;
+        private Text _playerHpLabel;
+        private Image _playerAvatarImage;
+        private Image _enemyAvatarImage;
+        private Image _enemyAvatarSpriteImage;
+        private Image _energyPanelImage;
+        private Image _worldPanelImage;
+        private SpriteFrameAnimatorUI _enemyAnimator;
+        private Canvas _canvas;
+        private Font _uiFont;
+
+        // ── Configuración (copiada desde los SerializeField de CombatUIController) ──
+        private float _hitFeedbackDuration = 0.85f;
+        private float _handLimitToastDuration = 0.7f;
+        private float _handLimitToastCooldown = 0.6f;
+
+        // ── Estado interno ──
+        private float _hitFeedbackTimer;
+        private float _handLimitTimer;
+        private float _handLimitCooldownRemaining;
+        private Coroutine _panelFlashRoutine;
+        private bool _initialized;
+
+        // Feedback visual: color de flash para paneles de error (ej. sin energía).
+        private static readonly Color HudFlashColor = new Color(1f, 0.4f, 0.4f, 0.9f);
+
+        /// <summary>
+        /// Inyecta todas las referencias necesarias. Llamado por CombatUIController
+        /// después de BuildUI(). Sin esta llamada, el componente no hace nada.
+        /// </summary>
+        public void Initialize(
+            TurnManager turnManager,
+            Text hitFeedbackText,
+            Text handLimitText,
+            Text playerHpLabel,
+            Image playerAvatarImage,
+            Image enemyAvatarImage,
+            Image enemyAvatarSpriteImage,
+            Image energyPanelImage,
+            Image worldPanelImage,
+            SpriteFrameAnimatorUI enemyAnimator,
+            Canvas canvas,
+            Font uiFont,
+            float hitFeedbackDuration,
+            float handLimitToastDuration,
+            float handLimitToastCooldown)
+        {
+            _turnManager = turnManager;
+            _hitFeedbackText = hitFeedbackText;
+            _handLimitText = handLimitText;
+            _playerHpLabel = playerHpLabel;
+            _playerAvatarImage = playerAvatarImage;
+            _enemyAvatarImage = enemyAvatarImage;
+            _enemyAvatarSpriteImage = enemyAvatarSpriteImage;
+            _energyPanelImage = energyPanelImage;
+            _worldPanelImage = worldPanelImage;
+            _enemyAnimator = enemyAnimator;
+            _canvas = canvas;
+            _uiFont = uiFont;
+            _hitFeedbackDuration = hitFeedbackDuration;
+            _handLimitToastDuration = handLimitToastDuration;
+            _handLimitToastCooldown = handLimitToastCooldown;
+            _initialized = true;
+
+            SubscribeEvents();
+        }
+
+        private void OnEnable()
+        {
+            if (_initialized)
+            {
+                SubscribeEvents();
+            }
+        }
+
+        private void OnDisable()
+        {
+            UnsubscribeEvents();
+        }
+
+        private void SubscribeEvents()
+        {
+            if (_turnManager == null) return;
+            _turnManager.PlayerHitEffectiveness += OnPlayerHitEffectiveness;
+            _turnManager.EnemyTookDamage += OnEnemyTookDamage;
+            _turnManager.PlayerHandLimitReached += OnPlayerHandLimitReached;
+        }
+
+        private void UnsubscribeEvents()
+        {
+            if (_turnManager == null) return;
+            _turnManager.PlayerHitEffectiveness -= OnPlayerHitEffectiveness;
+            _turnManager.EnemyTookDamage -= OnEnemyTookDamage;
+            _turnManager.PlayerHandLimitReached -= OnPlayerHandLimitReached;
+        }
+
+        private void Update()
+        {
+            if (!_initialized) return;
+            UpdateHitFeedbackTimer();
+            UpdateHandLimitTimer();
+        }
+
+        // ────────────────────────────────────────────────────────
+        // Efectividad: popups WEAK / RESIST / MOMENTUM +1
+        // ────────────────────────────────────────────────────────
+
+        private void OnPlayerHitEffectiveness(Effectiveness effectiveness, bool momentumGranted)
+        {
+            if (_hitFeedbackText == null) return;
+
+            string message = effectiveness switch
+            {
+                Effectiveness.SuperEficaz => momentumGranted ? "WEAK!\nMOMENTUM +1" : "WEAK!",
+                Effectiveness.PocoEficaz => "RESIST",
+                _ => string.Empty
+            };
+
+            if (string.IsNullOrEmpty(message))
+            {
+                _hitFeedbackText.gameObject.SetActive(false);
+                return;
+            }
+
+            _hitFeedbackText.text = message;
+            _hitFeedbackText.gameObject.SetActive(true);
+            _hitFeedbackTimer = _hitFeedbackDuration;
+
+            // Juice: player avatar shake + HP label red flash + SFX
+            AudioManager.Instance?.PlaySFX(AudioManager.Instance.HitSFX);
+            if (_playerAvatarImage != null)
+            {
+                UIAnimationHelper.Punch(_playerAvatarImage.transform, 0.15f, 0.3f);
+            }
+
+            if (_playerHpLabel != null)
+            {
+                _playerHpLabel.color = new Color(1f, 0.3f, 0.3f, 1f);
+                DOTween.To(
+                    () => _playerHpLabel.color,
+                    x => _playerHpLabel.color = x,
+                    Color.white, 0.4f)
+                    .SetTarget(_playerHpLabel)
+                    .SetUpdate(true);
+            }
+        }
+
+        // ────────────────────────────────────────────────────────
+        // Daño al enemigo: shake + hit animation
+        // ────────────────────────────────────────────────────────
+
+        private void OnEnemyTookDamage(int damage)
+        {
+            AudioManager.Instance?.PlaySFX(AudioManager.Instance.HitSFX);
+            if (damage <= 0) return;
+
+            if (_enemyAnimator != null)
+            {
+                _enemyAnimator.PlayAttackOnce();
+            }
+            else
+            {
+                // Fallback: DOTween-based enemy shake
+                if (_enemyAvatarImage != null)
+                {
+                    UIAnimationHelper.Punch(_enemyAvatarImage.transform, 0.2f, 0.25f);
+                }
+
+                if (_enemyAvatarSpriteImage != null)
+                {
+                    Color originalColor = _enemyAvatarSpriteImage.color;
+                    _enemyAvatarSpriteImage.color = Color.white;
+                    DOTween.To(
+                        () => _enemyAvatarSpriteImage.color,
+                        x => _enemyAvatarSpriteImage.color = x,
+                        originalColor, 0.15f)
+                        .SetTarget(_enemyAvatarSpriteImage)
+                        .SetUpdate(true);
+                }
+            }
+        }
+
+        // ────────────────────────────────────────────────────────
+        // Hand limit toast
+        // ────────────────────────────────────────────────────────
+
+        private void OnPlayerHandLimitReached(int maxHandSize)
+        {
+            if (_handLimitText == null) return;
+            if (_handLimitCooldownRemaining > 0f) return;
+
+            _handLimitText.text = $"Hand limit: {maxHandSize}";
+            _handLimitText.gameObject.SetActive(true);
+            _handLimitText.transform.SetAsLastSibling();
+            _handLimitTimer = _handLimitToastDuration;
+            _handLimitCooldownRemaining = _handLimitToastCooldown;
+            StartCoroutine(HandLimitCooldownRoutine());
+        }
+
+        private IEnumerator HandLimitCooldownRoutine()
+        {
+            while (_handLimitCooldownRemaining > 0f)
+            {
+                _handLimitCooldownRemaining -= Time.deltaTime;
+                yield return null;
+            }
+            _handLimitCooldownRemaining = 0f;
+        }
+
+        // ────────────────────────────────────────────────────────
+        // Panel flash (energy/world panels cuando accion invalida)
+        // ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Flash visual en un panel para indicar acción inválida (ej. sin energía).
+        /// Público para que CombatUIController pueda delegarlo desde OnEndTurnButtonClicked
+        /// y OnChangeWorldButtonClicked.
+        /// </summary>
+        public void FlashPanel(Image panelImage)
+        {
+            if (panelImage == null) return;
+            if (_panelFlashRoutine != null)
+            {
+                StopCoroutine(_panelFlashRoutine);
+            }
+            _panelFlashRoutine = StartCoroutine(FlashPanelRoutine(panelImage));
+        }
+
+        private IEnumerator FlashPanelRoutine(Image panelImage)
+        {
+            Color original = panelImage.color;
+            panelImage.color = HudFlashColor;
+            yield return new WaitForSeconds(0.12f);
+            panelImage.color = original;
+            _panelFlashRoutine = null;
+        }
+
+        // Accesores para que CombatUIController delegue FlashPanel en los paneles correctos.
+        public Image EnergyPanelImage => _energyPanelImage;
+        public Image WorldPanelImage => _worldPanelImage;
+
+        // ────────────────────────────────────────────────────────
+        // Victory / Defeat text
+        // ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Muestra texto animado "VICTORY" centrado en pantalla.
+        /// </summary>
+        public void ShowVictoryText()
+        {
+            AudioManager.Instance?.PlaySFX(AudioManager.Instance.VictorySFX);
+            ShowCombatResultText("VICTORY", new Color(0.2f, 1f, 0.4f));
+        }
+
+        /// <summary>
+        /// Muestra texto animado "DEFEAT" centrado en pantalla.
+        /// </summary>
+        public void ShowDefeatText()
+        {
+            AudioManager.Instance?.PlaySFX(AudioManager.Instance.DefeatSFX);
+            ShowCombatResultText("DEFEAT", new Color(1f, 0.3f, 0.3f));
+        }
+
+        private void ShowCombatResultText(string message, Color color)
+        {
+            if (_canvas == null) return;
+
+            RectTransform canvasRect = _canvas.GetComponent<RectTransform>();
+
+            // Crea texto temporal con animación scale-in + fade-in, auto-destrucción a 2s.
+            GameObject textGO = new GameObject("CombatResultText", typeof(RectTransform), typeof(Text));
+            textGO.transform.SetParent(canvasRect, false);
+
+            RectTransform textRect = textGO.GetComponent<RectTransform>();
+            textRect.anchorMin = new Vector2(0.1f, 0.3f);
+            textRect.anchorMax = new Vector2(0.9f, 0.7f);
+            textRect.offsetMin = Vector2.zero;
+            textRect.offsetMax = Vector2.zero;
+
+            Text resultText = textGO.GetComponent<Text>();
+            resultText.font = _uiFont;
+            resultText.fontSize = 60;
+            resultText.alignment = TextAnchor.MiddleCenter;
+            resultText.fontStyle = FontStyle.Bold;
+            resultText.color = color;
+            resultText.text = message;
+
+            CanvasGroup group = textGO.AddComponent<CanvasGroup>();
+            group.alpha = 0f;
+
+            UIAnimationHelper.ScaleIn(textRect.transform, 0.4f);
+            UIAnimationHelper.FadeIn(group, 0.3f);
+
+            Destroy(textGO, 2f);
+        }
+
+        // ────────────────────────────────────────────────────────
+        // Timers internos
+        // ────────────────────────────────────────────────────────
+
+        private void UpdateHitFeedbackTimer()
+        {
+            if (_hitFeedbackText == null || !_hitFeedbackText.gameObject.activeSelf) return;
+
+            _hitFeedbackTimer -= Time.deltaTime;
+            if (_hitFeedbackTimer <= 0f)
+            {
+                _hitFeedbackText.gameObject.SetActive(false);
+            }
+        }
+
+        private void UpdateHandLimitTimer()
+        {
+            if (_handLimitText == null || !_handLimitText.gameObject.activeSelf) return;
+
+            _handLimitTimer -= Time.deltaTime;
+            if (_handLimitTimer <= 0f)
+            {
+                _handLimitText.gameObject.SetActive(false);
+            }
+        }
+
+        private void OnDestroy()
+        {
+            UnsubscribeEvents();
+            if (_playerAvatarImage != null) DOTween.Kill(_playerAvatarImage.transform);
+            if (_enemyAvatarImage != null) DOTween.Kill(_enemyAvatarImage.transform);
+            if (_playerHpLabel != null) DOTween.Kill(_playerHpLabel);
+            if (_enemyAvatarSpriteImage != null) DOTween.Kill(_enemyAvatarSpriteImage);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Combat/CombatFeedbackView.cs.meta
+++ b/Assets/Scripts/Gameplay/Combat/CombatFeedbackView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b833cae6e13c24b48afc558364a337af

--- a/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
@@ -1,12 +1,8 @@
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
-using DG.Tweening;
 using RoguelikeCardBattler.Core.Audio;
-using RoguelikeCardBattler.Core.UI;
-using RoguelikeCardBattler.Gameplay.Cards;
 using RoguelikeCardBattler.Gameplay.Enemies;
 
 namespace RoguelikeCardBattler.Gameplay.Combat
@@ -73,13 +69,11 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         [SerializeField] private List<Sprite> heroAttackFrames = new List<Sprite>();
         [SerializeField] private float heroAttackFps = 16f;
         private Text _hitFeedbackText;
-        private float _hitFeedbackTimer;
         // Tiempos de feedback visual ajustables por diseño sin tocar gameplay.
         [Header("Feedback Timing")]
         [SerializeField, Min(0.1f)] private float hitFeedbackDuration = 0.85f;
         private SpriteFrameAnimatorUI _playerAnimator;
         private Image _playerAvatarSpriteImage;
-        private bool _isPlayingAttack;
         [Header("Enemy Hit Feedback")]
         [SerializeField] private List<Sprite> enemyHitFrames = new List<Sprite>();
         [SerializeField] private float enemyHitFps = 16f;
@@ -87,11 +81,9 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         private Image _enemyAvatarSpriteImage;
         private Image _energyPanelImage;
         private Image _worldPanelImage;
-        private Coroutine _panelFlashRoutine;
-        private float _handLimitTimer;
-        private float _handLimitCooldown;
-        private float _lastHandWidth;
-        private int _lastHandCount = -1;
+        // Componentes extraídos que manejan áreas específicas de la UI de combate.
+        private CombatFeedbackView _feedbackView;
+        private CardHandView _cardHandView;
 
         // Layout/estilo del HUD: constantes para mantener jerarquía visual y escalado.
         private const float TopBarMinY = 0.92f;
@@ -105,30 +97,10 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         private static readonly Color ButtonDisabledColor = new Color(0.12f, 0.12f, 0.16f, 0.7f);
         private static readonly Color ButtonPressedColor = new Color(0.35f, 0.35f, 0.45f, 1f);
         private static readonly Color ButtonHighlightColor = new Color(0.3f, 0.3f, 0.4f, 1f);
-        private static readonly Color CardButtonNormalColor = new Color(0.18f, 0.18f, 0.25f, 0.95f);
-        private static readonly Color CardButtonDisabledColor = new Color(0.1f, 0.1f, 0.14f, 0.6f);
         private static readonly Color DisabledLabelColor = new Color(0.75f, 0.75f, 0.75f, 0.7f);
         private static readonly Color WarningLabelColor = new Color(1f, 0.6f, 0.6f, 1f);
-        private static readonly Color HudFlashColor = new Color(1f, 0.4f, 0.4f, 0.9f);
         [SerializeField, Min(0.1f)] private float handLimitToastDuration = 0.7f;
         [SerializeField, Min(0f)] private float handLimitToastCooldown = 0.6f;
-        private const float HandCardWidthBase = 230f;
-        private const float HandCardHeightBase = 130f;
-        private const float HandCardWidthMin = 150f;
-        private const float HandCardHeightMin = 96f;
-        private const float HandSpacingBase = 12f;
-        private const float HandSpacingMin = 4f;
-
-        private readonly List<CardButtonBinding> _cardButtons = new List<CardButtonBinding>();
-        private readonly List<CardDeckEntry> _handCache = new List<CardDeckEntry>();
-
-        private class CardButtonBinding
-        {
-            public CardDeckEntry CardEntry;
-            public Button Button;
-            public Text Label;
-            public CanvasGroup Group;
-        }
 
         private void Awake()
         {
@@ -164,22 +136,13 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 turnManager = GetComponent<TurnManager>();
             }
 
-            if (turnManager != null)
-            {
-                turnManager.PlayerHitEffectiveness += OnPlayerHitEffectiveness;
-                turnManager.EnemyTookDamage += OnEnemyTookDamage;
-                turnManager.PlayerHandLimitReached += OnPlayerHandLimitReached;
-            }
+            // Eventos de feedback (PlayerHitEffectiveness, EnemyTookDamage,
+            // PlayerHandLimitReached) delegados a CombatFeedbackView.
         }
 
         private void OnDisable()
         {
-            if (turnManager != null)
-            {
-                turnManager.PlayerHitEffectiveness -= OnPlayerHitEffectiveness;
-                turnManager.EnemyTookDamage -= OnEnemyTookDamage;
-                turnManager.PlayerHandLimitReached -= OnPlayerHandLimitReached;
-            }
+            // Desuscripción de eventos de feedback delegada a CombatFeedbackView.
         }
 
         private void Update()
@@ -190,9 +153,8 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             }
 
             UpdateInfoTexts();
-            SyncHandButtons();
-            UpdateHitFeedbackTimer();
-            UpdateHandLimitTimer();
+            _cardHandView?.SyncHandButtons();
+            // Hit feedback y hand limit timers delegados a CombatFeedbackView.
         }
 
         private void EnsureEventSystem()
@@ -474,6 +436,41 @@ namespace RoguelikeCardBattler.Gameplay.Combat
 
             InitializePlayerAnimator();
             UpdateWorldVisuals();
+            InitializeExtractedViews();
+        }
+
+        /// <summary>
+        /// Crea e inicializa los componentes extraídos (CombatFeedbackView, CardHandView).
+        /// Les pasa las referencias de UI que necesitan después de BuildUI().
+        /// </summary>
+        private void InitializeExtractedViews()
+        {
+            _feedbackView = gameObject.AddComponent<CombatFeedbackView>();
+            _feedbackView.Initialize(
+                turnManager,
+                _hitFeedbackText,
+                _handLimitText,
+                _playerHpLabel,
+                _playerAvatarImage,
+                _enemyAvatarImage,
+                _enemyAvatarSpriteImage,
+                _energyPanelImage,
+                _worldPanelImage,
+                _enemyAnimator,
+                _canvas,
+                uiFont,
+                hitFeedbackDuration,
+                handLimitToastDuration,
+                handLimitToastCooldown);
+
+            _cardHandView = gameObject.AddComponent<CardHandView>();
+            _cardHandView.Initialize(
+                turnManager,
+                _handContainer,
+                _playerAnimator,
+                _feedbackView,
+                _energyPanelImage,
+                uiFont);
         }
         private Text CreateCornerCounter(RectTransform parent, Vector2 anchorMin, Vector2 size, string label)
         {
@@ -657,78 +654,20 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             blockRect.offsetMax = Vector2.zero;
         }
 
-        private Button CreateCardButton(CardDeckEntry entry, Transform parent)
-        {
-            CardDefinition activeCard = turnManager.GetActiveCardDefinition(entry);
-            string label = activeCard != null ? activeCard.name : "Card";
-
-            GameObject buttonGO = new GameObject(label + "_Button", typeof(RectTransform), typeof(Image), typeof(Button), typeof(LayoutElement));
-            buttonGO.transform.SetParent(parent, false);
-
-            RectTransform rect = buttonGO.GetComponent<RectTransform>();
-            rect.sizeDelta = new Vector2(HandCardWidthBase, HandCardHeightBase);
-
-            Image image = buttonGO.GetComponent<Image>();
-            image.color = CardButtonNormalColor;
-
-            LayoutElement layout = buttonGO.GetComponent<LayoutElement>();
-            layout.preferredWidth = HandCardWidthBase;
-            layout.preferredHeight = HandCardHeightBase;
-
-            Button button = buttonGO.GetComponent<Button>();
-
-            Text labelText = CreateText("Label", rect, BuildCardLabel(entry), 20, TextAnchor.MiddleCenter);
-            labelText.fontStyle = FontStyle.Bold;
-
-            button.onClick.AddListener(() => OnCardButtonClicked(entry));
-
-            return button;
-        }
+        // CreateCardButton extraído a CardHandView.
 
         private void OnEndTurnButtonClicked()
         {
             if (turnManager == null || !turnManager.IsPlayerTurn())
             {
-                FlashPanel(_energyPanelImage);
+                _feedbackView?.FlashPanel(_energyPanelImage);
                 return;
             }
 
             turnManager.EndPlayerTurn();
         }
 
-        private void OnCardButtonClicked(CardDeckEntry entry)
-        {
-            AudioManager.Instance?.PlaySFX(AudioManager.Instance.CardPlaySFX);
-            if (turnManager == null || entry == null || _isPlayingAttack)
-            {
-                return;
-            }
-
-            if (!turnManager.TryPrepareCardPlay(entry, out PreparedCardPlay prepared))
-            {
-                FlashPanel(_energyPanelImage);
-                return;
-            }
-
-            SyncHandButtons(forceRebuild: true);
-
-            if (prepared.IsAttackCard && _playerAnimator != null)
-            {
-                _isPlayingAttack = true;
-                SetCardButtonsInteractable(false);
-                _playerAnimator.PlayAttackOnce(() =>
-                {
-                    turnManager.ResolvePreparedCardPlay(prepared);
-                    _isPlayingAttack = false;
-                    SyncHandButtons(forceRebuild: true);
-                });
-            }
-            else
-            {
-                turnManager.ResolvePreparedCardPlay(prepared);
-                SyncHandButtons(forceRebuild: true);
-            }
-        }
+        // OnCardButtonClicked extraído a CardHandView.
 
         private void UpdateInfoTexts()
         {
@@ -798,217 +737,8 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             return new Color(color.r * factor, color.g * factor, color.b * factor, color.a);
         }
 
-        private void SetCardButtonsInteractable(bool interactable)
-        {
-            foreach (CardButtonBinding binding in _cardButtons)
-            {
-                if (binding?.Button != null)
-                {
-                    binding.Button.interactable = interactable;
-                }
-            }
-        }
-
-        private void SyncHandButtons(bool forceRebuild = false)
-        {
-            if (turnManager == null)
-            {
-                return;
-            }
-
-            if (forceRebuild || !IsHandCacheValid())
-            {
-                RebuildHandButtons();
-            }
-
-            bool canInteract = turnManager.IsPlayerTurn();
-            foreach (CardButtonBinding binding in _cardButtons)
-            {
-                bool canPlay = turnManager.CanPlayCard(binding.CardEntry);
-                binding.Button.interactable = canInteract && canPlay;
-                binding.Label.text = BuildCardLabel(binding.CardEntry);
-                if (binding.Label != null)
-                {
-                    binding.Label.color = binding.Button.interactable ? Color.white : DisabledLabelColor;
-                }
-                Image image = binding.Button.GetComponent<Image>();
-                if (image != null)
-                {
-                    image.color = binding.Button.interactable ? CardButtonNormalColor : CardButtonDisabledColor;
-                }
-            }
-
-            UpdateHandLayout();
-        }
-
-        private void UpdateHitFeedbackTimer()
-        {
-            if (_hitFeedbackText == null || !_hitFeedbackText.gameObject.activeSelf)
-            {
-                return;
-            }
-
-            _hitFeedbackTimer -= Time.deltaTime;
-            if (_hitFeedbackTimer <= 0f)
-            {
-                _hitFeedbackText.gameObject.SetActive(false);
-            }
-        }
-
-        private void UpdateHandLimitTimer()
-        {
-            if (_handLimitText == null || !_handLimitText.gameObject.activeSelf)
-            {
-                return;
-            }
-
-            _handLimitTimer -= Time.deltaTime;
-            if (_handLimitTimer <= 0f)
-            {
-                _handLimitText.gameObject.SetActive(false);
-            }
-        }
-
-        private void OnPlayerHitEffectiveness(Effectiveness effectiveness, bool momentumGranted)
-        {
-            if (_hitFeedbackText == null)
-            {
-                return;
-            }
-
-            string message = effectiveness switch
-            {
-                Effectiveness.SuperEficaz => momentumGranted ? "WEAK!\nMOMENTUM +1" : "WEAK!",
-                Effectiveness.PocoEficaz => "RESIST",
-                _ => string.Empty
-            };
-
-            if (string.IsNullOrEmpty(message))
-            {
-                _hitFeedbackText.gameObject.SetActive(false);
-                return;
-            }
-
-            _hitFeedbackText.text = message;
-            _hitFeedbackText.gameObject.SetActive(true);
-            _hitFeedbackTimer = hitFeedbackDuration;
-
-            // ── Juice: player avatar shake + HP label red flash + SFX ──
-            AudioManager.Instance?.PlaySFX(AudioManager.Instance.HitSFX);
-            if (_playerAvatarImage != null)
-            {
-                UIAnimationHelper.Punch(_playerAvatarImage.transform, 0.15f, 0.3f);
-            }
-
-            if (_playerHpLabel != null)
-            {
-                _playerHpLabel.color = new Color(1f, 0.3f, 0.3f, 1f);
-                DOTween.To(
-                    () => _playerHpLabel.color,
-                    x => _playerHpLabel.color = x,
-                    Color.white, 0.4f)
-                    .SetTarget(_playerHpLabel)
-                    .SetUpdate(true);
-            }
-        }
-
-        private void OnEnemyTookDamage(int damage)
-        {
-            AudioManager.Instance?.PlaySFX(AudioManager.Instance.HitSFX);
-            if (damage <= 0)
-            {
-                return;
-            }
-
-            if (_enemyAnimator != null && enemyHitFrames != null && enemyHitFrames.Count > 0)
-            {
-                _enemyAnimator.Configure(_enemyAvatarSpriteImage, new List<Sprite>(), enemyHitFrames, enemyHitFps);
-                _enemyAnimator.PlayAttackOnce();
-            }
-            else
-            {
-                // ── Juice: DOTween-based enemy shake (replaces coroutine) ──
-                if (_enemyAvatarImage != null)
-                {
-                    UIAnimationHelper.Punch(_enemyAvatarImage.transform, 0.2f, 0.25f);
-                }
-
-                if (_enemyAvatarSpriteImage != null)
-                {
-                    Color originalColor = _enemyAvatarSpriteImage.color;
-                    _enemyAvatarSpriteImage.color = Color.white;
-                    DOTween.To(
-                        () => _enemyAvatarSpriteImage.color,
-                        x => _enemyAvatarSpriteImage.color = x,
-                        originalColor, 0.15f)
-                        .SetTarget(_enemyAvatarSpriteImage)
-                        .SetUpdate(true);
-                }
-            }
-        }
-
-        private bool IsHandCacheValid()
-        {
-            if (turnManager == null)
-            {
-                return false;
-            }
-
-            IReadOnlyList<CardDeckEntry> hand = turnManager.PlayerHand;
-            if (hand.Count != _handCache.Count)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < hand.Count; i++)
-            {
-                if (hand[i] != _handCache[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        private void RebuildHandButtons()
-        {
-            foreach (CardButtonBinding binding in _cardButtons)
-            {
-                if (binding?.Button != null)
-                {
-                    DOTween.Kill(binding.Button.GetComponent<RectTransform>());
-                    if (binding.Group != null) DOTween.Kill(binding.Group);
-                    Destroy(binding.Button.gameObject);
-                }
-            }
-
-            _cardButtons.Clear();
-            _handCache.Clear();
-
-            IReadOnlyList<CardDeckEntry> hand = turnManager.PlayerHand;
-            for (int i = 0; i < hand.Count; i++)
-            {
-                CardDeckEntry entry = hand[i];
-                Button button = CreateCardButton(entry, _handContainer);
-                Text label = button.GetComponentInChildren<Text>();
-
-                // ── Juice: staggered fade-in only (no scale/slide — LayoutGroup controls position and scale) ──
-                CanvasGroup cardGroup = button.gameObject.AddComponent<CanvasGroup>();
-                cardGroup.alpha = 0f;
-                float delay = i * 0.05f;
-                UIAnimationHelper.FadeIn(cardGroup, 0.2f).SetDelay(delay);
-
-                _cardButtons.Add(new CardButtonBinding
-                {
-                    CardEntry = entry,
-                    Button = button,
-                    Label = label,
-                    Group = cardGroup
-                });
-                _handCache.Add(entry);
-            }
-        }
+        // SetCardButtonsInteractable, SyncHandButtons, IsHandCacheValid,
+        // RebuildHandButtons extraídos a CardHandView.
 
         private void InitializePlayerAnimator()
         {
@@ -1068,31 +798,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             _enemyAnimator.Configure(_enemyAvatarSpriteImage, new List<Sprite>(), enemyHitFrames, enemyHitFps);
         }
 
-        private string BuildCardLabel(CardDeckEntry entry)
-        {
-            if (entry == null)
-            {
-                return "Unknown Card";
-            }
-
-            CardDefinition activeCard = turnManager != null ? turnManager.GetActiveCardDefinition(entry) : null;
-            if (activeCard == null)
-            {
-                return "Unknown Card";
-            }
-
-            string prefix = string.Empty;
-            if (entry.DualCard != null)
-            {
-                prefix = turnManager.CurrentWorld == TurnManager.WorldSide.A ? "[A] " : "[B] ";
-            }
-
-            string typePrefix = activeCard.ElementType != ElementType.None ? $"[{activeCard.ElementType}] " : string.Empty;
-            string title = string.IsNullOrEmpty(prefix)
-                ? $"{typePrefix}{activeCard.CardName}"
-                : $"{prefix}{typePrefix}{activeCard.CardName}";
-            return $"{title} (Cost {activeCard.Cost})\n{activeCard.Description}";
-        }
+        // BuildCardLabel extraído a CardHandView.
 
         private string BuildEnemyIntentLabel()
         {
@@ -1147,118 +853,15 @@ namespace RoguelikeCardBattler.Gameplay.Combat
 
             bool changed = turnManager.TryChangeWorld();
             UpdateWorldVisuals();
-            SyncHandButtons(forceRebuild: true);
+            _cardHandView?.SyncHandButtons(forceRebuild: true);
             if (!changed)
             {
-                FlashPanel(_worldPanelImage);
+                _feedbackView?.FlashPanel(_worldPanelImage);
             }
         }
 
-        private void OnPlayerHandLimitReached(int maxHandSize)
-        {
-            if (_handLimitText == null)
-            {
-                return;
-            }
-
-            if (_handLimitCooldown > 0f)
-            {
-                return;
-            }
-
-            _handLimitText.text = $"Hand limit: {maxHandSize}";
-            _handLimitText.gameObject.SetActive(true);
-            _handLimitText.transform.SetAsLastSibling();
-            _handLimitTimer = handLimitToastDuration;
-            _handLimitCooldown = handLimitToastCooldown;
-            StartCoroutine(HandLimitCooldownRoutine());
-        }
-
-        private IEnumerator HandLimitCooldownRoutine()
-        {
-            while (_handLimitCooldown > 0f)
-            {
-                _handLimitCooldown -= Time.deltaTime;
-                yield return null;
-            }
-
-            _handLimitCooldown = 0f;
-        }
-
-        /// <summary>
-        /// Ajusta tamaño y espaciado de la mano para mantenerla centrada y visible.
-        /// Usa preferredWidth/Height (no sizeDelta) porque HorizontalLayoutGroup se guía por LayoutElement.
-        /// Se fuerza un rebuild para evitar que el layout quede desplazado.
-        /// </summary>
-        private void UpdateHandLayout()
-        {
-            if (_handContainer == null)
-            {
-                return;
-            }
-
-            int count = _cardButtons.Count;
-            float availableWidth = _handContainer.rect.width;
-            if (count <= 0 || availableWidth <= 0f)
-            {
-                return;
-            }
-
-            if (Mathf.Abs(availableWidth - _lastHandWidth) < 1f && count == _lastHandCount)
-            {
-                return;
-            }
-
-            _lastHandWidth = availableWidth;
-            _lastHandCount = count;
-
-            float padding = 32f; // coincide con padding izquierdo/derecho del layout
-            float targetWidth = Mathf.Max(0f, availableWidth - padding);
-            float spacing = HandSpacingBase;
-            float cardWidth = HandCardWidthBase;
-
-            float totalWidth = (count * cardWidth) + ((count - 1) * spacing);
-            if (totalWidth > targetWidth)
-            {
-                float scale = targetWidth / totalWidth;
-                cardWidth = Mathf.Max(HandCardWidthMin, cardWidth * scale);
-                spacing = Mathf.Max(HandSpacingMin, spacing * scale);
-            }
-
-            float cardHeight = Mathf.Max(HandCardHeightMin, HandCardHeightBase * (cardWidth / HandCardWidthBase));
-
-            HorizontalLayoutGroup layout = _handContainer.GetComponent<HorizontalLayoutGroup>();
-            if (layout != null)
-            {
-                layout.spacing = spacing;
-            }
-
-            bool layoutChanged = false;
-            foreach (CardButtonBinding binding in _cardButtons)
-            {
-                if (binding?.Button == null)
-                {
-                    continue;
-                }
-
-                LayoutElement element = binding.Button.GetComponent<LayoutElement>();
-                if (element != null)
-                {
-                    if (!Mathf.Approximately(element.preferredWidth, cardWidth)
-                        || !Mathf.Approximately(element.preferredHeight, cardHeight))
-                    {
-                        element.preferredWidth = cardWidth;
-                        element.preferredHeight = cardHeight;
-                        layoutChanged = true;
-                    }
-                }
-            }
-
-            if (layoutChanged)
-            {
-                LayoutRebuilder.ForceRebuildLayoutImmediate(_handContainer);
-            }
-        }
+        // OnPlayerHandLimitReached, HandLimitCooldownRoutine extraídos a CombatFeedbackView.
+        // UpdateHandLayout extraído a CardHandView.
 
         private void ApplyButtonStyle(Button button)
         {
@@ -1277,28 +880,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             button.colors = colors;
         }
 
-        private void FlashPanel(Image panelImage)
-        {
-            if (panelImage == null)
-            {
-                return;
-            }
-
-            if (_panelFlashRoutine != null)
-            {
-                StopCoroutine(_panelFlashRoutine);
-            }
-            _panelFlashRoutine = StartCoroutine(FlashPanelRoutine(panelImage));
-        }
-
-        private IEnumerator FlashPanelRoutine(Image panelImage)
-        {
-            Color original = panelImage.color;
-            panelImage.color = HudFlashColor;
-            yield return new WaitForSeconds(0.12f);
-            panelImage.color = original;
-            _panelFlashRoutine = null;
-        }
+        // FlashPanel y FlashPanelRoutine extraídos a CombatFeedbackView.
 
         private void UpdateWorldVisuals()
         {
@@ -1388,86 +970,11 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             rectTransform.localScale = scale;
         }
 
-        // ────────────────────────────────────────────────────────
-        // Juice: combat result text + DOTween cleanup
-        // ────────────────────────────────────────────────────────
+        // ShowVictoryText, ShowDefeatText, ShowCombatResultText extraídos a CombatFeedbackView.
+        // Acceso público via: _feedbackView.ShowVictoryText() / _feedbackView.ShowDefeatText()
 
-        /// <summary>
-        /// Shows an animated "VICTORY" text centered on screen.
-        /// Not connected to any event yet — call from BattleFlowController in a future issue.
-        /// </summary>
-        public void ShowVictoryText()
-        {
-            AudioManager.Instance?.PlaySFX(AudioManager.Instance.VictorySFX);
-            ShowCombatResultText("VICTORY", new Color(0.2f, 1f, 0.4f));
-        }
-
-        /// <summary>
-        /// Shows an animated "DEFEAT" text centered on screen.
-        /// Not connected to any event yet — call from BattleFlowController in a future issue.
-        /// </summary>
-        public void ShowDefeatText()
-        {
-            AudioManager.Instance?.PlaySFX(AudioManager.Instance.DefeatSFX);
-            ShowCombatResultText("DEFEAT", new Color(1f, 0.3f, 0.3f));
-        }
-
-        /// <summary>
-        /// Creates a large centered text with scale-in + fade-in animation, auto-destroys after 2s.
-        /// </summary>
-        private void ShowCombatResultText(string message, Color color)
-        {
-            if (_canvas == null)
-            {
-                return;
-            }
-
-            RectTransform canvasRect = _canvas.GetComponent<RectTransform>();
-            Text resultText = CreateText("CombatResultText", canvasRect, message, 60, TextAnchor.MiddleCenter);
-            resultText.fontStyle = FontStyle.Bold;
-            resultText.color = color;
-
-            RectTransform textRect = resultText.GetComponent<RectTransform>();
-            textRect.anchorMin = new Vector2(0.1f, 0.3f);
-            textRect.anchorMax = new Vector2(0.9f, 0.7f);
-            textRect.offsetMin = Vector2.zero;
-            textRect.offsetMax = Vector2.zero;
-
-            CanvasGroup group = resultText.gameObject.AddComponent<CanvasGroup>();
-            group.alpha = 0f;
-
-            UIAnimationHelper.ScaleIn(textRect.transform, 0.4f);
-            UIAnimationHelper.FadeIn(group, 0.3f);
-
-            Destroy(resultText.gameObject, 2f);
-        }
-
-        /// <summary>
-        /// Cleanup: kill all active DOTween tweens owned by this controller's UI elements.
-        /// </summary>
-        private void OnDestroy()
-        {
-            // Kill tweens on card buttons
-            foreach (CardButtonBinding binding in _cardButtons)
-            {
-                if (binding?.Button != null)
-                {
-                    DOTween.Kill(binding.Button.GetComponent<RectTransform>());
-                }
-                if (binding?.Group != null)
-                {
-                    DOTween.Kill(binding.Group);
-                }
-            }
-
-            // Kill tweens on avatars
-            if (_playerAvatarImage != null) DOTween.Kill(_playerAvatarImage.transform);
-            if (_enemyAvatarImage != null) DOTween.Kill(_enemyAvatarImage.transform);
-
-            // Kill tweens on labels
-            if (_playerHpLabel != null) DOTween.Kill(_playerHpLabel);
-            if (_enemyAvatarSpriteImage != null) DOTween.Kill(_enemyAvatarSpriteImage);
-        }
+        // OnDestroy: tweens de card buttons limpiados por CardHandView.OnDestroy(),
+        // tweens de avatares/labels limpiados por CombatFeedbackView.OnDestroy().
     }
 }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md — RoguelikeCardBattler
+
+## Project
+
+Unity roguelike card battler (C#). Combate 1v1 por turnos con mecanica de mundos duales (A/B),
+tipos elementales asimetricos, y sistema Momentum. Estetica handmade (carton, crayones, papel).
+
+## Architecture (non-negotiable)
+
+- **Scene-owned controllers**: cada escena tiene su controlador (RunFlowController,
+  BattleFlowController, MainMenuController). No hay managers globales flotantes.
+- **RunSession es el UNICO DontDestroyOnLoad**. Comunica estado entre escenas via
+  RunState flags (PendingReturnFromBattle, LastNodeOutcome, CurrentNodeId, RunFailed, ActoCompleted).
+- **Separacion**: RunState = datos. Controllers = flujo. UI/VFX = presentacion.
+  No mezclar logica de gameplay en UI.
+- **Data-driven**: ScriptableObjects para cartas, enemigos, configuracion. Nunca hardcodear datos.
+
+## DO NOT MODIFY (core combat)
+
+Estos archivos son intocables. Si una tarea requiere cambiarlos, PARAR y preguntar al usuario:
+
+- `Assets/Scripts/Gameplay/Combat/TurnManager.cs` — flujo de turnos, efectividad, energia, momentum
+- `Assets/Scripts/Gameplay/Combat/ActionQueue.cs` — orden de ejecucion determinista (FIFO)
+- `Assets/Scripts/Gameplay/Combat/PlayerCombatActor.cs` — mecanicas del jugador en combate
+
+## CombatUIController — Special Rules
+
+`CombatUIController.cs` es un monolito de 1400+ lineas. Reglas especiales:
+
+- **NO agregar** metodos ni responsabilidades nuevas.
+- Features nuevas de UI de combate van en **componentes separados** (MonoBehaviours propios)
+  que se suscriben a eventos de TurnManager, no dentro de CombatUIController.
+- CombatUIController es **solo presentacion**. Nunca mutar estado de gameplay desde ahi.
+- BattleFlowController NO referencia CombatUIController — son independientes. Ambos se
+  conectan a TurnManager por separado.
+- Ver `Assets/Scripts/Gameplay/Combat/CLAUDE.md` para reglas detalladas de combate.
+
+## Coding Standards
+
+- **CS0104**: Si un archivo usa `System` y `UnityEngine`, siempre escribir `UnityEngine.Object`
+  (nunca `Object` a secas).
+- **Zero console errors** es el criterio de aceptacion base de todo cambio.
+- **No manual editor setup**: features nuevas deben auto-crear GameObjects en runtime o ser
+  instanciadas por un scene controller existente. Nunca requerir attach manual en inspector.
+- **Animaciones fire-and-forget**: la logica de gameplay NUNCA espera ni vive dentro de callbacks
+  de animacion cosmetica. La logica continua inmediatamente.
+- **Comentarios de onboarding** en todo codigo nuevo.
+- **No duplicar logica**: verificar helpers existentes antes de crear nuevos.
+  Revisar `Core/UI/UIAnimationHelper.cs` (8 metodos DOTween) y `Core/Audio/AudioManager.cs`.
+
+## Workflow
+
+- **Plan mode primero**: usar Plan mode antes de implementar features no triviales.
+- **GOLDEN_RULES.md tiene autoridad final** sobre cualquier otra instruccion o documento.
+  Si hay contradiccion, GOLDEN_RULES gana.
+- **Leer docs relevantes antes de codear**: para combate leer COMBAT_ARCHITECTURE.md,
+  para reglas de juego leer GOLDEN_RULES.md.
+- **Git branches**: `feat/*` para features, `docs/*` para documentacion, `chore/*` para misc.
+- **PRs**: incluir `Closes #<issue>` para autocerrar issues.
+
+## Key References (leer cuando sea relevante, no memorizar)
+
+- `Docs/dev/GOLDEN_RULES.md` — reglas de juego + codigo (fuente de verdad)
+- `Docs/dev/COMBAT_ARCHITECTURE.md` — diagramas y mapa de archivos de combate
+- `Docs/dev/DEV_ONBOARDING.md` — setup, quick-start, test runner
+- `Docs/dev/GLOSSARY.md` — definiciones de terminologia
+- `Docs/design/DESIGN_DECISIONS.md` — decisiones de diseno abiertas (NO implementar items
+  no decididos sin aprobacion del usuario)
+- `Docs/design/CARDS.md` — schema de datos de cartas
+- `Docs/design/ENEMIES.md` — schema de datos de enemigos
+- `Docs/design/MECHANIC_DUALITY.md` — sistema de mundos duales (diseño conceptual)
+- `Docs/epics/EPIC_4_VERTICAL_SLICE_ACTO_1.md` — scope del vertical slice
+
+## Project Conventions
+
+- **DOTween** (Demigiant) para todas las animaciones UI y transiciones de escena.
+- **Unity UI legacy Text** (no TextMeshPro) en todo el proyecto.
+- **ScriptableObjects** viven en `Assets/ScriptableObjects/` organizados por tipo.
+- **Runtime asmdef**: `Assets/Scripts/RoguelikeCardBattler.asmdef`
+- **Test asmdef**: `Assets/Tests/EditMode/EditModeTests.asmdef`
+- **Tests**: EditMode con NUnit. Ejecutar via `Window > Test Runner > EditMode > Run All`.
+- **Escena principal para probar combate**: `Assets/Scenes/BattleScene.unity`

--- a/Docs/dev/COMBAT_ARCHITECTURE.md
+++ b/Docs/dev/COMBAT_ARCHITECTURE.md
@@ -70,6 +70,42 @@ flowchart TD
 - Cambio de mundo: 1 uso por combate; flag de debug permite ilimitado.
 - UI se construye en runtime por `CombatUIController`; sprites de avatares se configuran vía inspector/captura inicial.
 
+### CombatUIController — Plan de descomposicion
+
+`CombatUIController.cs` es un monolito de 1400+ lineas con 5 responsabilidades mezcladas.
+Se descompone incrementalmente en componentes independientes, cada uno un MonoBehaviour
+que se suscribe a eventos de TurnManager y recibe referencias de UI necesarias.
+
+**Acoplamiento clave**: BattleFlowController NO referencia CombatUIController. Ambos
+se conectan a TurnManager de forma independiente. Esto permite extraer componentes
+sin tocar BattleFlowController.
+
+#### Componentes objetivo (en orden de extraccion)
+
+| Componente | Responsabilidad | Dependencias | Estado |
+|------------|----------------|--------------|--------|
+| `CombatFeedbackView` | Popups WEAK/RESIST/MOMENTUM, enemy shake, victory/defeat text, hand limit toast, panel flash | TurnManager events, UIAnimationHelper, AudioManager | **Fase 1** |
+| `CardHandView` | Mano de cartas, CardButtonBinding, sync, layout adaptivo, click → TurnManager | TurnManager (card play API), UI builders | Fase 2 |
+| `CombatHudView` | Paneles de HP, energia, momentum, mundo, block overlays, intents | TurnManager (read state), UI builders | Fase 3 |
+| `CombatBackgroundView` | Fondos sky/ground por mundo, CoverFill, sprites A/B | TurnManager.CurrentWorld | Fase 4 |
+
+#### Patron de integracion
+
+Cada componente extraido:
+1. Vive en el mismo GameObject que CombatUIController (o hijo directo).
+2. Se suscribe a TurnManager events en OnEnable/OnDisable.
+3. Recibe referencias de UI via campos internos (no SerializeField).
+4. CombatUIController le pasa las referencias despues de BuildUI() via metodo `Initialize()`.
+5. Es **solo presentacion** — nunca muta estado de gameplay.
+
+#### Reglas de extraccion
+
+- Cada fase es un commit/PR independiente.
+- Despues de cada fase: zero console errors + gameplay funcional = criterio de aceptacion.
+- CombatUIController se adelgaza pero sigue siendo el orquestador de BuildUI().
+- Los UI builder helpers (CreatePanel, CreateText, etc.) permanecen en CombatUIController
+  hasta que se extraigan todos los componentes; luego se mueven a un utility compartido.
+
 ### Troubleshooting
 - No aparecen tests en Test Runner:
   - Verifica asmdefs: runtime (`Assets/Scripts/RoguelikeCardBattler.asmdef`) y tests (`Assets/Tests/EditMode/EditModeTests.asmdef`). Usa pestaña EditMode en `Window > General > Test Runner`.

--- a/Docs/dev/PROMPT_MASTER_AND_PROGRAMMING.md
+++ b/Docs/dev/PROMPT_MASTER_AND_PROGRAMMING.md
@@ -1,6 +1,10 @@
-# Prompt Master y Programming Master — Workflow de desarrollo
+> **DEPRECATED**: Este workflow dual-agent ha sido reemplazado por un solo agente usando
+> Claude Code Plan mode + `CLAUDE.md` como guardrails. Se mantiene como referencia histórica.
+> Ver `CLAUDE.md` en la raíz del proyecto para el workflow actual.
 
-Este documento describe cómo está organizado el proceso de desarrollo del proyecto: la arquitectura de software que seguimos, la separación de roles entre **Prompt Master** y **Programming Master**, y las reglas que garantizan consistencia y calidad.
+# Prompt Master y Programming Master — Workflow de desarrollo (HISTÓRICO)
+
+Este documento describe el proceso de desarrollo original del proyecto: la arquitectura de software que seguimos, la separación de roles entre **Prompt Master** y **Programming Master**, y las reglas que garantizan consistencia y calidad.
 
 ---
 
@@ -29,9 +33,8 @@ MainMenu → RunScene (mapa) → BattleScene (combate) → RunScene (resultado) 
 
 ### Archivos y responsabilidades
 
-- **No tocar on-chain**: Nunca modificar contratos Anchor, IDL, ni lógica que interactúe directamente con la blockchain.
-- **No tocar lógica de bids/combate core**: TurnManager, ActionQueue, PlayerCombatActor manejan la mecánica. Los controllers orquestan, no implementan.
-- **Helpers reutilizables**: Funciones como `isAuctionClosed`, `getAuctionStatusLabel` en `lib/utils` deben usarse en vez de duplicar lógica.
+- **No tocar core de combate**: TurnManager, ActionQueue, PlayerCombatActor manejan la mecánica. Los controllers orquestan, no implementan.
+- **Helpers reutilizables**: Métodos en `Core/UI/UIAnimationHelper.cs` y `Core/Audio/AudioManager.cs` deben usarse en vez de duplicar lógica.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Consolidates CLAUDE.md context files** — root CLAUDE.md (auto-loaded every conversation) + combat-specific CLAUDE.md with guardrails. Deprecates dual-agent workflow doc.
- **Extracts CombatFeedbackView** (Phase 1) — WEAK/RESIST/MOMENTUM popups, enemy shake, victory/defeat text, panel flash, hand limit toast. 357 lines.
- **Extracts CardHandView** (Phase 2) — card buttons, click-to-play, attack animation, adaptive layout. 400 lines.
- **CombatUIController reduced from 1473 → 980 lines** (-33%). Retains BuildUI, HUD sync, world visuals.
- **Fixes BossAct1 Regenerate move** — was DrawCards (no-op for enemies), now Block 10.

## Architecture

Both extracted views live on the same GameObject as CombatUIController. They receive UI references via `Initialize()` after `BuildUI()` and subscribe to TurnManager events independently. Neither view mutates gameplay state — presentation only.

Decomposition plan documented in `Docs/dev/COMBAT_ARCHITECTURE.md`. Phases 3-4 (CombatHudView, CombatBackgroundView) remain planned for future PRs.

## Test plan

- [x] Open BattleScene → Play → cards appear, click works, attack animation fires
- [x] Cards without energy are disabled visually
- [x] WEAK/RESIST/MOMENTUM popups appear on type-effective hits
- [x] Enemy shake on damage
- [x] Change World → cards rebuild with [A]/[B] labels
- [x] Boss attacks normally (Regenerate now gives Block instead of no-op)
- [x] Zero console errors
