### PR TITLE
Título: M1 GDD v2 + M-tech Fases 3-4 (CombatHudView + CombatBackgroundView)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ InitTestScene*.unity*
 
 # Auto-generated scenes by play mode tests
 /[Aa]ssets/[Ii]nit[Tt]est[Ss]cene*.unity*
+
+# Claude Code project-local settings
+.claude/

--- a/Assets/Scripts/Gameplay/Combat/CombatBackgroundView.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatBackgroundView.cs
@@ -1,0 +1,182 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace RoguelikeCardBattler.Gameplay.Combat
+{
+    /// <summary>
+    /// Gestiona las capas de fondo del combate (sky y ground): creación en runtime,
+    /// sprites/colores por mundo, y CoverFill. Detecta cambios de mundo mediante
+    /// polling autónomo (compara CurrentWorld cada frame) en lugar de recibir
+    /// callbacks desde CombatHudView o CombatUIController.
+    ///
+    /// Extraído de CombatUIController como parte de la descomposición en componentes
+    /// independientes (ver Docs/dev/COMBAT_ARCHITECTURE.md — Fase 4).
+    ///
+    /// Por qué polling y no callback: en M2 las cartas con efecto WorldSwitch
+    /// cambiarán el mundo vía TurnManager sin pasar por el botón Change World.
+    /// Con polling el view reacciona automáticamente a cualquier origen de cambio,
+    /// sin que haya que coordinar cada nuevo punto de llamada manualmente.
+    /// </summary>
+    public class CombatBackgroundView : MonoBehaviour
+    {
+        // ── SerializeFields: movidos desde CombatUIController ──
+        [Header("Background (Canvas Placeholder)")]
+        [SerializeField] private bool useCanvasBackground = false;
+        [SerializeField] private Color worldASkyColor = new Color(0.07f, 0.12f, 0.3f, 1f);
+        [SerializeField] private Color worldAGroundColor = new Color(0.02f, 0.07f, 0.09f, 1f);
+        [SerializeField] private Color worldBSkyColor = new Color(0.2f, 0.05f, 0.05f, 1f);
+        [SerializeField] private Color worldBGroundColor = new Color(0.09f, 0.02f, 0.04f, 1f);
+        [Header("Background Sprites")]
+        [SerializeField] private Sprite worldASkySprite;
+        [SerializeField] private Sprite worldAGroundSprite;
+        [SerializeField] private Sprite worldBSkySprite;
+        [SerializeField] private Sprite worldBGroundSprite;
+
+        // ── Referencias inyectadas ──
+        private TurnManager _turnManager;
+
+        // ── Estado de fondo ──
+        private Image _skyBackgroundImage;
+        private Image _groundBackgroundImage;
+
+        // Centinela: valor fuera del enum para forzar un refresh en el primer Update.
+        private TurnManager.WorldSide _lastKnownWorld = (TurnManager.WorldSide)(-1);
+        private bool _initialized;
+
+        /// <summary>
+        /// Inyecta el TurnManager para leer CurrentWorld. Llamado por CombatUIController
+        /// antes de TryCreateLayers().
+        /// </summary>
+        public void Initialize(TurnManager turnManager)
+        {
+            _turnManager = turnManager;
+            _initialized = true;
+        }
+
+        /// <summary>
+        /// Crea las capas sky/ground como primeros hijos del canvas (z-order).
+        /// Solo actúa si useCanvasBackground = true. Se llama desde BuildUI() justo
+        /// después de CreateCanvas() para garantizar el orden de capas correcto antes
+        /// de que el resto de la UI se construya encima.
+        /// </summary>
+        public void TryCreateLayers(RectTransform canvasRect)
+        {
+            if (!useCanvasBackground) return;
+
+            GameObject skyGO = new GameObject("BackgroundSky", typeof(RectTransform), typeof(Image));
+            skyGO.transform.SetParent(canvasRect, false);
+            RectTransform sky = skyGO.GetComponent<RectTransform>();
+            sky.anchorMin = new Vector2(0f, 0f);
+            sky.anchorMax = new Vector2(1f, 1f);
+            sky.offsetMin = Vector2.zero;
+            sky.offsetMax = Vector2.zero;
+            sky.pivot = new Vector2(0.5f, 0.5f);
+            sky.SetAsFirstSibling();
+            _skyBackgroundImage = skyGO.GetComponent<Image>();
+            _skyBackgroundImage.color = worldASkyColor;
+            _skyBackgroundImage.raycastTarget = false;
+
+            GameObject groundGO = new GameObject("BackgroundGround", typeof(RectTransform), typeof(Image));
+            groundGO.transform.SetParent(canvasRect, false);
+            RectTransform ground = groundGO.GetComponent<RectTransform>();
+            ground.anchorMin = new Vector2(0f, 0f);
+            ground.anchorMax = new Vector2(1f, 0.45f);
+            ground.offsetMin = Vector2.zero;
+            ground.offsetMax = Vector2.zero;
+            ground.pivot = new Vector2(0.5f, 0.5f);
+            ground.SetSiblingIndex(1);
+            _groundBackgroundImage = groundGO.GetComponent<Image>();
+            _groundBackgroundImage.color = worldAGroundColor;
+            _groundBackgroundImage.raycastTarget = false;
+
+            // Pintado inicial para que el primer frame no muestre el estado centinela.
+            _lastKnownWorld = _turnManager != null ? _turnManager.CurrentWorld : TurnManager.WorldSide.A;
+            UpdateBackgroundVisuals();
+        }
+
+        private void Update()
+        {
+            if (!_initialized || _turnManager == null) return;
+            if (_turnManager.CurrentWorld != _lastKnownWorld)
+            {
+                _lastKnownWorld = _turnManager.CurrentWorld;
+                UpdateBackgroundVisuals();
+            }
+        }
+
+        private void UpdateBackgroundVisuals()
+        {
+            if (_turnManager == null) return;
+
+            bool isWorldA = _turnManager.CurrentWorld == TurnManager.WorldSide.A;
+            Color targetSky = isWorldA ? worldASkyColor : worldBSkyColor;
+            Color targetGround = isWorldA ? worldAGroundColor : worldBGroundColor;
+            Sprite targetSkySprite = isWorldA ? worldASkySprite : worldBSkySprite;
+            Sprite targetGroundSprite = isWorldA ? worldAGroundSprite : worldBGroundSprite;
+
+            if (_skyBackgroundImage != null)
+            {
+                if (targetSkySprite != null)
+                {
+                    _skyBackgroundImage.sprite = targetSkySprite;
+                    _skyBackgroundImage.type = Image.Type.Simple;
+                    _skyBackgroundImage.preserveAspect = true;
+                    _skyBackgroundImage.color = Color.white;
+                    CoverFill(_skyBackgroundImage.rectTransform, targetSkySprite);
+                }
+                else
+                {
+                    _skyBackgroundImage.sprite = null;
+                    _skyBackgroundImage.color = targetSky;
+                }
+            }
+
+            if (_groundBackgroundImage != null)
+            {
+                if (targetGroundSprite != null)
+                {
+                    _groundBackgroundImage.sprite = targetGroundSprite;
+                    _groundBackgroundImage.type = Image.Type.Simple;
+                    _groundBackgroundImage.preserveAspect = true;
+                    _groundBackgroundImage.color = Color.white;
+                    CoverFill(_groundBackgroundImage.rectTransform, targetGroundSprite);
+                }
+                else
+                {
+                    _groundBackgroundImage.sprite = null;
+                    // Sin sprite de ground, transparente para no tapar el sky.
+                    Color transparent = targetGround;
+                    transparent.a = 0f;
+                    _groundBackgroundImage.color = transparent;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Simula "cover": escala manteniendo aspect ratio y recorta lo sobrante
+        /// para llenar el panel sin deformar el sprite.
+        /// </summary>
+        private void CoverFill(RectTransform rectTransform, Sprite sprite)
+        {
+            if (rectTransform == null || sprite == null) return;
+
+            Rect panelRect = rectTransform.rect;
+            float panelAspect = panelRect.width / Mathf.Max(0.0001f, panelRect.height);
+            float spriteAspect = sprite.rect.width / Mathf.Max(0.0001f, sprite.rect.height);
+
+            Vector3 scale;
+            if (spriteAspect > panelAspect)
+            {
+                // Sprite más ancho: escalar por altura, recortar ancho.
+                scale = new Vector3(spriteAspect / panelAspect, 1f, 1f);
+            }
+            else
+            {
+                // Sprite más alto: escalar por ancho, recortar alto.
+                scale = new Vector3(1f, panelAspect / spriteAspect, 1f);
+            }
+
+            rectTransform.localScale = scale;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Combat/CombatBackgroundView.cs.meta
+++ b/Assets/Scripts/Gameplay/Combat/CombatBackgroundView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0a9309db4e10146438cb25c104867998

--- a/Assets/Scripts/Gameplay/Combat/CombatHudView.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatHudView.cs
@@ -1,0 +1,328 @@
+using UnityEngine;
+using UnityEngine.UI;
+using RoguelikeCardBattler.Core.Audio;
+using RoguelikeCardBattler.Gameplay.Enemies;
+
+namespace RoguelikeCardBattler.Gameplay.Combat
+{
+    /// <summary>
+    /// Maneja todos los textos y botones del HUD de combate: energía, momentum,
+    /// HP, bloqueo, intent del enemigo, tipo, mundo, switches, draw/discard, y los
+    /// botones End Turn / Change World. También controla el highlight del avatar
+    /// según el turno activo.
+    ///
+    /// Extraído de CombatUIController como parte de la descomposición en componentes
+    /// independientes (ver Docs/dev/COMBAT_ARCHITECTURE.md — Fase 3).
+    ///
+    /// Este componente es SOLO presentación — nunca muta estado de gameplay.
+    /// A diferencia de CombatFeedbackView, NO se suscribe a eventos: hace polling
+    /// vía Sync() invocado por CombatUIController.Update() cada frame, igual que
+    /// el código original pre-extracción.
+    /// </summary>
+    public class CombatHudView : MonoBehaviour
+    {
+        // ── Referencias inyectadas por CombatUIController.InitializeExtractedViews() ──
+        private TurnManager _turnManager;
+
+        // Textos del HUD
+        private Text _playerEnergyText;
+        private Text _freePlaysText;
+        private Text _playerHpLabel;
+        private Text _enemyHpLabel;
+        private Text _enemyTypeLabel;
+        private Text _playerBlockText;
+        private Text _enemyBlockText;
+        private Text _drawPileText;
+        private Text _discardPileText;
+        private Text _enemyIntentText;
+        private Text _worldLabel;
+        private Text _worldSwitchesText;
+
+        // Botones
+        private Button _endTurnButton;
+        private Text _endTurnLabel;
+        private Button _changeWorldButton;
+        private Text _changeWorldLabel;
+
+        // Imágenes
+        private Image _playerBlockOverlay;
+        private Image _enemyBlockOverlay;
+        private Image _playerAvatarImage;
+        private Image _enemyAvatarImage;
+        private Image _energyPanelImage;
+        private Image _worldPanelImage;
+
+        // Cross-refs
+        private CombatFeedbackView _feedbackView;
+        private CardHandView _cardHandView;
+
+        // Constantes de estilo (movidas desde CombatUIController)
+        private static readonly Color DisabledLabelColor = new Color(0.75f, 0.75f, 0.75f, 0.7f);
+        private static readonly Color WarningLabelColor = new Color(1f, 0.6f, 0.6f, 1f);
+
+        // Color de overlay de bloqueo (inyectado, definido en CombatUIController.SerializeField)
+        private Color _blockOverlayColor;
+
+        // Colores base de avatares, capturados al Initialize.
+        private Color _playerAvatarBaseColor;
+        private Color _enemyAvatarBaseColor;
+
+        private bool _initialized;
+
+        /// <summary>
+        /// Inyecta todas las referencias necesarias. Llamado por CombatUIController
+        /// después de BuildUI(). Sin esta llamada, el componente no hace nada.
+        /// </summary>
+        public void Initialize(
+            TurnManager turnManager,
+            // Textos
+            Text playerEnergyText, Text freePlaysText,
+            Text playerHpLabel, Text enemyHpLabel, Text enemyTypeLabel,
+            Text playerBlockText, Text enemyBlockText,
+            Text drawPileText, Text discardPileText,
+            Text enemyIntentText,
+            Text worldLabel, Text worldSwitchesText,
+            // Botones
+            Button endTurnButton, Text endTurnLabel,
+            Button changeWorldButton, Text changeWorldLabel,
+            // Imágenes
+            Image playerBlockOverlay, Image enemyBlockOverlay,
+            Image playerAvatarImage, Image enemyAvatarImage,
+            Image energyPanelImage, Image worldPanelImage,
+            // Refs cruzadas
+            CombatFeedbackView feedbackView,
+            CardHandView cardHandView,
+            // Constante
+            Color blockOverlayColor)
+        {
+            _turnManager = turnManager;
+            _playerEnergyText = playerEnergyText;
+            _freePlaysText = freePlaysText;
+            _playerHpLabel = playerHpLabel;
+            _enemyHpLabel = enemyHpLabel;
+            _enemyTypeLabel = enemyTypeLabel;
+            _playerBlockText = playerBlockText;
+            _enemyBlockText = enemyBlockText;
+            _drawPileText = drawPileText;
+            _discardPileText = discardPileText;
+            _enemyIntentText = enemyIntentText;
+            _worldLabel = worldLabel;
+            _worldSwitchesText = worldSwitchesText;
+            _endTurnButton = endTurnButton;
+            _endTurnLabel = endTurnLabel;
+            _changeWorldButton = changeWorldButton;
+            _changeWorldLabel = changeWorldLabel;
+            _playerBlockOverlay = playerBlockOverlay;
+            _enemyBlockOverlay = enemyBlockOverlay;
+            _playerAvatarImage = playerAvatarImage;
+            _enemyAvatarImage = enemyAvatarImage;
+            _energyPanelImage = energyPanelImage;
+            _worldPanelImage = worldPanelImage;
+            _feedbackView = feedbackView;
+            _cardHandView = cardHandView;
+            _blockOverlayColor = blockOverlayColor;
+
+            // Capturamos el color base de los avatares aquí — antes vivía en CombatUIController.
+            // Se usa para dim/restore en UpdateAvatarHighlight cada frame.
+            if (_playerAvatarImage != null) _playerAvatarBaseColor = _playerAvatarImage.color;
+            if (_enemyAvatarImage != null) _enemyAvatarBaseColor = _enemyAvatarImage.color;
+
+            // Listeners de los botones: se agregan aquí, no en BuildUI, para mantener
+            // toda la responsabilidad del HUD encapsulada en este view.
+            if (_endTurnButton != null)
+            {
+                _endTurnButton.onClick.AddListener(OnEndTurnButtonClicked);
+            }
+            if (_changeWorldButton != null)
+            {
+                _changeWorldButton.onClick.AddListener(OnChangeWorldButtonClicked);
+            }
+
+            _initialized = true;
+        }
+
+        // ────────────────────────────────────────────────────────
+        // Polling: CombatUIController.Update() llama a Sync() cada frame.
+        // Refleja el estado actual del TurnManager en los textos del HUD.
+        // ────────────────────────────────────────────────────────
+
+        public void Sync()
+        {
+            if (!_initialized || _turnManager == null) return;
+
+            _playerEnergyText.text = $"Energy {_turnManager.PlayerEnergy}/{_turnManager.PlayerMaxEnergy}";
+            if (_freePlaysText != null)
+            {
+                _freePlaysText.text = $"Momentum: {_turnManager.FreePlays}";
+            }
+            if (_worldSwitchesText != null)
+            {
+                string switchesLabel = _turnManager.DebugUnlimitedWorldSwitches
+                    ? "Switches: ∞"
+                    : $"Switches: {_turnManager.WorldSwitchesUsed}/{_turnManager.MaxWorldSwitchesPerCombat}";
+                _worldSwitchesText.text = switchesLabel;
+            }
+            _playerHpLabel.text = $"{_turnManager.PlayerHP}/{_turnManager.PlayerMaxHP}";
+            _enemyHpLabel.text = $"{_turnManager.EnemyHP}/{_turnManager.EnemyMaxHP}";
+            _enemyTypeLabel.text = BuildEnemyTypeLabel();
+            _drawPileText.text = $"Draw: {_turnManager.PlayerDrawPileCount}";
+            _discardPileText.text = $"Discard: {_turnManager.PlayerDiscardPileCount}";
+            _enemyIntentText.text = BuildEnemyIntentLabel();
+            UpdateBlockVisuals(_playerBlockText, _playerBlockOverlay, _turnManager.PlayerBlock);
+            UpdateBlockVisuals(_enemyBlockText, _enemyBlockOverlay, _turnManager.EnemyBlock);
+
+            // Label de mundo: el texto se actualiza acá; los fondos (sky/ground)
+            // los maneja CombatBackgroundView con polling autónomo.
+            if (_worldLabel != null)
+            {
+                string worldLabel = _turnManager.CurrentWorld == TurnManager.WorldSide.A ? "A" : "B";
+                _worldLabel.text = $"World: {worldLabel}";
+            }
+
+            bool playerTurn = _turnManager.IsPlayerTurn();
+            _endTurnButton.interactable = playerTurn && !_turnManager.IsCombatFinished;
+            if (_endTurnLabel != null)
+            {
+                _endTurnLabel.color = _endTurnButton.interactable ? Color.white : DisabledLabelColor;
+            }
+            bool worldSwitchAvailable = _turnManager.DebugUnlimitedWorldSwitches
+                || _turnManager.WorldSwitchesUsed < _turnManager.MaxWorldSwitchesPerCombat;
+            _changeWorldButton.interactable = playerTurn
+                && !_turnManager.IsCombatFinished
+                && worldSwitchAvailable;
+            if (_changeWorldLabel != null)
+            {
+                _changeWorldLabel.color = _changeWorldButton.interactable ? Color.white : DisabledLabelColor;
+            }
+            if (_worldSwitchesText != null)
+            {
+                _worldSwitchesText.color = worldSwitchAvailable ? Color.white : WarningLabelColor;
+            }
+            UpdateAvatarHighlight(playerTurn);
+        }
+
+        // ────────────────────────────────────────────────────────
+        // Highlight de avatares: el del turno activo a color base, el otro atenuado.
+        // ────────────────────────────────────────────────────────
+
+        private void UpdateAvatarHighlight(bool playerTurn)
+        {
+            if (_playerAvatarImage == null || _enemyAvatarImage == null)
+            {
+                return;
+            }
+
+            _playerAvatarImage.color = playerTurn
+                ? _playerAvatarBaseColor
+                : DimColor(_playerAvatarBaseColor, 0.6f);
+
+            _enemyAvatarImage.color = playerTurn
+                ? DimColor(_enemyAvatarBaseColor, 0.6f)
+                : _enemyAvatarBaseColor;
+        }
+
+        private Color DimColor(Color color, float factor)
+        {
+            factor = Mathf.Clamp01(factor);
+            return new Color(color.r * factor, color.g * factor, color.b * factor, color.a);
+        }
+
+        // ────────────────────────────────────────────────────────
+        // Helpers de etiquetas (intent, tipo) y overlay de bloqueo.
+        // ────────────────────────────────────────────────────────
+
+        private string BuildEnemyIntentLabel()
+        {
+            EnemyIntentType intentType = _turnManager?.PlannedEnemyIntentType ?? EnemyIntentType.Unknown;
+            int value = _turnManager?.PlannedEnemyIntentValue ?? 0;
+
+            return intentType switch
+            {
+                EnemyIntentType.Attack when value > 0 => $"ATTACK {value}",
+                EnemyIntentType.Defend when value > 0 => $"DEFEND {value}",
+                EnemyIntentType.Attack => "ATTACK",
+                EnemyIntentType.Defend => "DEFEND",
+                _ => "?"
+            };
+        }
+
+        private string BuildEnemyTypeLabel()
+        {
+            if (_turnManager == null)
+            {
+                return "Type: —";
+            }
+
+            ElementType type = _turnManager.EnemyElementType;
+            return type == ElementType.None ? "Type: —" : $"Type: {type}";
+        }
+
+        private void UpdateBlockVisuals(Text label, Image overlay, int blockValue)
+        {
+            if (label != null)
+            {
+                label.text = $"Block {blockValue}";
+            }
+
+            if (overlay != null)
+            {
+                overlay.color = new Color(
+                    _blockOverlayColor.r,
+                    _blockOverlayColor.g,
+                    _blockOverlayColor.b,
+                    blockValue > 0 ? _blockOverlayColor.a : 0f);
+            }
+        }
+
+        // ────────────────────────────────────────────────────────
+        // Handlers de botones: invocados por los listeners agregados en Initialize.
+        // ────────────────────────────────────────────────────────
+
+        private void OnEndTurnButtonClicked()
+        {
+            if (_turnManager == null || !_turnManager.IsPlayerTurn())
+            {
+                // Click inválido: flash rojo del energy panel para feedback visual.
+                _feedbackView?.FlashPanel(_energyPanelImage);
+                return;
+            }
+
+            _turnManager.EndPlayerTurn();
+        }
+
+        private void OnChangeWorldButtonClicked()
+        {
+            AudioManager.Instance?.PlaySFX(AudioManager.Instance.WorldChangeSFX);
+            if (_turnManager == null)
+            {
+                return;
+            }
+
+            bool changed = _turnManager.TryChangeWorld();
+            // El label de mundo se actualiza en el próximo Sync().
+            // Los fondos (sky/ground) los detecta CombatBackgroundView por polling
+            // autónomo — no hace falta ninguna llamada explícita desde aquí.
+            _cardHandView?.SyncHandButtons(forceRebuild: true);
+            if (!changed)
+            {
+                _feedbackView?.FlashPanel(_worldPanelImage);
+            }
+        }
+
+        // ────────────────────────────────────────────────────────
+        // Cleanup defensivo: removemos los listeners al destruir el componente.
+        // ────────────────────────────────────────────────────────
+
+        private void OnDestroy()
+        {
+            if (_endTurnButton != null)
+            {
+                _endTurnButton.onClick.RemoveListener(OnEndTurnButtonClicked);
+            }
+            if (_changeWorldButton != null)
+            {
+                _changeWorldButton.onClick.RemoveListener(OnChangeWorldButtonClicked);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Combat/CombatHudView.cs.meta
+++ b/Assets/Scripts/Gameplay/Combat/CombatHudView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 65ca08d0fde3a0048b3b4ae0f25ec6c7

--- a/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
-using RoguelikeCardBattler.Core.Audio;
 using RoguelikeCardBattler.Gameplay.Enemies;
 
 namespace RoguelikeCardBattler.Gameplay.Combat
@@ -20,8 +19,6 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         [SerializeField] private Sprite enemySprite;
         [SerializeField] private bool showPlayerBackground = true;
         [SerializeField] private bool showEnemyBackground = true;
-        [Header("Background (Canvas Placeholder)")]
-        [SerializeField] private bool useCanvasBackground = false;
         [SerializeField] private float playerSpriteScale = 1f;
         [SerializeField] private float enemySpriteScale = 0.8f;
         [SerializeField] private float playerSpriteYOffset = -40f;
@@ -29,46 +26,13 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         [SerializeField] private Color blockOverlayColor = new Color(0.2f, 0.6f, 1f, 0.35f);
 
         private Canvas _canvas;
-        private Text _playerEnergyText;
-        private Text _freePlaysText;
-        private Text _playerHpLabel;
-        private Text _enemyHpLabel;
-        private Text _enemyTypeLabel;
-        private Text _playerBlockText;
-        private Text _enemyBlockText;
-        private Text _drawPileText;
-        private Text _discardPileText;
-        private Text _enemyIntentText;
-        private Text _worldLabel;
-        private Text _worldSwitchesText;
-        private Button _endTurnButton;
-        private Button _changeWorldButton;
-        private Text _endTurnLabel;
-        private Text _changeWorldLabel;
-        private Text _handLimitText;
         private RectTransform _handContainer;
         private Image _playerAvatarImage;
         private Image _enemyAvatarImage;
-        private Color _playerAvatarBaseColor;
-        private Color _enemyAvatarBaseColor;
-        private Image _playerBlockOverlay;
-        private Image _enemyBlockOverlay;
-        private Image _skyBackgroundImage;
-        private Image _groundBackgroundImage;
-        [SerializeField] private Color worldASkyColor = new Color(0.07f, 0.12f, 0.3f, 1f);
-        [SerializeField] private Color worldAGroundColor = new Color(0.02f, 0.07f, 0.09f, 1f);
-        [SerializeField] private Color worldBSkyColor = new Color(0.2f, 0.05f, 0.05f, 1f);
-        [SerializeField] private Color worldBGroundColor = new Color(0.09f, 0.02f, 0.04f, 1f);
-        [Header("Background Sprites")]
-        [SerializeField] private Sprite worldASkySprite;
-        [SerializeField] private Sprite worldAGroundSprite;
-        [SerializeField] private Sprite worldBSkySprite;
-        [SerializeField] private Sprite worldBGroundSprite;
         [Header("Hero Animation")]
         [SerializeField] private List<Sprite> heroIdleFrames = new List<Sprite>();
         [SerializeField] private List<Sprite> heroAttackFrames = new List<Sprite>();
         [SerializeField] private float heroAttackFps = 16f;
-        private Text _hitFeedbackText;
         // Tiempos de feedback visual ajustables por diseño sin tocar gameplay.
         [Header("Feedback Timing")]
         [SerializeField, Min(0.1f)] private float hitFeedbackDuration = 0.85f;
@@ -79,11 +43,11 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         [SerializeField] private float enemyHitFps = 16f;
         private SpriteFrameAnimatorUI _enemyAnimator;
         private Image _enemyAvatarSpriteImage;
-        private Image _energyPanelImage;
-        private Image _worldPanelImage;
         // Componentes extraídos que manejan áreas específicas de la UI de combate.
+        private CombatBackgroundView _backgroundView;
         private CombatFeedbackView _feedbackView;
         private CardHandView _cardHandView;
+        private CombatHudView _hudView;
 
         // Layout/estilo del HUD: constantes para mantener jerarquía visual y escalado.
         private const float TopBarMinY = 0.92f;
@@ -97,8 +61,6 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         private static readonly Color ButtonDisabledColor = new Color(0.12f, 0.12f, 0.16f, 0.7f);
         private static readonly Color ButtonPressedColor = new Color(0.35f, 0.35f, 0.45f, 1f);
         private static readonly Color ButtonHighlightColor = new Color(0.3f, 0.3f, 0.4f, 1f);
-        private static readonly Color DisabledLabelColor = new Color(0.75f, 0.75f, 0.75f, 0.7f);
-        private static readonly Color WarningLabelColor = new Color(1f, 0.6f, 0.6f, 1f);
         [SerializeField, Min(0.1f)] private float handLimitToastDuration = 0.7f;
         [SerializeField, Min(0f)] private float handLimitToastCooldown = 0.6f;
 
@@ -152,7 +114,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 return;
             }
 
-            UpdateInfoTexts();
+            _hudView?.Sync();
             _cardHandView?.SyncHandButtons();
             // Hit feedback y hand limit timers delegados a CombatFeedbackView.
         }
@@ -239,10 +201,11 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             _canvas = CreateCanvas("CombatCanvas");
             RectTransform canvasRect = _canvas.GetComponent<RectTransform>();
 
-            if (useCanvasBackground)
-            {
-                CreateBackgroundLayers(canvasRect);
-            }
+            // BackgroundView se crea aquí (no en InitializeExtractedViews) para que
+            // sus capas existan antes que el resto de la UI y queden al fondo del z-order.
+            _backgroundView = gameObject.AddComponent<CombatBackgroundView>();
+            _backgroundView.Initialize(turnManager);
+            _backgroundView.TryCreateLayers(canvasRect);
 
             // Layout principal del HUD:
             // - TopBar: estado de mundo y switches (ligero, lectura rápida).
@@ -280,7 +243,6 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 showPlayerBackground,
                 playerSpriteScale,
                 new Vector2(0f, playerSpriteYOffset));
-            _playerAvatarBaseColor = _playerAvatarImage.color;
 
             Vector2 enemyOffset = new Vector2(0f, enemySpriteYOffset);
             float enemyScale = enemySpriteScale;
@@ -322,7 +284,6 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 showEnemyBackground,
                 enemyScale,
                 enemyOffset);
-            _enemyAvatarBaseColor = _enemyAvatarImage.color;
             InitializeEnemyAnimator();
 
             RectTransform energyPanel = CreatePanel(
@@ -331,9 +292,9 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 new Vector2(0.02f, 0.52f),
                 new Vector2(0.17f, 0.95f),
                 HudPanelColor);
-            _energyPanelImage = energyPanel.GetComponent<Image>();
-            _playerEnergyText = CreateText("PlayerEnergy", energyPanel, "Energy 0/0", 26, TextAnchor.UpperCenter);
-            _freePlaysText = CreateText("FreePlays", energyPanel, "Momentum: 0", 18, TextAnchor.LowerCenter);
+            Image energyPanelImage = energyPanel.GetComponent<Image>();
+            Text playerEnergyText = CreateText("PlayerEnergy", energyPanel, "Energy 0/0", 26, TextAnchor.UpperCenter);
+            Text freePlaysText = CreateText("FreePlays", energyPanel, "Momentum: 0", 18, TextAnchor.LowerCenter);
 
             RectTransform worldPanel = CreatePanel(
                 "WorldPanel",
@@ -341,9 +302,9 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 new Vector2(0.38f, 0.1f),
                 new Vector2(0.62f, 0.9f),
                 HudPanelColor);
-            _worldPanelImage = worldPanel.GetComponent<Image>();
-            _worldLabel = CreateText("WorldLabel", worldPanel, "World: A", 24, TextAnchor.UpperCenter);
-            _worldSwitchesText = CreateText("WorldSwitches", worldPanel, "Switches: 0/0", 18, TextAnchor.LowerCenter);
+            Image worldPanelImage = worldPanel.GetComponent<Image>();
+            Text worldLabel = CreateText("WorldLabel", worldPanel, "World: A", 24, TextAnchor.UpperCenter);
+            Text worldSwitchesText = CreateText("WorldSwitches", worldPanel, "Switches: 0/0", 18, TextAnchor.LowerCenter);
 
             RectTransform handPanel = CreatePanel(
                 "HandPanel",
@@ -362,27 +323,27 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             _handContainer = handPanel;
 
 
-            _playerHpLabel = CreateText("PlayerHpLabel", _playerAvatarImage.rectTransform, "0/0", 24, TextAnchor.LowerCenter);
-            RectTransform playerHpRect = _playerHpLabel.GetComponent<RectTransform>();
+            Text playerHpLabel = CreateText("PlayerHpLabel", _playerAvatarImage.rectTransform, "0/0", 24, TextAnchor.LowerCenter);
+            RectTransform playerHpRect = playerHpLabel.GetComponent<RectTransform>();
             playerHpRect.anchorMin = new Vector2(0.1f, -0.15f);
             playerHpRect.anchorMax = new Vector2(0.9f, -0.02f);
             playerHpRect.offsetMin = Vector2.zero;
             playerHpRect.offsetMax = Vector2.zero;
-            CreateBlockUI(_playerAvatarImage.rectTransform, "Player", out _playerBlockOverlay, out _playerBlockText);
+            CreateBlockUI(_playerAvatarImage.rectTransform, "Player", out Image playerBlockOverlay, out Text playerBlockText);
 
-            _enemyHpLabel = CreateText("EnemyHpLabel", _enemyAvatarImage.rectTransform, "0/0", 24, TextAnchor.LowerCenter);
-            RectTransform enemyHpRect = _enemyHpLabel.GetComponent<RectTransform>();
+            Text enemyHpLabel = CreateText("EnemyHpLabel", _enemyAvatarImage.rectTransform, "0/0", 24, TextAnchor.LowerCenter);
+            RectTransform enemyHpRect = enemyHpLabel.GetComponent<RectTransform>();
             enemyHpRect.anchorMin = new Vector2(0.1f, -0.15f);
             enemyHpRect.anchorMax = new Vector2(0.9f, -0.02f);
             enemyHpRect.offsetMin = Vector2.zero;
             enemyHpRect.offsetMax = Vector2.zero;
-            _enemyTypeLabel = CreateText("EnemyTypeLabel", _enemyAvatarImage.rectTransform, "Type: —", 18, TextAnchor.UpperCenter);
-            RectTransform enemyTypeRect = _enemyTypeLabel.GetComponent<RectTransform>();
+            Text enemyTypeLabel = CreateText("EnemyTypeLabel", _enemyAvatarImage.rectTransform, "Type: —", 18, TextAnchor.UpperCenter);
+            RectTransform enemyTypeRect = enemyTypeLabel.GetComponent<RectTransform>();
             enemyTypeRect.anchorMin = new Vector2(0.05f, 0.76f);
             enemyTypeRect.anchorMax = new Vector2(0.95f, 0.88f);
             enemyTypeRect.offsetMin = Vector2.zero;
             enemyTypeRect.offsetMax = Vector2.zero;
-            CreateBlockUI(_enemyAvatarImage.rectTransform, "Enemy", out _enemyBlockOverlay, out _enemyBlockText);
+            CreateBlockUI(_enemyAvatarImage.rectTransform, "Enemy", out Image enemyBlockOverlay, out Text enemyBlockText);
 
             RectTransform intentPanel = CreatePanel(
                 "EnemyIntentPanel",
@@ -390,72 +351,91 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 new Vector2(0.1f, 1.02f),
                 new Vector2(0.9f, 1.2f),
                 HudPanelColor);
-            _enemyIntentText = CreateText("EnemyIntent", intentPanel, "?", 24, TextAnchor.MiddleCenter);
+            Text enemyIntentText = CreateText("EnemyIntent", intentPanel, "?", 24, TextAnchor.MiddleCenter);
 
-            _hitFeedbackText = CreateText("HitFeedback", battlefield, "", 30, TextAnchor.UpperCenter);
-            RectTransform hitRect = _hitFeedbackText.GetComponent<RectTransform>();
+            Text hitFeedbackText = CreateText("HitFeedback", battlefield, "", 30, TextAnchor.UpperCenter);
+            RectTransform hitRect = hitFeedbackText.GetComponent<RectTransform>();
             hitRect.anchorMin = new Vector2(0.35f, 0.92f);
             hitRect.anchorMax = new Vector2(0.65f, 0.99f);
             hitRect.offsetMin = Vector2.zero;
             hitRect.offsetMax = Vector2.zero;
-            _hitFeedbackText.gameObject.SetActive(false);
+            hitFeedbackText.gameObject.SetActive(false);
 
             // Toast para límite de mano: visible y centrado en el battlefield.
-            _handLimitText = CreateText("HandLimitText", battlefield, "", 28, TextAnchor.UpperCenter);
-            _handLimitText.fontStyle = FontStyle.Bold;
-            RectTransform handLimitRect = _handLimitText.GetComponent<RectTransform>();
+            Text handLimitText = CreateText("HandLimitText", battlefield, "", 28, TextAnchor.UpperCenter);
+            handLimitText.fontStyle = FontStyle.Bold;
+            RectTransform handLimitRect = handLimitText.GetComponent<RectTransform>();
             handLimitRect.anchorMin = new Vector2(0.35f, 0.86f);
             handLimitRect.anchorMax = new Vector2(0.65f, 0.93f);
             handLimitRect.offsetMin = Vector2.zero;
             handLimitRect.offsetMax = Vector2.zero;
-            _handLimitText.color = Color.white;
-            _handLimitText.gameObject.SetActive(false);
+            handLimitText.color = Color.white;
+            handLimitText.gameObject.SetActive(false);
 
-            _drawPileText = CreateCornerCounter(bottomBar, new Vector2(0.02f, 0.05f), new Vector2(0.14f, 0.32f), "Draw: 0");
-            _discardPileText = CreateCornerCounter(bottomBar, new Vector2(0.84f, 0.05f), new Vector2(0.14f, 0.32f), "Discard: 0");
+            Text drawPileText = CreateCornerCounter(bottomBar, new Vector2(0.02f, 0.05f), new Vector2(0.14f, 0.32f), "Draw: 0");
+            Text discardPileText = CreateCornerCounter(bottomBar, new Vector2(0.84f, 0.05f), new Vector2(0.14f, 0.32f), "Discard: 0");
 
-            _endTurnButton = CreateButton(
+            Button endTurnButton = CreateButton(
                 "EndTurnButton",
                 bottomBar,
                 new Vector2(0.82f, 0.52f),
                 new Vector2(0.98f, 0.95f),
                 "End Turn");
-            _endTurnLabel = _endTurnButton.GetComponentInChildren<Text>();
-            _endTurnButton.onClick.AddListener(OnEndTurnButtonClicked);
-            ApplyButtonStyle(_endTurnButton);
+            Text endTurnLabel = endTurnButton.GetComponentInChildren<Text>();
+            ApplyButtonStyle(endTurnButton);
 
-            _changeWorldButton = CreateButton(
+            Button changeWorldButton = CreateButton(
                 "ChangeWorldButton",
                 topBar,
                 new Vector2(0.74f, 0.1f),
                 new Vector2(0.98f, 0.9f),
                 "Change World");
-            _changeWorldLabel = _changeWorldButton.GetComponentInChildren<Text>();
-            _changeWorldButton.onClick.AddListener(OnChangeWorldButtonClicked);
-            ApplyButtonStyle(_changeWorldButton);
+            Text changeWorldLabel = changeWorldButton.GetComponentInChildren<Text>();
+            ApplyButtonStyle(changeWorldButton);
 
             InitializePlayerAnimator();
-            UpdateWorldVisuals();
-            InitializeExtractedViews();
+            InitializeExtractedViews(
+                hitFeedbackText, handLimitText,
+                energyPanelImage, worldPanelImage,
+                playerEnergyText, freePlaysText,
+                playerHpLabel, enemyHpLabel, enemyTypeLabel,
+                playerBlockText, enemyBlockText,
+                drawPileText, discardPileText,
+                enemyIntentText,
+                worldLabel, worldSwitchesText,
+                endTurnButton, endTurnLabel,
+                changeWorldButton, changeWorldLabel,
+                playerBlockOverlay, enemyBlockOverlay);
         }
 
         /// <summary>
-        /// Crea e inicializa los componentes extraídos (CombatFeedbackView, CardHandView).
-        /// Les pasa las referencias de UI que necesitan después de BuildUI().
+        /// Crea e inicializa los componentes extraídos (CombatFeedbackView, CardHandView,
+        /// CombatHudView). Les pasa las referencias de UI que necesitan después de BuildUI().
         /// </summary>
-        private void InitializeExtractedViews()
+        private void InitializeExtractedViews(
+            Text hitFeedbackText, Text handLimitText,
+            Image energyPanelImage, Image worldPanelImage,
+            Text playerEnergyText, Text freePlaysText,
+            Text playerHpLabel, Text enemyHpLabel, Text enemyTypeLabel,
+            Text playerBlockText, Text enemyBlockText,
+            Text drawPileText, Text discardPileText,
+            Text enemyIntentText,
+            Text worldLabel, Text worldSwitchesText,
+            Button endTurnButton, Text endTurnLabel,
+            Button changeWorldButton, Text changeWorldLabel,
+            Image playerBlockOverlay, Image enemyBlockOverlay)
         {
             _feedbackView = gameObject.AddComponent<CombatFeedbackView>();
             _feedbackView.Initialize(
                 turnManager,
-                _hitFeedbackText,
-                _handLimitText,
-                _playerHpLabel,
+                hitFeedbackText,
+                handLimitText,
+                playerHpLabel,
                 _playerAvatarImage,
                 _enemyAvatarImage,
                 _enemyAvatarSpriteImage,
-                _energyPanelImage,
-                _worldPanelImage,
+                energyPanelImage,
+                worldPanelImage,
                 _enemyAnimator,
                 _canvas,
                 uiFont,
@@ -469,8 +449,25 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 _handContainer,
                 _playerAnimator,
                 _feedbackView,
-                _energyPanelImage,
+                energyPanelImage,
                 uiFont);
+
+            _hudView = gameObject.AddComponent<CombatHudView>();
+            _hudView.Initialize(
+                turnManager,
+                playerEnergyText, freePlaysText,
+                playerHpLabel, enemyHpLabel, enemyTypeLabel,
+                playerBlockText, enemyBlockText,
+                drawPileText, discardPileText,
+                enemyIntentText,
+                worldLabel, worldSwitchesText,
+                endTurnButton, endTurnLabel,
+                changeWorldButton, changeWorldLabel,
+                playerBlockOverlay, enemyBlockOverlay,
+                _playerAvatarImage, _enemyAvatarImage,
+                energyPanelImage, worldPanelImage,
+                _feedbackView, _cardHandView,
+                blockOverlayColor);
         }
         private Text CreateCornerCounter(RectTransform parent, Vector2 anchorMin, Vector2 size, string label)
         {
@@ -500,27 +497,6 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             scaler.matchWidthOrHeight = 0.5f;
 
             return canvas;
-        }
-
-        private void CreateBackgroundLayers(RectTransform canvasRect)
-        {
-            RectTransform sky = CreatePanel(
-                "BackgroundSky",
-                canvasRect,
-                new Vector2(0f, 0f),
-                new Vector2(1f, 1f),
-                worldASkyColor);
-            sky.SetAsFirstSibling();
-            _skyBackgroundImage = sky.GetComponent<Image>();
-
-            RectTransform ground = CreatePanel(
-                "BackgroundGround",
-                canvasRect,
-                new Vector2(0, 0),
-                new Vector2(1, 0.45f),
-                worldAGroundColor);
-            ground.SetSiblingIndex(1);
-            _groundBackgroundImage = ground.GetComponent<Image>();
         }
 
         private RectTransform CreatePanel(string name, RectTransform parent, Vector2 anchorMin, Vector2 anchorMax, Color? background = null)
@@ -654,92 +630,6 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             blockRect.offsetMax = Vector2.zero;
         }
 
-        // CreateCardButton extraído a CardHandView.
-
-        private void OnEndTurnButtonClicked()
-        {
-            if (turnManager == null || !turnManager.IsPlayerTurn())
-            {
-                _feedbackView?.FlashPanel(_energyPanelImage);
-                return;
-            }
-
-            turnManager.EndPlayerTurn();
-        }
-
-        // OnCardButtonClicked extraído a CardHandView.
-
-        private void UpdateInfoTexts()
-        {
-            _playerEnergyText.text = $"Energy {turnManager.PlayerEnergy}/{turnManager.PlayerMaxEnergy}";
-            if (_freePlaysText != null)
-            {
-                _freePlaysText.text = $"Momentum: {turnManager.FreePlays}";
-            }
-            if (_worldSwitchesText != null)
-            {
-                string switchesLabel = turnManager.DebugUnlimitedWorldSwitches
-                    ? "Switches: ∞"
-                    : $"Switches: {turnManager.WorldSwitchesUsed}/{turnManager.MaxWorldSwitchesPerCombat}";
-                _worldSwitchesText.text = switchesLabel;
-            }
-            _playerHpLabel.text = $"{turnManager.PlayerHP}/{turnManager.PlayerMaxHP}";
-            _enemyHpLabel.text = $"{turnManager.EnemyHP}/{turnManager.EnemyMaxHP}";
-            _enemyTypeLabel.text = BuildEnemyTypeLabel();
-            _drawPileText.text = $"Draw: {turnManager.PlayerDrawPileCount}";
-            _discardPileText.text = $"Discard: {turnManager.PlayerDiscardPileCount}";
-            _enemyIntentText.text = BuildEnemyIntentLabel();
-            UpdateBlockVisuals(_playerBlockText, _playerBlockOverlay, turnManager.PlayerBlock);
-            UpdateBlockVisuals(_enemyBlockText, _enemyBlockOverlay, turnManager.EnemyBlock);
-            UpdateWorldVisuals();
-
-            bool playerTurn = turnManager.IsPlayerTurn();
-            _endTurnButton.interactable = playerTurn && !turnManager.IsCombatFinished;
-            if (_endTurnLabel != null)
-            {
-                _endTurnLabel.color = _endTurnButton.interactable ? Color.white : DisabledLabelColor;
-            }
-            bool worldSwitchAvailable = turnManager.DebugUnlimitedWorldSwitches
-                || turnManager.WorldSwitchesUsed < turnManager.MaxWorldSwitchesPerCombat;
-            _changeWorldButton.interactable = playerTurn
-                && !turnManager.IsCombatFinished
-                && worldSwitchAvailable;
-            if (_changeWorldLabel != null)
-            {
-                _changeWorldLabel.color = _changeWorldButton.interactable ? Color.white : DisabledLabelColor;
-            }
-            if (_worldSwitchesText != null)
-            {
-                _worldSwitchesText.color = worldSwitchAvailable ? Color.white : WarningLabelColor;
-            }
-            UpdateAvatarHighlight(playerTurn);
-        }
-
-        private void UpdateAvatarHighlight(bool playerTurn)
-        {
-            if (_playerAvatarImage == null || _enemyAvatarImage == null)
-            {
-                return;
-            }
-
-            _playerAvatarImage.color = playerTurn
-                ? _playerAvatarBaseColor
-                : DimColor(_playerAvatarBaseColor, 0.6f);
-
-            _enemyAvatarImage.color = playerTurn
-                ? DimColor(_enemyAvatarBaseColor, 0.6f)
-                : _enemyAvatarBaseColor;
-        }
-
-        private Color DimColor(Color color, float factor)
-        {
-            factor = Mathf.Clamp01(factor);
-            return new Color(color.r * factor, color.g * factor, color.b * factor, color.a);
-        }
-
-        // SetCardButtonsInteractable, SyncHandButtons, IsHandCacheValid,
-        // RebuildHandButtons extraídos a CardHandView.
-
         private void InitializePlayerAnimator()
         {
             if (_playerAvatarImage == null)
@@ -798,71 +688,6 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             _enemyAnimator.Configure(_enemyAvatarSpriteImage, new List<Sprite>(), enemyHitFrames, enemyHitFps);
         }
 
-        // BuildCardLabel extraído a CardHandView.
-
-        private string BuildEnemyIntentLabel()
-        {
-            EnemyIntentType intentType = turnManager?.PlannedEnemyIntentType ?? EnemyIntentType.Unknown;
-            int value = turnManager?.PlannedEnemyIntentValue ?? 0;
-
-            return intentType switch
-            {
-                EnemyIntentType.Attack when value > 0 => $"ATTACK {value}",
-                EnemyIntentType.Defend when value > 0 => $"DEFEND {value}",
-                EnemyIntentType.Attack => "ATTACK",
-                EnemyIntentType.Defend => "DEFEND",
-                _ => "?"
-            };
-        }
-
-        private string BuildEnemyTypeLabel()
-        {
-            if (turnManager == null)
-            {
-                return "Type: —";
-            }
-
-            ElementType type = turnManager.EnemyElementType;
-            return type == ElementType.None ? "Type: —" : $"Type: {type}";
-        }
-
-        private void UpdateBlockVisuals(Text label, Image overlay, int blockValue)
-        {
-            if (label != null)
-            {
-                label.text = $"Block {blockValue}";
-            }
-
-            if (overlay != null)
-            {
-                overlay.color = new Color(
-                    blockOverlayColor.r,
-                    blockOverlayColor.g,
-                    blockOverlayColor.b,
-                    blockValue > 0 ? blockOverlayColor.a : 0f);
-            }
-        }
-
-        private void OnChangeWorldButtonClicked()
-        {
-            AudioManager.Instance?.PlaySFX(AudioManager.Instance.WorldChangeSFX);
-            if (turnManager == null)
-            {
-                return;
-            }
-
-            bool changed = turnManager.TryChangeWorld();
-            UpdateWorldVisuals();
-            _cardHandView?.SyncHandButtons(forceRebuild: true);
-            if (!changed)
-            {
-                _feedbackView?.FlashPanel(_worldPanelImage);
-            }
-        }
-
-        // OnPlayerHandLimitReached, HandLimitCooldownRoutine extraídos a CombatFeedbackView.
-        // UpdateHandLayout extraído a CardHandView.
-
         private void ApplyButtonStyle(Button button)
         {
             if (button == null)
@@ -880,101 +705,6 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             button.colors = colors;
         }
 
-        // FlashPanel y FlashPanelRoutine extraídos a CombatFeedbackView.
-
-        private void UpdateWorldVisuals()
-        {
-            if (turnManager == null || _worldLabel == null)
-            {
-                return;
-            }
-
-            string worldLabel = turnManager.CurrentWorld == TurnManager.WorldSide.A ? "A" : "B";
-            _worldLabel.text = $"World: {worldLabel}";
-
-            bool isWorldA = turnManager.CurrentWorld == TurnManager.WorldSide.A;
-            Color targetSky = isWorldA ? worldASkyColor : worldBSkyColor;
-            Color targetGround = isWorldA ? worldAGroundColor : worldBGroundColor;
-            Sprite targetSkySprite = isWorldA ? worldASkySprite : worldBSkySprite;
-            Sprite targetGroundSprite = isWorldA ? worldAGroundSprite : worldBGroundSprite;
-
-            if (_skyBackgroundImage != null)
-            {
-                if (targetSkySprite != null)
-                {
-                    _skyBackgroundImage.sprite = targetSkySprite;
-                    _skyBackgroundImage.type = Image.Type.Simple;
-                    _skyBackgroundImage.preserveAspect = true;
-                    _skyBackgroundImage.color = Color.white;
-                    CoverFill(_skyBackgroundImage.rectTransform, targetSkySprite);
-                }
-                else
-                {
-                    _skyBackgroundImage.sprite = null;
-                    _skyBackgroundImage.color = targetSky;
-                }
-            }
-
-            if (_groundBackgroundImage != null)
-            {
-                if (targetGroundSprite != null)
-                {
-                    _groundBackgroundImage.sprite = targetGroundSprite;
-                    _groundBackgroundImage.type = Image.Type.Simple;
-                    _groundBackgroundImage.preserveAspect = true;
-                    _groundBackgroundImage.color = Color.white;
-                    CoverFill(_groundBackgroundImage.rectTransform, targetGroundSprite);
-                }
-                else
-                {
-                    _groundBackgroundImage.sprite = null;
-                    // Si no hay sprite de ground, lo dejamos transparente para no tapar el sky.
-                    Color transparent = targetGround;
-                    transparent.a = 0f;
-                    _groundBackgroundImage.color = transparent;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Ajusta el rect transform para simular "cover": escala manteniendo aspect
-        /// y recorta lo sobrante para llenar el panel.
-        /// </summary>
-        private void CoverFill(RectTransform rectTransform, Sprite sprite)
-        {
-            if (rectTransform == null || sprite == null)
-            {
-                return;
-            }
-
-            Rect panelRect = rectTransform.rect;
-            float panelAspect = panelRect.width / Mathf.Max(0.0001f, panelRect.height);
-            float spriteAspect = sprite.rect.width / Mathf.Max(0.0001f, sprite.rect.height);
-
-            Vector3 scale = Vector3.one;
-            if (spriteAspect > panelAspect)
-            {
-                // Sprite más "ancho": escalar por altura, recortar ancho.
-                float heightScale = 1f;
-                float widthScale = spriteAspect / panelAspect;
-                scale = new Vector3(widthScale, heightScale, 1f);
-            }
-            else
-            {
-                // Sprite más "alto": escalar por ancho, recortar alto.
-                float widthScale = 1f;
-                float heightScale = panelAspect / spriteAspect;
-                scale = new Vector3(widthScale, heightScale, 1f);
-            }
-
-            rectTransform.localScale = scale;
-        }
-
-        // ShowVictoryText, ShowDefeatText, ShowCombatResultText extraídos a CombatFeedbackView.
-        // Acceso público via: _feedbackView.ShowVictoryText() / _feedbackView.ShowDefeatText()
-
-        // OnDestroy: tweens de card buttons limpiados por CardHandView.OnDestroy(),
-        // tweens de avatares/labels limpiados por CombatFeedbackView.OnDestroy().
     }
 }
 

--- a/Docs/design/DESIGN_DECISIONS.md
+++ b/Docs/design/DESIGN_DECISIONS.md
@@ -1,249 +1,90 @@
-# DESIGN DECISIONS — Decisiones Abiertas y Propuestas
+# DESIGN DECISIONS — Decisiones de Diseno
 
-> Este documento recoge las decisiones de diseno que estan EN DISCUSION.
-> Nada aqui es definitivo hasta que se pruebe y se mueva a GOLDEN_RULES.md.
-> Formato: Pregunta -> Opciones -> Recomendacion -> Estado
-
----
-
-## DD-001: Cuando y como se cambia de mundo
-
-### Pregunta central
-El cambio de mundo es la mecanica diferenciadora. Pero: cuando el jugador decide cambiar? Que lo motiva? Actualmente hay 1 switch por combate, pero no hay un detonante claro que haga que el momento del cambio importe.
-
-### Opciones
-
-**A) Cambio dinamico (multiples cambios por combate)**
-- El jugador puede cambiar varias veces si cumple condiciones (ej: encadenar SuperEficaces)
-- Pro: combos explosivos, se siente activo y recompensa jugar bien
-- Contra: puede volverse "spam" optimo, pierde peso estrategico si es muy facil
-- Riesgo: si cambiar es frecuente y barato, deja de ser una decision
-
-**B) Cambio unico e irreversible**
-- 1 cambio por combate, no se puede volver
-- Pro: decision de altisimo peso, define el combate entero
-- Contra: puede sentirse limitante, el jugador se queda "atrapado" si cambia mal
-- Riesgo: si el jugador cambia en mal momento, el combate se vuelve injusto
-
-**C) Hibrido: 1 cambio gratis + cambios extra por Momentum (RECOMENDADO)**
-- Empiezas con 1 switch gratuito por combate
-- Encadenar SuperEficaces (Momentum) desbloquea switches adicionales
-- Loop: buen mazo -> explotas tipos -> ganas momentum -> cambias mundo -> explotas OTROS tipos -> mas momentum
-- Pro: el cambio de mundo interactua directamente con tipos y Momentum, creando un loop de recompensa
-- Contra: requiere balanceo fino del costo en Momentum para un switch extra
-- Esto responde "cuando cambio?" -> cambias cuando puedes encadenar
-
-### Estado: POR DECIDIR
-La implementacion actual (1 switch fijo) sirve como placeholder. Hay que prototipar la opcion C y testear si el loop se siente bien.
+> Este documento recoge las decisiones de diseno que estan EN DISCUSION o CERRADAS.
+> Cuando una decision se cierra y se cristaliza, su regla resultante se mueve a GOLDEN_RULES.md.
+> Formato: pregunta -> opciones -> resolucion / estado.
 
 ---
 
-## DD-002: Que hace que el sistema de tipos sea unico (no solo Pokemon)
+## Estado actual
 
-### Problema
-6 tipos con multiplicadores 1.5x/1.0x/0.75x suena a Pokemon simplificado. Necesita un "twist" que lo haga propio.
+GDD v2 (procesado el 2026-04-28) cerro **DD-001 a DD-016**. Las reglas resultantes viven en `GOLDEN_RULES.md`. En la revision post-GDD se abrieron **DD-017 a DD-021** y se cerraron todas excepto DD-017.
 
-### Lo que ya tenemos a favor
-- La tabla ES ASIMETRICA: Rojo->Amarillo es SuperEficaz, pero Amarillo->Rojo es Neutro. Esto ya es diferente a Pokemon y significa que EL ORDEN IMPORTA.
-- Las cartas duales significan que una carta puede tener tipo Rojo en Mundo A y tipo Morado en Mundo B. El jugador puede "elegir" con que tipo atacar cambiando de mundo.
-- Combinado con el cambio de mundo, el sistema de tipos se vuelve un puzzle: en que mundo estoy? que tipo tiene el enemigo? con que lado de mis cartas duales puedo encadenar SuperEficaces?
-
-### Preguntas abiertas
-
-**El jugador ve el tipo del enemigo antes del combate?**
-- Recomendacion: SI, en el nodo del mapa. Mostrar icono del tipo del enemigo.
-- Razon: permite que la decision del mapa sea estrategica ("voy por este camino porque tengo cartas fuertes contra ese tipo")
-- Opcion alternativa: solo mostrar para enemigos ya enfrentados en runs anteriores (como un bestiario que se desbloquea)
-
-**Que pasa con mazo mono-tipo?**
-- Mono-tipo es viable si el jugador elige combates donde su tipo es fuerte
-- El mapa deberia forzar 1-2 combates donde no lo sea (elites, boss)
-- Las cartas duales naturalmente desincentivan mono-tipo porque cada carta tiene DOS tipos
-- Recomendacion: no prohibir mono-tipo, pero que el mapa y los bosses lo castiguen naturalmente
-
-**Sistema de afinidades del heroe (del GDD original)**
-- Al inicio de cada run, el jugador elige 2 atributos principales
-- Cartas de esos tipos obtienen bonificaciones
-- El heroe es mas vulnerable a tipos que contrarrestan sus atributos
-- Estado: NO IMPLEMENTADO. Decidir si se implementa o si las cartas duales ya cubren este espacio estrategico.
-
-### Estado: PARCIALMENTE IMPLEMENTADO
-La tabla de tipos y el Momentum funcionan. Falta decidir afinidades del heroe y visibilidad de tipos en mapa.
+**Hoy queda abierta una sola decision: DD-017.**
 
 ---
 
-## DD-003: Recompensas post-combate
+## Cerradas por GDD v2 (2026-04-28)
 
-### Pregunta
-Cuantas cartas se ofrecen? Se puede skipear? Hay duplicados?
-
-### Propuesta base
-- 3 cartas a elegir despues de cada combate
-- El jugador elige 1 o puede skipear (no tomar ninguna)
-- Skip es una decision valida: a veces un mazo mas pequeno es mejor
-- Al menos 1 de las 3 cartas deberia ser dual (para reforzar la mecanica central)
-- Duplicados posibles pero con peso reducido
-- Tambien se otorga oro
-
-### Pool de cartas
-- En Slay the Spire el pool depende del personaje
-- En nuestro juego propuesta: el pool depende del PAR DE MUNDOS de la run
-- Ejemplo: mundos Medieval/Cyberpunk tienen un pool, mundos Futurista/Retro otro
-- Esto permite que cada combinacion de mundos se sienta como un "personaje" diferente
-- Cada pool favorece builds y sinergias distintas
-
-### Estado: POR IMPLEMENTAR
-Hay issue #27 para shop minimo. Las recompensas post-combate necesitan su propio issue.
+| DD  | Tema | Resolucion (resumen) | Donde vive |
+|-----|------|----------------------|------------|
+| DD-001 | Cambio de mundo y sistema de cargas | Momentum se elimina. Sistema unico: Contador de Estilo. +1 carga por SuperEficaz hecho, -1 por SuperEficaz recibido, 5 cargas = 1 cambio extra (no acumulable). 1 cambio gratis base por combate; cambios adicionales por cargas, cartas o items | GOLDEN_RULES §2, §4 |
+| DD-002 | Sistema de tipos | El jugador elige 2 tipos al inicio (uno por mundo). El tipo activo del jugador = tipo del mundo activo. El pool de cartas se filtra por los 2 tipos elegidos. Mazo inicial: 10 cartas exactas | GOLDEN_RULES §3, §5 |
+| DD-003 | Sistema de tipos | Redundante: cubierta por DD-002 | — |
+| DD-004 | Diseno de bosses | 2 tipos por boss (1 SuperEficaz contra el jugador, 1 debilidad). Mecanicas unicas que interactuan con el cambio de mundo. Fase 2 obligatoria al 50% HP. Pueden aplicar debuffs unicos vinculados al tema (Sangrado en Medieval, Virus en Cyberpunk) | GOLDEN_RULES §6 |
+| DD-005 | Sistema de nodos | 6 tipos: Combat, Elite, Boss, Shop, Campfire, Event. Mapa scroll lateral generado por seed. Eventos multidimensionales permiten elegir mundo | GOLDEN_RULES §7 |
+| DD-006 | Progresion roguelite | XP entre runs. Desbloqueos amplian opciones (cartas, Retazos), nunca poder | GOLDEN_RULES §11 |
+| DD-007 | Atributos del heroe | Cerrada via DD-002. El "atributo del heroe" es el tipo activo, derivado del mundo en que esta. No hay sistema separado | GOLDEN_RULES §3 |
+| DD-008 | Pool de cartas | Cerrada via DD-002. El pool se filtra por los 2 tipos elementales elegidos al inicio del run, no por par narrativo de mundos | GOLDEN_RULES §5 |
+| DD-009 | Economia | Combate 10-20, Elite 30-50, Boss 100. No persiste entre runs. Usos: comprar cartas/Retazos/consumibles, eliminar cartas | GOLDEN_RULES §8 |
+| DD-010 | Tamano del mazo | Inicio 10 (exactas), Acto 1 objetivo 15-20, fin de run objetivo 20-25. Sin limite duro | GOLDEN_RULES §5 |
+| DD-011 | Dificultad y actos | HP base 70. 3 actos. Acto 1: 1 tipo / patrones simples. Acto 2: 2 tipos / fases / transdimensionales. Acto 3: multifase / ancla / bosses que interactuan con cambio | GOLDEN_RULES §9 |
+| DD-012 | Retazos | Pasivos persistentes. 3 categorias: neutros, de cambio, de mundo. Sin limite. Obtencion: Elite (garantizado), Boss (unico), Tienda, Eventos. (Retazos de cambio en contenido base: ver DD-017) | GOLDEN_RULES §10 |
+| DD-013 | Mejora de cartas | 1 mejora por carta por run. En cartas duales mejora ambos lados. Hoguera (heal vs upgrade) y eventos especiales | GOLDEN_RULES §5 |
+| DD-014 | Enemigos transdimensionales | 2 categorias: estandar (cambian tipo activo con el mundo) y ancla (tipo fijo, no reaccionan). La frase "tres categorias" del GDD era ruido de transcripcion | GOLDEN_RULES §6 |
+| DD-016 | Meta-progresion | XP por progreso. Desbloqueos: cartas duales nuevas, Retazos nuevos, vinetas narrativas. Curva: rapido al inicio, lento despues con mayor impacto | GOLDEN_RULES §11 |
 
 ---
 
-## DD-004: Diseno de bosses
+## Cerradas en revision post-GDD (2026-04-28)
 
-### Pregunta
-Que hace especial a un boss? Tiene fases? Interactua con el cambio de mundo?
-
-### Ideas (no probadas)
-- **Fases**: el boss cambia patron de IA al bajar de cierto % de HP
-- **Interaccion con mundos**: el boss podria forzar un cambio de mundo, o bloquear el cambio temporalmente
-- **Tipo variable**: el boss cambia su tipo elemental entre fases, obligando al jugador a adaptar su estrategia
-- **Ataques exclusivos por mundo**: ciertos ataques del boss solo ocurren en Mundo A o B
-- **Boss "ancla"**: no cambia nunca de tipo, es un check de si tu mazo tiene suficiente versatilidad
-
-### Principio de diseno
-- El boss debe ser el examen final del acto
-- Debe testear si el jugador construyo un mazo equilibrado
-- Debe interactuar con la mecanica de mundos duales de forma que no sea opcional
-
-### Estado: POR DISENAR
-El boss de Acto 1 existe como placeholder. El diseno de fases y mecanicas necesita su propio documento cuando se aborde.
+| DD  | Tema | Resolucion |
+|-----|------|------------|
+| DD-018 | Multiplicador de dano enemigo SuperEficaz contra el tipo activo del jugador | **Si**: el dano se multiplica x1.5 (igual que dano del jugador). El multiplicador es configurable (constante en codigo, ajustable sin cambiar logica). Esto reabre la regla anterior de "efectividad solo al dano jugador->enemigo": ahora aplica en ambas direcciones | GOLDEN_RULES §3 |
+| DD-019 | Sangrado y Virus: genericos o exclusivos del boss | **Exclusivos del Boss Acto 1** (Costura Maldita / UNIT-RB7). No son debuffs genericos del juego. Si en futuros bosses se necesita el mismo concepto, se reevalua entonces | GOLDEN_RULES §6 |
+| DD-020 | Carta especial dual inicial: filtrada o pool fijo | **Filtrada** por los 2 tipos elementales que el jugador elige al inicio del run | GOLDEN_RULES §5 |
+| DD-021 | Representacion del MCguffin de quests | **Diferida** al diseno de M4 (Eventos). No es bloqueante para diseno actual. Se decide cuando se ataque el sistema de eventos | — |
 
 ---
 
-## DD-005: Nodos Shop, Event y Campfire
+## Abiertas
 
-### Pregunta
-Que se hace en cada uno? Como complementan (no compiten con) el sistema de tipos y mundos?
+### DD-017: Retazos de cambio en contenido base o post-launch
 
-### Propuestas
+#### Pregunta
+El GDD v2 (linea 129, dentro de DD-012) define 3 categorias de Retazos: neutros, de cambio y de mundo. Para los **Retazos de cambio** (los que se activan cada vez que el jugador ejecuta un cambio de mundo) el GDD textualmente dice: *"Estado actual: pendiente de decision de implementacion para contenido base"*.
 
-**Shop (Tienda)**
-- Comprar cartas especificas (control sobre el mazo — el jugador elige exactamente que tipo quiere)
-- Eliminar cartas (refinar estrategia — un mazo mas fino es mas consistente)
-- Comprar reliquias (pasivas que alteran reglas)
-- Posible: cartas exclusivas de tienda que no salen como recompensa
-- Complementa tipos: el jugador puede comprar cartas del tipo que le falta
+La pregunta es: cuando se implemente el sistema de Retazos (M3), ¿incluimos Retazos de cambio en el pool del **contenido base** del juego, o los dejamos para **contenido posterior** junto con los Retazos de mundo (que ya estan diferidos)?
 
-**Campfire (Hoguera)**
-- Opcion A: Curar HP (seguridad)
-- Opcion B: Mejorar una carta (subir dano, bajar costo, anadir efecto)
-- Posible opcion C: Transformar el tipo de una carta (refuerza sistema de tipos)
-- Decision siempre: salud inmediata vs poder a largo plazo
-- Complementa mundos: mejorar una carta dual mejora AMBOS lados
+#### Opciones
 
-**Event (Evento)**
-- Encuentros narrativos con los hermanos discutiendo
-- Decisiones con consecuencias mecanicas:
-  - "Ganar una reliquia pero perder HP"
-  - "Cambiar el tipo de una carta"
-  - "Enfrentar un mini-combate opcional por recompensa rara"
-  - "Sacrificar una carta para mejorar otra"
-- Complementa narrativa: los hermanos proponen opciones desde sus mundos
-- Complementa tipos: algunos eventos permiten manipular tipos del mazo
+**A) Si, incluir Retazos de cambio en el contenido base.**
+- Pro: refuerzan la mecanica diferenciadora del juego (el cambio de mundo) desde el primer run.
+- Pro: dan otro vector de identidad de build ("build basada en cambiar mucho").
+- Contra: requiere disenar y balancear ~10-15 Retazos de cambio adicionales para que la categoria tenga variedad.
+- Contra: aumenta complejidad cognitiva del primer run.
 
-### Por que no compiten
-- Shop da CONTROL (eliges que comprar)
-- Campfire da MEJORA (fortaleces lo que tienes)
-- Event da RIESGO/RECOMPENSA (apuestas por algo mejor)
-- Combate da CARTAS NUEVAS + ORO (expandes el mazo)
-- Cada uno llena un rol diferente en la construccion del mazo
+**B) No, dejarlos para contenido posterior.**
+- Pro: M3 entrega un sistema completo de Retazos sin sobrecargar el balance.
+- Pro: los Retazos de cambio quedan como "novedad" para una primera expansion / actualizacion.
+- Contra: el primer run no muestra una de las categorias mas vinculadas a la mecanica core.
+- Contra: hay que decidir si el UI menciona la categoria como "vacia por ahora" o la esconde.
 
-### Estado: POR IMPLEMENTAR
-Issues #27 (shop), #28 (bonfire), #29 (event) existen en Epic 4.
+**C) Hibrido: 2-3 Retazos de cambio en base como demo de la categoria.**
+- Pro: existe la categoria sin la carga de balance de A.
+- Contra: poca variedad para que el jugador construya builds alrededor.
+
+#### Estado: POR DECIDIR
+**No bloqueante hoy.** La decision se puede cerrar al disenar M3 (sistema de Retazos), no antes.
 
 ---
 
-## DD-006: Progresion roguelite (meta entre runs)
+## Postponed
 
-### Pregunta
-Que se desbloquea permanentemente? Como afecta el balance?
-
-### Ideas del GDD original
-- Nuevas cartas duales en el pool de draft
-- Nuevas reliquias
-- Nuevos mundos/actos
-- Mejoras de inicio (boosts para la primera etapa)
-- Cosmeticos y escenas narrativas
-
-### Problemas a resolver
-- Si desbloqueas cartas muy fuertes, las runs tempranas son dificiles y las tardias faciles
-- Si desbloqueas demasiado rapido, el jugador se aburre
-- Si desbloqueas demasiado lento, el jugador siente que perder no vale
-
-### Principios propuestos
-- Los desbloqueos deben ANADIR OPCIONES, no PODER. Cartas nuevas no son mejores, son diferentes.
-- Las primeras 5-10 runs deben desbloquear contenido rapido para enganchar
-- Despues, el ritmo baja y los desbloqueos son mas especializados
-- Nunca desbloquear algo que haga que una estrategia sea objetivamente la mejor
-
-### Estado: POR DISENAR
-Necesita un documento propio cuando se aborde el sistema de progresion.
+### DD-015 — Narrativa y vinetas
+Tema: vinetas narrativas, dialogo de los hermanos, lore. **Postponed** hasta que se aborde la capa de narrativa explicitamente. No bloqueante para gameplay base.
 
 ---
 
-## DD-007: Atributos del heroe (sistema de debilidades)
-
-### Del GDD original
-- Al inicio de cada run, el jugador elige 2 atributos principales (de los 6 tipos)
-- Cartas de esos tipos obtienen bonificaciones
-- El heroe es mas vulnerable a esos tipos que lo contrarrestan
-
-### Pregunta
-Esto se implementa? O las cartas duales + el pool de mundos ya cubren el espacio de "identidad del mazo"?
-
-### Argumentos a favor
-- Anade una capa mas de decision al inicio de la run
-- Cada combinacion de atributos crea un "build" diferente
-- 15 combinaciones posibles (6 tipos, elegir 2) = alta rejugabilidad
-
-### Argumentos en contra
-- Ya hay mucha complejidad con mundos duales + tipos + cartas duales
-- Puede confundir al jugador nuevo
-- El pool de cartas por par de mundos ya cumple una funcion similar
-
-### Posible compromiso
-- No implementar al principio
-- Si las cartas duales + mundos no generan suficiente variedad entre runs, agregar este sistema
-- Podria ser un desbloqueo roguelite: "despues de X runs, desbloqueas el sistema de afinidades"
-
-### Estado: POR DECIDIR
-
----
-
-## DD-008: Pool de cartas por par de mundos
-
-### Idea
-En vez de un personaje (como Slay the Spire), el "personaje" es un par de mundos.
-
-### Ejemplo
-- Par Medieval/Cyberpunk: pool con cartas de espada+hacking, builds agresivos
-- Par Futurista/Retro: pool con cartas de laser+vintage, builds defensivos/combo
-- Cada par tiene sus propias sinergias, cartas exclusivas y cartas duales unicas
-
-### Ventajas
-- Rejugabilidad enorme: cada par se siente como un juego diferente
-- Justifica narrativamente los mundos de los hermanos
-- Permite balancear cada pool independientemente
-- Los desbloqueos roguelite pueden anadir cartas a pools especificos
-
-### Requisitos
-- Minimo 2 pares de mundos para que funcione
-- Cada par necesita ~30-40 cartas unicas para que haya variedad de builds
-- El par inicial (Medieval/Cyberpunk) seria el "personaje base"
-
-### Estado: POR DISENAR
-Es una decision que afecta todo el contenido futuro. Debe decidirse antes de disenar cartas en masa.
-
----
-
-> Ultima actualizacion: 2026-03-17
-> Formato: cuando una decision se tome, documentar el resultado y mover las reglas resultantes a GOLDEN_RULES.md
+> Ultima actualizacion: 2026-04-28
+> Cuando una decision se cierra, su regla resultante se mueve a GOLDEN_RULES.md y se marca su entrada aqui con la referencia a la seccion correspondiente.

--- a/Docs/design/_gdd.md
+++ b/Docs/design/_gdd.md
@@ -1,0 +1,152 @@
+Proyecto C
+Diseñado por TrickShotStudios Para Pc Fecha de salida esperada: 15/06/202?
+Refinación de mecánicas claves
+En este documento se encuentra el contenido de la refinación de mecánicas claves para el loop jugable del videojuego.
+DESCRIPCIÓN CORTA DEL VIDEOJUEGO :
+Deckbuilder roguelite donde el jugador manipula dos mundos simultáneamente, explotando debilidades de tipos mediante un sistema de cambio dimensional + One More (Nombre provisional) DD-OO1 - Sistema de cambio de mundos Un cambio GRATIS por combate
+Posibilidad de más cambios mediante cartas, items y desencadenar combos.
+El sistema de combos funciona con un contador de debilidades. Dependiendo del tipo que lleves en ese momento.
+Al salir de combate, el mapa tendrá los mismos nodos en ambos mundos, pero todas las mejoras, y eventos serán específicos de ese mundo, exceptuando los eventos multidimensionales.
+Sistema de combos El juego cuenta con un sistema de Contador de Estilo, que recompensa al jugador por explotar correctamente las debilidades de los enemigos. Cada vez que el jugador golpea a un enemigo con un ataque súper eficaz, se acumula 1 carga de estilo. Al alcanzar un total de 5 cargas, el jugador obtiene automáticamente un cambio de mundo gratuito, que puede activar en cualquier momento durante ese combate. Este cambio de mundo funciona como un recurso adicional independiente del cambio base del combate. Sin embargo, no puede acumularse: si el jugador ya tiene un cambio gratuito disponible, seguir generando cargas no otorgará uno adicional.
+El contador de estilo también introduce riesgo. Cada vez que el jugador recibe daño de un ataque que explota una de sus debilidades de tipo, pierde 1 carga de estilo, incentivando tanto la ofensiva inteligente como la defensa estratégica.
+DD-002 - Sistema de tipos
+Sistema de Tipos Iniciales y Mazo Base
+Al inicio de cada partida, el jugador debe seleccionar dos tipos elementales, asignando uno a cada mundo de la run:
+● Mundo A → Tipo 1 (ej. Rojo)
+● Mundo B → Tipo 2 (ej. Amarillo)
+Esta elección define tanto el pool de cartas disponible durante la partida como la afinidad inicial del mazo.
+Mazo Inicial
+El jugador comienza con un mazo de 10 cartas:
+● 5 cartas de ataque (Strike)
+● 4 cartas de defensa (Defend)
+● 1 carta especial
+De estas cartas:
+● 3 Strikes y 2 Defends tendrán afinidad de tipo
+● Las cartas restantes serán neutras
+Interacción con el Cambio de Mundo
+Las cartas con afinidad de tipo no son fijas, sino que cambian su tipo según el mundo activo:
+● En Mundo A, adoptan el primer tipo elegido
+● En Mundo B, adoptan el segundo tipo elegido
+Esto permite que una misma carta pueda adaptarse estratégicamente para explotar distintas debilidades dependiendo del momento del combate.
+Cartas Neutras
+Las cartas neutras:
+● Infligen 90% del daño base
+● No generan puntos de estilo
+● No interactúan con debilidades ni resistencias
+Cumplen una función de estabilidad dentro del mazo, pero son menos eficientes en términos ofensivos y de generación de combos.
+Carta Especial Inicial
+El jugador comienza con una carta especial dual, que se construye al inicio de la partida:
+● Se presentan 6 opciones en total
+○ 3 correspondientes al Mundo A
+○ 3 correspondientes al Mundo B
+El jugador selecciona una combinación, forjando una carta que integra ambos mundos y establece la base de su estrategia inicial.
+Este sistema asegura que, desde el primer combate, el jugador tenga acceso a herramientas que interactúan con los tipos elementales, al mismo tiempo que introduce decisiones estratégicas claras entre consistencia (cartas neutras) y potencial de combos (cartas con afinidad).
+Sistema de Tipos Asimétrico
+El juego utiliza un sistema de tipos elementales asimétrico, lo que significa que las relaciones de ventaja y desventaja entre tipos no son necesariamente recíprocas. A diferencia de los sistemas tradicionales donde si un tipo es fuerte contra otro, este último suele ser débil en la misma proporción, aquí las interacciones están diseñadas para ser más dinámicas y menos predecibles.
+Cada tipo puede tener tres tipos de interacción frente a otro:
+● Súper eficaz (1.5x daño)
+● Neutral (1.0x daño)
+● Poco eficaz (0.75x daño)
+Por ejemplo, el tipo Rojo puede ser súper eficaz contra Amarillo, pero Amarillo no necesariamente será débil contra Rojo, pudiendo ser neutral o incluso tener otra interacción distinta con otros tipos. Esto rompe la lógica circular clásica y obliga al jugador a aprender y adaptarse, en lugar de memorizar relaciones simples.
+Este sistema cobra aún más profundidad al combinarse con las cartas duales y el cambio de mundo, ya que una misma carta puede tener diferentes tipos según el mundo activo, permitiendo al jugador manipular estratégicamente sus opciones ofensivas para explotar debilidades específicas en el momento adecuado.
+En conjunto, la asimetría en la tabla de tipos fomenta la experimentación, evita estrategias dominantes simples y convierte cada combate en un ejercicio de lectura, planificación y adaptación constante. (DD-003 notas para merlo: Esta se vio contestada en el apartado DD-002) 
+DD-004 Diseño de bosses Los Bosses tendrá habilidades únicas, y fases. En su mayoría relacionadas con las mecánicas de tipo y cambio de mundo. Cada uno tendrá sus 2 tipos, dependiendo del mundo y cada boss podrá tener cada uno de los 6 tipos, y tenderá a escogerse de manera aleotaria, uno al que seas supereficaz y el otro debil. Ejemplo claves de mecanicas:
+Bloquea cambio de mundo
+Fuerza cambio
+Invierte debilidades
+Ejemplo de boss: Mundo A (Medieval): Costura maldita - Mundo B (Futurista) UNIT-RB7 A: Medieval, un peluche de paja en forma de conejo, poseído por una maldición, en su pecho se ve como sale una mano oscura con la cual ataca (inspiración en mimikyu) y en el mundo B: Futurista, es un robot de juguete infectado por un virus de una IA mutada
+MECÁNICA PRINCIPAL: Desfase Dimensional”
+El boss entra en un estado cargado:
+● Carga durante 1 turno
+● Luego activa: “Cada 3 cartas jugadas en un solo turno → cambio automático de mundo”
+● Dura 3 turnos
+● Se pone un contador de cartas que le dice al jugador cuando se va a activar
+El cambio es automático y arruina la cadena de combos del jugador.
+Otros ataques:
+“Costura Viva / Código Reescrito”+
+Medieval:
+● La mano oscura sale del pecho y:
+○ Aplica debuff (maldición / sangrado) El sangrado: Te quita una cantidad de vida cada vez que lanzas un ataque
+Futurista:
+● Se convierte en:
+○ brazo mecánico glitch
+○ aplica “Virus” (cartas fallan / cambian) Virus: Tus cartas de defensa bajan su efectividad a un 80%
+FASE 2 (OBLIGATORIA)
+Cuando baja a 50% HP:
+● Ya no espera 3 cartas
+● Cambia mundo cada 2 cartas
+DD-005 Sistema de nodos El jugador atravesará un mapa de scroll lateral (izquierda a derecha) que se creará a través de un sistema de semillas, y podrá encontrar 6 tipos de NODOS:
+- Peleas: Luchas contra enemigos normales
+- Peleas Elite: Luchas contra minijefes
+- Peleas jefe
+- Tiendas
+- Hogueras: Para curarse, y mejorar cartas
+- Eventos
+El mapa se creará a través de un sistema de semillas. Eventos: En los eventos habrá una gran variedad, y se podrán encontrar: Reliquias, mejoras, maldiciones, cartas, y quests. Además, habrán eventos especiales que te dejarán elegir en que mundo quieres hacerlos Ejemplo de Evento tipo quest multidimensional: Al entrar a la quest decides en que mundo quieres hacerlo. La quests es exactamente la misma, solo cambia; el enunciado y la recompensa. Enunciado mundo A (medieval)
+Te encuentras un hombre moribundo, que dice ser parte de una legión de magos. Te pide llevar un objeto místico a determinado sitio (MCguffin) y, si lo haces, se te dará una recompensa. Enunciado mundo B (Futurista) Te encuentras un Robot con todas sus piezas rotas y haciendo cortocircuito, te dice que es parte de una facción revolucionaria y tiene que llevar un disco duro con información importante Mundo A (medieval) Aceptar: Se te da el objeto que te da 2 más de oro en cada combate, y tienes que llevarlo a un punto resaltado en el mapa. Robar: El objeto se destruye y le robas 100 de oro al hombre.
+Mundo B (Futurista) Aceptar: Se te da el objeto, el cual te da 1 de escudo adicional cada que juegues una carta de escudo, y tienes que llevarlo a un punto resaltado en el mapa.
+Robar: El objeto se destruye y le robas 100 de oro al hombre. DD-006 progresión Roguelite El juego contará con un sistema de progresión roguelite, en el cual el jugador irá desbloqueando cartas, fragmentos (reliquias) y eventos a medida que complete runs.
+Estos desbloqueos no aumentan directamente el poder del jugador, sino que amplían las opciones disponibles, enriqueciendo la variedad de estrategias, builds y situaciones posibles en futuras partidas. DD-009 Economía El oro es la principal moneda del juego y funciona como un recurso limitado que el jugador obtiene y gestiona únicamente durante cada run.
+Se consigue principalmente al:
+● Completar combates
+● Derrotar enemigos élite y jefes (mayor cantidad)
+● Participar en eventos
+● Activar efectos de ciertas cartas o fragmentos
+El oro se utiliza en nodos de tienda, donde el jugador puede:
+● Comprar cartas
+● Adquirir fragmentos (reliquias)
+● Obtener consumibles (si aplica)
+● Eliminar cartas del mazo
+Combate - 10-20 Oro Elite - 30 - 50 Boss - 100
+El oro no se conserva entre partidas, asegurando que cada run sea una experiencia independiente y balanceada, centrada en la toma de decisiones y la adaptación, en lugar de la acumulación de recursos a largo plazo.
+DD - 010 Tamaño del mazo
+Tamaño típico del mazo al final
+● Inicio: 10–12 cartas
+● Acto 1: 15–20
+● Ideal final: 20–25
+Tamaño típico del mazo al final
+● 20 a 30 cartas - rango más común
+● 15–20 cartas - mazos muy optimizados (alta consistencia)
+● 30–40 cartas - más raros, suelen ser builds específicos
+DD - 011 Dificultad
+La dificultad de Proyecto C escala a lo largo de los 3 actos de cada run siguiendo el modelo de Slay the Spire: los enemigos no solo aumentan sus estadísticas base, sino que incrementan progresivamente la complejidad de sus patrones, la cantidad de mecánicas activas y su interacción con los sistemas de mundo y tipo elemental del jugador.
+HP base del jugador El héroe inicia cada run con 70 HP. Este valor puede aumentarse durante la run mediante reliquias, eventos o mejoras de inicio desbloqueadas en el meta. No hay un máximo definido por diseño; el techo real lo pone la economía de cada run.
+Estructura de escalado por acto
+Acto 1 — Introducción al sistema Los enemigos tienen 1 tipo elemental fijo y patrones de ataque simples y predecibles (atacar, defender, cargar). El HP enemigo es bajo. Este acto funciona como zona de aprendizaje: el jugador practica One More, el cambio de mundo y la lectura de intenciones sin presión severa. Los elites de acto 1 tienen una mecánica única pero sencilla, suficiente para distinguirlos de los enemigos normales sin abrumar al jugador.
+Acto 2 — Presión real Los enemigos aumentan HP y comienzan a presentar 2 tipos elementales simultáneos, lo que complica la explotación de debilidades. Los patrones incorporan fases simples: un enemigo puede cambiar su comportamiento al llegar a cierto umbral de HP. Aparecen los primeros enemigos transdimensionales, que cambian su tipo activo cuando el jugador cambia de mundo. Los elites de acto 2 combinan al menos dos mecánicas y representan el primer desafío de decisión real: enfrentarlos tiene riesgo genuino.
+Acto 3 — Dominio o muerte Los enemigos alcanzan su HP máximo y sus patrones son multifase. Aparecen los primeros enemigos ancla (inmunes al cambio dimensional) y combinaciones de tipos que crean conflictos directos con los atributos del héroe. Los jefes de acto 3 tienen fases que interactúan directamente con el cambio de mundo: pueden bloquear temporalmente el cambio, forzar al jugador a un mundo específico, o alterar su comportamiento drásticamente según el mundo activo. El margen de error es mínimo.
+Elites: Los elites no son enemigos normales con más HP. Cada elite posee al menos una mecánica exclusiva que no aparece en los enemigos comunes de su acto. Derrotar un elite garantiza una reliquia como recompensa, lo que justifica el riesgo de enfrentarlos. El jugador
+nunca está obligado a pelear un elite; siempre existe una ruta alternativa en el mapa, pero evitarlos tiene un coste de progresión real.
+DD-012 — Retazos
+Los Retazos son objetos pasivos que el héroe acumula durante la run y permanecen activos hasta el final de ella. Representan físicamente fragmentos del mundo imaginario de los hermanos: pedazos de cartón, recortes de revista, figuras rotas, trozos de cinta. Cada Retazo otorga un efecto permanente que modifica pasivamente el comportamiento del héroe, sus cartas o los combates.
+Obtención Los Retazos se obtienen de cuatro fuentes:
+● Elites: garantizan un Retazo al ser derrotados. Es la recompensa principal que justifica el riesgo de enfrentarlos.
+● Bosses: otorgan un Retazo de mayor poder al final de cada acto. Estos Retazos de boss son únicos y temáticamente ligados al jefe derrotado.
+● Tienda: el jugador puede comprar Retazos con monedas. La tienda ofrece una selección aleatoria por run.
+● Eventos: algunos nodos de evento otorgan un Retazo como resultado de una decisión, con o sin condición asociada.
+Cantidad activa No existe un límite numérico de Retazos activos. El jugador puede acumular todos los que obtenga durante la run. El límite real lo imponen la economía del juego y la frecuencia de obtención por run.
+Categorías
+Retazos neutros: funcionan de forma constante independientemente del mundo activo. Son la categoría base y la más común. Ejemplos de efecto: ganar 1 bloqueo al inicio de cada combate, robar 1 carta adicional al comienzo del turno, recuperar 3 HP al derrotar un enemigo.
+Retazos de cambio: se activan en el momento exacto en que el jugador ejecuta un cambio de mundo, ya sea el cambio base o uno obtenido mediante el Contador de Estilo. Son la categoría más singular del juego y la que mejor representa la dualidad dimensional. Son raros y más poderosos que los neutros. Estado actual: pendiente de decisión de implementación para contenido base.
+Retazos de mundo: se activan únicamente cuando el jugador se encuentra en un mundo específico (Cyberpunk o Medieval Oscuro). Definidos como contenido posterior, no incluidos en el contenido base.
+Interacción con sistemas existentes Los Retazos son la capa de personalización pasiva de la run. Funcionan en conjunto con el mazo del jugador y el Contador de Estilo, pero no los reemplazan. Un Retazo nunca debe resolver un combate por sí solo; su función es amplificar las decisiones del jugador, no sustituirlas.
+Retazos de boss Al derrotar al jefe de cada acto, el jugador recibe un Retazo especial vinculado narrativamente a ese jefe. Estos Retazos tienen efectos más radicales que los comunes y una pequeña viñeta de texto que los contextualiza dentro de la historia de los hermanos. Son los Retazos de mayor impacto por run y condicionan significativamente las estrategias disponibles en los actos siguientes.
+DD-013 — Mejora de cartas
+Las cartas del mazo pueden mejorarse una vez durante la run, pasando de su versión base a su versión mejorada. Esta mejora es permanente dentro de la run y no puede revertirse.
+Dualidad de la mejora Dado que cada carta existe en dos versiones simultáneas (una por mundo), mejorar una carta mejora automáticamente ambos lados. El jugador nunca mejora solo la versión Cyberpunk o solo la versión Medieval Oscuro de una carta: la mejora es siempre total. Esto garantiza que la decisión de mejorar una carta tenga peso real en ambos mundos y simplifica la carga cognitiva del jugador.
+Dónde se mejoran
+Hoguera: es el nodo principal de mejora. Al visitar una hoguera, el jugador puede elegir entre descansar (recuperar HP) o mejorar una carta de su mazo. Es la misma decisión de Slay the Spire: salud vs. poder. Solo se puede mejorar una carta por visita a hoguera.
+Eventos especiales: ciertos nodos de evento ofrecen la mejora de una carta como resultado de una decisión narrativa. Estos eventos son la excepción, no la regla, y su condición de obtención varía caso a caso.
+Lo que cambia al mejorar La mejora no transforma la identidad de la carta sino que amplifica su efecto. Los patrones generales son: reducción de coste de energía, aumento de daño o bloqueo, adición de un efecto secundario menor, o eliminación de una condición limitante. Cada carta tiene su propia mejora definida en su ficha individual.
+DD-014 — Enemigos transdimensionales
+Todo enemigo en Proyecto C tiene uno o más tipos elementales que determinan sus debilidades y resistencias. Sin embargo, no todos los enemigos se relacionan igual con el sistema de cambio de mundo. Existen tres categorías de comportamiento dimensional:
+Enemigos estándar: Cada enemigo estándar tiene un tipo elemental fijo asociado al mundo en el que aparece. El enemigo cambia su tipo activo instantáneamente. Esto significa que un cambio de mundo puede convertir a un enemigo de resistente a vulnerable, o viceversa, en el mismo turno. El jugador siempre puede ver ambos tipos del enemigo en su ficha, anticipando el efecto del cambio antes de ejecutarlo.
+Enemigos ancla: Los enemigos ancla existen fuera de la lógica dimensional. Su tipo elemental es fijo e invariable sin importar en qué mundo se encuentre el jugador ni cuántas veces cambie. No reaccionan al cambio de mundo de ninguna forma. Su función estratégica es actuar como contrapunto al cambio de mundo: cuando el jugador enfrenta un ancla, el cambio de mundo no altera la ecuación ofensiva contra ese enemigo, forzando al jugador a resolverlo con lo que tiene en el mundo actual o a construir su mazo considerando tipos que
+DD-016 — Progresión meta y desbloqueos
+El sistema de progresión meta de Proyecto C funciona mediante experiencia acumulada entre runs, siguiendo el modelo de Slay the Spire. Cada run otorga experiencia independientemente de su resultado, y al alcanzar ciertos umbrales se desbloquea contenido nuevo de forma permanente que expande el pool de cartas duales, Retazos y otras opciones disponibles en futuras runs.
+Experiencia y progreso: Al finalizar una run, el jugador recibe experiencia basada en qué tan lejos llegó. Los factores que otorgan experiencia son los siguientes, de menor a mayor peso: iniciar una run, superar cada acto, derrotar elites, derrotar bosses de acto y completar la run con victoria. La derrota siempre otorga experiencia proporcional al progreso alcanzado: morir en acto 3 otorga más que morir en acto 1. Ninguna run es tiempo perdido.
+Qué se desbloquea El contenido que se va abriendo con la progresión meta es de dos tipos principales:
+Cartas duales: nuevas cartas se agregan al pool de draft, ampliando las combinaciones posibles en futuras runs. Los primeros desbloqueos son cartas base accesibles y fáciles de integrar. A medida que avanza la progresión, se desbloquean cartas más radicales con efectos que cambian significativamente la forma de construir el mazo.
+Retazos: nuevos Retazos se agregan al pool general de obtención en run. Al igual que las cartas, los primeros son simples y los posteriores más complejos e interactivos con los sistemas del juego.
+Curva de desbloqueo: La curva está diseñada para que las primeras runs siempre entreguen algo nuevo, generando sensación constante de progreso. A medida que el jugador avanza, los desbloqueos se espacian pero aumentan en impacto. El contenido final de la curva son cartas y Retazos que habilitan estrategias completamente distintas a las del contenido base, recompensando al jugador veterano con nuevas formas de jugar.
+Viñetas narrativas: Ciertos hitos de progresión, como derrotar un boss por primera vez o completar la primera run, desbloquean viñetas cortas sobre la historia de los hermanos. Estas viñetas no son contenido de gameplay sino recompensa narrativa que contextualiza el mundo y los personajes a medida que el jugador avanza.funcionen en ambos mundos simultáneamente.

--- a/Docs/dev/GOLDEN_RULES.md
+++ b/Docs/dev/GOLDEN_RULES.md
@@ -3,7 +3,12 @@
 > Este documento define las reglas fundamentales del juego y del codigo.
 > Ningun cambio, feature ni refactor puede romper estas reglas.
 > Si un issue o prompt contradice algo de aqui, este documento tiene prioridad.
-> Solo se agregan reglas aqui cuando estan PROBADAS y FUNCIONANDO en el build actual.
+
+> Estado de cada regla:
+> - ✓ implementado y funcionando en el build actual
+> - ⏳ cerrado por diseno (GDD v2), implementacion pendiente
+>
+> Para decisiones de diseno abiertas, ver Docs/design/DESIGN_DECISIONS.md
 
 ---
 
@@ -13,11 +18,12 @@
 - Roguelite deckbuilder con combate por turnos 1v1
 - Mecanica diferenciadora: sistema de Mundos Duales (A/B) que afecta cartas, tipos y estrategia
 - Estetica handmade: carton, crayones, papel recortado, materiales escolares
-- Narrativa: dos hermanos que discuten sobre que jugar y mezclan sus mundos (cyberpunk vs medieval oscuro)
+- Narrativa: dos hermanos que discuten sobre que jugar y mezclan sus mundos
+- Mundo A: **Medieval Oscuro**. Mundo B: **Cyberpunk**
 
 ### Roguelite, no Roguelike
 - Las runs son permadeath (al morir, se pierde el progreso de esa run)
-- Habra progresion permanente entre runs (desbloqueos de cartas, reliquias, eventos, potencialmente personajes)
+- Hay progresion permanente entre runs por XP (ver §11)
 - El jugador siempre debe sentir que avanza, incluso al perder
 
 ### Principio de diseno central
@@ -29,47 +35,57 @@
 
 ## 2. REGLAS DE COMBATE (IRROMPIBLES)
 
-### Flujo de turno
+### Flujo de turno (✓)
 1. Turno del jugador: robar cartas -> jugar cartas -> fin de turno
 2. Turno del enemigo: limpiar bloqueo -> ejecutar movimiento -> planear siguiente -> verificar fin de combate
 3. Este ciclo se repite hasta Victoria o Derrota
 4. NUNCA alterar este orden
 
-### Energia
+### Energia (✓)
 - El jugador recibe energia fija al inicio de cada turno (default: 3)
 - Las cartas cuestan energia para jugarse
 - La energia NO se acumula entre turnos
 
-### Momentum (One More)
-- Se gana +1 Momentum cuando un ataque del jugador hace dano SuperEficaz > 0
-- Momentum permite jugar la siguiente carta gratis (sin coste de energia)
-- Momentum se consume al jugar una carta, no al seleccionarla
-- Es la recompensa por explotar el sistema de tipos
-
-### Bloqueo
+### Bloqueo (✓)
 - Se limpia al inicio de cada fase de turno
 - Bloqueo del enemigo se limpia cuando empieza turno del jugador
 - Bloqueo del jugador se limpia cuando empieza turno del enemigo
 - El bloqueo NUNCA persiste entre turnos
 
-### Limite de mano
+### Limite de mano (✓)
 - Maximo 7 cartas en mano (configurable)
 - Si se intenta robar con mano llena, se descarta
 
-### Cambio de mundo (implementacion actual)
-- Limitado a 1 cambio por combate (funcional, pero las reglas definitivas estan en discusion — ver DESIGN_DECISIONS.md)
-- Cambiar de mundo afecta que lado de las cartas duales esta activo
-- El cambio afecta tipos, costos y efectos de las cartas duales
+### Cambio de mundo
+- ⏳ 1 cambio gratuito por combate (base, no acumulable entre combates)
+- ⏳ Cambios adicionales pueden venir de:
+  - Sistema de Contador de Estilo (ver §4): 5 cargas otorgan 1 cambio extra (no acumulable)
+  - Cartas con efecto de cambio de mundo
+  - Items (Retazos, ver §10)
+- ⏳ Cambiar de mundo afecta:
+  - Que lado de las cartas duales esta activo
+  - El tipo activo del jugador (= tipo asignado al mundo)
+  - El tipo activo de enemigos transdimensionales (ver §6)
+  - NO afecta enemigos ancla (ver §6)
+- ✓ Hoy implementado: 1 cambio por combate (placeholder, sera reemplazado en M2)
 
 ---
 
 ## 3. SISTEMA DE TIPOS Y EFECTIVIDAD
 
-### Tipos elementales (nombres placeholder)
-- Rojo, Amarillo, Azul, Morado, Negro, Blanco, None
-- Los nombres cambiaran pero la mecanica se mantiene
+### Tipos elementales (✓)
+- 6 tipos: Rojo, Amarillo, Azul, Morado, Negro, Blanco + None
+- Los nombres son placeholder; la mecanica se mantiene
 
-### Tabla de efectividad (ASIMETRICA — implementada)
+### Tipo activo del jugador (⏳ DD-002, DD-007)
+- El jugador elige 2 tipos elementales al inicio del run, asignando uno a cada mundo
+- El tipo activo del jugador = tipo asignado al mundo en que esta parado
+- El cambio de mundo cambia instantaneamente el tipo activo del jugador
+- Esto afecta:
+  - Que ataques enemigos son SuperEficaces contra el (ver "reglas de aplicacion")
+  - Que cartas con afinidad cambian su tipo (ver §5)
+
+### Tabla de efectividad (ASIMETRICA — implementada) (✓)
 
 | Atacante \ Defensor | Rojo    | Amarillo    | Azul        | Morado      | Negro       | Blanco      |
 |---------------------|---------|-------------|-------------|-------------|-------------|-------------|
@@ -81,46 +97,111 @@
 | Blanco              | Neutro  | SuperEficaz | Poco eficaz | Neutro      | SuperEficaz | Neutro      |
 
 ### Reglas de aplicacion
-- SOLO aplica a: dano de carta del jugador vs tipo del enemigo
-- NO aplica a: dano del enemigo, bloqueo, robo de cartas ni ningun otro efecto
-- SuperEficaz: 1.5x dano + otorga Momentum
-- Neutro: 1.0x dano
-- PocoEficaz: 0.75x dano
-- None vs cualquier tipo = Neutro
+- Multiplicadores: SuperEficaz **1.5x**, Neutro **1.0x**, PocoEficaz **0.75x**
+- Multiplicadores configurables (constantes en codigo, ajustables sin cambiar logica)
+- ✓ Aplica a: dano de carta del jugador vs tipo del enemigo (multiplicador + cargas de Estilo)
+- ⏳ Aplica a: dano del enemigo vs tipo activo del jugador (multiplicador + cargas de Estilo, DD-018)
+- NO aplica a: bloqueo, robo de cartas, ni ningun otro efecto fuera de dano
+- None vs cualquier tipo = Neutro (no genera ni quita cargas)
 - La tabla es ASIMETRICA: Rojo->Amarillo es SuperEficaz, pero Amarillo->Rojo es Neutro
+
+### Cartas neutras (⏳ DD-002)
+- Cartas sin afinidad de tipo (None)
+- Infligen 90% del dano base (multiplicador adicional al base, configurable)
+- NO generan ni quitan cargas de Contador de Estilo
+- NO interactuan con debilidades ni resistencias
 
 ---
 
-## 4. CARTAS (IMPLEMENTADO)
+## 4. CONTADOR DE ESTILO (⏳ DD-001 — reemplaza Momentum)
 
-### Tipos de carta
+> Recurso por combate. Reemplaza completamente el sistema antiguo de Momentum.
+
+### Reglas
+- El Contador de Estilo se reinicia a 0 al iniciar cada combate
+- **+1 carga** cuando un ataque del jugador hace dano SuperEficaz contra el enemigo
+- **-1 carga** cuando un ataque del enemigo hace dano SuperEficaz contra el tipo activo del jugador
+- El contador no baja de 0
+- Al alcanzar **5 cargas**:
+  - Se otorga 1 cambio de mundo adicional para ese combate
+  - El contador se reinicia a 0
+  - El cambio adicional NO se acumula: si ya hay un cambio extra disponible y aun no se uso, alcanzar 5 otra vez no genera otro
+- Las cargas no persisten entre combates
+
+### El sistema viejo de Momentum se elimina
+- Carta gratis por SuperEficaz: ELIMINADO
+- No hay recompensa de energia por SuperEficaz
+- La unica recompensa por SuperEficaz es la acumulacion de cargas
+
+---
+
+## 5. CARTAS
+
+### Tipos de carta (✓)
 - Attack, Skill, Power, Curse, Status
 
-### Cartas simples vs duales
+### Cartas simples vs duales (✓)
 - Simple: una sola definicion, funciona igual en Mundo A y B
 - Dual: dos definiciones (sideA, sideB). El mundo activo determina cual esta activa
 - Al construir el mazo, el jugador esta construyendo DOS estrategias al mismo tiempo
 
-### Resolucion de efectos
+### Resolucion de efectos (✓)
 - Los efectos de una carta se encolan en ActionQueue en orden
 - ActionQueue.ProcessAll() los ejecuta secuencialmente (deterministico)
 - NUNCA cambiar el orden de resolucion
 - NUNCA hacer que la resolucion dependa de callbacks de animacion
 
+### Mazo inicial (⏳ DD-002, DD-008, DD-020)
+- Al inicio de cada run el jugador elige 2 tipos elementales (uno por mundo)
+- Esa eleccion define:
+  - El tipo activo del jugador en cada mundo (ver §3)
+  - El pool de cartas disponible durante el run (filtrado por los 2 tipos elegidos)
+  - La afinidad inicial del mazo
+- Mazo inicial: **10 cartas exactas**
+  - 5 Strike (3 con afinidad de tipo, 2 neutras)
+  - 4 Defend (2 con afinidad de tipo, 2 neutras)
+  - 1 carta especial dual elegida en draft inicial
+- Cartas con afinidad cambian su tipo segun el mundo activo (Mundo A = tipo 1, Mundo B = tipo 2)
+- Carta especial dual: el jugador elige una combinacion entre 6 opciones (3 por mundo) al inicio del run, filtradas por los 2 tipos elegidos
+
+### Tamano del mazo (⏳ DD-010)
+- Inicio: 10 cartas exactas
+- Fin de Acto 1 (objetivo): 15-20
+- Fin de run (objetivo): 20-25
+- Sin limite duro; el balance asume estos rangos
+
+### Mejora de cartas (⏳ DD-013)
+- Cada carta puede mejorarse 1 sola vez por run. La mejora es permanente dentro del run y no se revierte
+- En cartas duales, mejorar la carta mejora AMBOS lados (sideA y sideB) simultaneamente
+- Donde se mejora: Hoguera (decision exclusiva con descansar) y eventos especiales especificos
+- Patrones: reducir coste, aumentar dano/bloqueo, anadir efecto secundario menor, eliminar condicion limitante
+- La mejora amplifica la carta, no transforma su identidad
+
 ---
 
-## 5. ENEMIGOS (IMPLEMENTADO)
+## 6. ENEMIGOS
 
-### Estructura
-- Cada enemigo tiene: HP, tipo elemental, patron de IA, lista de movimientos
+### Estructura (✓)
+- Cada enemigo tiene: HP, tipos elementales, patron de IA, lista de movimientos
 - Cada movimiento tiene: efectos, peso (para random), tipo de intencion (Attack/Defend)
 
-### Patrones de IA
+### Patrones de IA (✓)
 - RandomWeighted: seleccion por peso (mas peso = mas probable)
 - Sequence: cicla por movimientos en orden
-- PhaseBased: declarado, no implementado aun
+- PhaseBased: declarado, no implementado aun (pendiente en M2)
 
-### Asignacion en mapa
+### Categorias dimensionales (⏳ DD-014)
+- **Estandar**: 1 o mas tipos elementales. El tipo activo cambia instantaneamente con el cambio de mundo del jugador. La ficha muestra ambos tipos cuando aplica
+- **Ancla**: tipo elemental fijo e invariable. No reacciona al cambio de mundo. Funcion estrategica: forzar al jugador a resolver con el mundo actual o construir mazo versatil
+
+### Bosses (⏳ DD-004)
+- Cada boss tiene 2 tipos elementales (uno por mundo)
+- Los tipos del boss se eligen para que: 1 sea SuperEficaz contra el jugador y 1 sea debilidad del jugador
+- Cada boss tiene al menos una mecanica unica que interactua con el cambio de mundo (bloquearlo, forzarlo, invertir debilidades, etc)
+- Cada boss tiene al menos 2 fases. Fase 2 obligatoria al 50% HP
+- Los bosses pueden aplicar debuffs unicos vinculados a su tematica (Sangrado en Medieval, Virus en Cyberpunk del Boss Acto 1 — DD-019). **Estos debuffs son exclusivos del boss, no genericos**
+
+### Asignacion en mapa (✓)
 - Los enemigos se asignan por profundidad BFS desde nodo inicio
 - Seleccion por peso desde el pool de esa profundidad
 - El boss se asigna por separado desde RunSession
@@ -128,21 +209,25 @@
 
 ---
 
-## 6. RUNS Y MAPA (IMPLEMENTADO)
+## 7. RUNS Y MAPA
 
-### Generacion del mapa
+### Generacion del mapa (✓)
 - Basada en seed: misma seed = mismo mapa
 - Seed 0 = aleatorio cada run
 - Topologia de templates predefinidos (DAG valido garantizado)
 - Tipos de nodo asignados por peso con minimos forzados
 
-### Tipos de nodo
-- Combat: pelea normal (funcional)
-- Elite: pelea dificil con mejor recompensa (funcional)
-- Boss: pelea final del acto (funcional)
-- Shop: por implementar
-- Event: por implementar
-- Campfire: por implementar
+### Tipos de nodo (⏳ DD-005 — 6 tipos)
+- ✓ Combat: pelea normal
+- ✓ Elite: pelea dificil con mejor recompensa, garantiza 1 Retazo (ver §10)
+- ✓ Boss: pelea final del acto, otorga 1 Retazo unico vinculado al boss
+- ⏳ Shop (Tienda): comprar cartas, Retazos, consumibles, eliminar cartas
+- ⏳ Campfire (Hoguera): elegir entre descansar (recuperar HP) o mejorar 1 carta
+- ⏳ Event (Evento): encuentros con decisiones; algunos son multidimensionales (el jugador elige en que mundo realizarlos)
+
+### Estructura del mapa
+- Scroll lateral (izquierda a derecha)
+- Mismos nodos en ambos mundos; las recompensas y eventos especificos cambian segun mundo activo (excepto eventos multidimensionales)
 
 ### RunState = solo datos
 - NUNCA poner logica de flujo en RunState
@@ -151,18 +236,79 @@
 
 ---
 
-## 7. REGLAS DE CODIGO (IRROMPIBLES)
+## 8. ECONOMIA (⏳ DD-009)
+
+- El oro es la unica moneda. No persiste entre runs
+- Recompensas: Combate **10-20**, Elite **30-50**, Boss **100**. Eventos pueden otorgar oro variable
+- Usos: comprar cartas (Tienda), comprar Retazos (Tienda), eliminar cartas del mazo (Tienda), consumibles (si aplica)
+- Ciertos efectos de cartas y Retazos pueden generar oro durante combate o eventos
+
+---
+
+## 9. ACTOS Y DIFICULTAD (⏳ DD-011)
+
+- HP base del jugador: **70** al inicio de cada run. Sin maximo definido por diseno (lo limita la economia del run)
+- 3 actos. Cada acto incrementa HP enemigo, complejidad de patrones, mecanicas activas
+- **Acto 1**: enemigos con 1 tipo fijo, patrones simples (atacar, defender, cargar). Elites con 1 mecanica unica simple
+- **Acto 2**: enemigos con 2 tipos simultaneos, patrones con fases por umbral de HP. Aparecen enemigos transdimensionales. Elites combinan al menos 2 mecanicas
+- **Acto 3**: enemigos multifase con HP maximo. Aparecen enemigos ancla. Bosses interactuan directamente con el cambio de mundo (bloquearlo, forzarlo, alterar comportamiento)
+- Elites NUNCA son enemigos normales con mas HP. Cada elite tiene al menos una mecanica exclusiva. Derrotar un elite garantiza un Retazo
+- El jugador siempre puede evitar elites pero pierde la recompensa
+
+---
+
+## 10. RETAZOS (⏳ DD-012)
+
+> Reliquias del juego. Nombre canonico: **Retazos**.
+
+### Reglas
+- Objetos pasivos que persisten durante toda la run
+- Sin limite numerico de Retazos activos por run
+- Obtencion: Elite (garantizado), Boss (Retazo unico narrativo), Tienda (compra), Eventos (variable)
+
+### Categorias
+- **Neutros**: efecto constante, independiente del mundo. Categoria base, mas comun
+- **De cambio**: se activan al ejecutar un cambio de mundo (base o por cargas). Mas raros y poderosos. **Inclusion en contenido base: pendiente, ver DD-017**
+- **De mundo**: se activan solo en un mundo especifico (Cyberpunk o Medieval Oscuro). Contenido posterior, NO incluidos en contenido base
+
+### Retazos de boss
+- Vinculados narrativamente al boss derrotado
+- Texto narrativo asociado
+- Mayor impacto por run que los Retazos comunes
+
+### Principio
+- Un Retazo nunca debe resolver un combate por si solo
+- Su funcion es amplificar las decisiones del jugador, no sustituirlas
+
+---
+
+## 11. META-PROGRESION (⏳ DD-006 + DD-016)
+
+- Cada run otorga XP segun progreso, independiente del resultado
+- Factores que dan XP (de menor a mayor peso): iniciar run, superar acto, derrotar elite, derrotar boss de acto, completar run con victoria
+- La derrota otorga XP proporcional al progreso (acto 3 > acto 1)
+- Desbloqueos al alcanzar umbrales:
+  - Cartas duales nuevas (al pool de draft)
+  - Retazos nuevos (al pool de obtencion)
+  - Vinetas narrativas (recompensa narrativa, no gameplay)
+- Los desbloqueos NUNCA aumentan poder directo, solo amplian opciones
+- Curva: primeras runs desbloquean rapido para enganchar, luego se espacian con mayor impacto
+
+---
+
+## 12. REGLAS DE CODIGO (IRROMPIBLES)
 
 ### Arquitectura
 - Scene-owned controllers: cada escena tiene su controlador
-- RunSession es el UNICO DontDestroyOnLoad
+- RunSession es el UNICO DontDestroyOnLoad de gameplay
 - RunState = datos. Controllers = flujo. UI/VFX = presentacion
 - Data-driven: ScriptableObjects para cartas, enemigos, configuracion
 
-### No tocar (core de combate)
-- TurnManager: flujo de turnos, resolucion de efectividad, energia, momentum
+### No tocar (core de combate, archivos protegidos)
+- TurnManager: flujo de turnos, resolucion de efectividad, energia, IA enemiga, world switch
 - ActionQueue: orden de ejecucion de acciones
 - PlayerCombatActor / EnemyCombatActor: mecanicas del actor
+- Cualquier modificacion requiere aprobacion explicita
 
 ### Regla de oro de animaciones
 - Las animaciones son SIEMPRE fire-and-forget
@@ -171,14 +317,22 @@
 - Excepcion unica: PlayAttackOnce() del flujo original de ataque
 
 ### Regla CS0104
-- Si un archivo usa System y UnityEngine, siempre escribir UnityEngine.Object
+- Si un archivo usa System y UnityEngine, siempre escribir UnityEngine.Object explicito
 
 ### Calidad minima
 - Cero errores en consola = requisito base de todo cambio
-- Comentarios de onboarding en todo codigo nuevo
+- Comentarios de onboarding en todo codigo nuevo (explican el porque, no el que)
+
+### No manual editor setup
+- Features nuevas auto-crean GameObjects en runtime o las instancia un scene controller existente
+- Nunca requerir attach manual en inspector para probar
+
+### No duplicar logica
+- Verificar UIAnimationHelper.cs (8 metodos DOTween) y AudioManager.cs antes de crear helpers nuevos
+- Verificar patrones existentes (IGameAction, EffectRef, eventos de TurnManager) antes de crear abstracciones nuevas
 
 ---
 
-> Ultima actualizacion: 2026-03-17
-> Solo agregar reglas que esten probadas y funcionando.
+> Ultima actualizacion: 2026-04-28 (post-GDD v2)
+> Solo agregar reglas que esten cerradas por diseno o probadas en codigo.
 > Para decisiones de diseno abiertas, ver Docs/design/DESIGN_DECISIONS.md

--- a/Docs/dev/_insights.md
+++ b/Docs/dev/_insights.md
@@ -31,4 +31,14 @@
 <!-- Los insights se agregan aquí en orden cronológico (más reciente arriba). -->
 <!-- No editar insights pasados sin pedido explícito. -->
 
-(Vacío. El primer insight se registrará cuando aparezca uno.)
+## Insight 1 — Validación de fase de extracción debe abrir Unity, no solo revisar el diff — 2026-05-01
+
+**Contexto:** durante la validación de la Fase 4 (extracción de CombatBackgroundView), al abrir Unity por primera vez post-merge me salió el editor en Safe Mode con 6 errores CS0246/CS0103 en CombatHudView.cs. El error venía latente desde Fase 3: `BuildEnemyIntentLabel()` se movió de CombatUIController a CombatHudView pero el `using RoguelikeCardBattler.Gameplay.Enemies;` no se replicó. Como el code review de Fase 3 fue por inspección de diff y no abriendo Unity, el error pasó. Recién apareció en Fase 4 cuando volví a abrir el editor.
+
+**Idea:** la validación de una fase de refactor que mueve código entre archivos NO es completa hasta que Unity compile sin errores. El code review del diff puede pasar y aún así el proyecto no compilar (typically por usings faltantes, asmdefs mal referenciados, o tipos del namespace destino que no existen en el origen).
+
+**Conexión con sistemas:** proceso de desarrollo / validación. No afecta gameplay directamente, pero afecta cómo cerramos sub-tareas en `_roadmap.md`.
+
+**Potencial:** agregar al protocolo de extracción de combate (y refactors en general) un checkbox explícito: "Abrir Unity y verificar zero compilation errors antes de marcar como validada". Esto es independiente y previo a "validar comportamiento en BattleScene". Para M2 (que va a tocar mucho más código y reescribir tests), este chequeo es no-negociable porque la cantidad de errores potenciales se multiplica.
+
+**Estado:** aplicado — la regla queda registrada acá para que se aplique en M2 y siguientes. El protocolo de futuros specs de refactor debe incluirla en la sección de validación.

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -7,9 +7,10 @@
 > En `modo:implementacion` se lee al inicio para saber qué milestone está activo
 > y qué sub-tareas quedan.
 >
-> **Fase actual:** Higiene técnica + preparación para GDD nuevo
-> **Milestone activo:** M0 — Setup del sistema de modos
-> **Última actualización:** 2026-04-27
+> **Fase actual:** post-procesamiento del GDD v2. Cerrando deuda técnica de UI antes de M2.
+> **Milestone activo:** M-tech — Deuda técnica acumulada (solo queda `gh` CLI)
+> **Próximo gran bloque:** M2 — TurnManager v2 (mecánica core nueva + bundle de deuda)
+> **Última actualización:** 2026-05-01 (post-validación Fase 4 CombatBackgroundView)
 
 ---
 
@@ -37,107 +38,281 @@
 - Si una tarea técnica surge a mitad de implementación y no encaja en el milestone
   activo, registrarla como sub-tarea del milestone pertinente o crear un milestone
   nuevo.
+- Mantener este archivo al día CONFORME se avanza, no en lotes.
 
 ---
 
 ## Activo
 
-### M0 — Setup del sistema de modos
-**Objetivo:** dejar instalado el sistema de modos especializados (gdd, diseño,
-implementación, revisión) + documentación de contexto persistente, antes de
-empezar a procesar el GDD nuevo.
+### M-tech — Deuda técnica acumulada
 
-**Por qué primero:** procesar el GDD sin un sistema de modos consistente nos haría
-volver a improvisar cada conversación. El setup paga dividendos durante toda la
-implementación del GDD nuevo.
+**Objetivo:** terminar la descomposición de CombatUIController y pagar deuda
+técnica de tooling antes de entrar a M2 (que reescribe TurnManager). Las deudas
+que tocan archivos protegidos se **bundlean con M2** porque su PR va a tocar
+TurnManager igual — abrirlo dos veces sería desperdicio.
 
-**Sub-tareas:**
+**Por qué se mantiene activo:** Fase 4 es refactor puro de UI sin tocar
+protegidos. Pagarla ahora deja CombatUIController listo para recibir las
+features nuevas de M2 (Contador de Estilo en HUD, indicador de tipo activo,
+etc.) sin reabrir el monolito.
 
-- [x] Crear `Docs/dev/_insights.md` con plantilla
-- [x] Crear `Docs/design/_gdd.md` placeholder
-- [x] Crear `Docs/dev/_tech_snapshot.md` capturando estado actual post-extracciones
-- [x] Crear `Docs/dev/_roadmap.md` (este archivo) con deuda técnica conocida
-- [x] Reescribir `CLAUDE.md` raíz con sistema de modos completo (gdd, diseño,
-      implementación, revisión + conversacional)
-- [x] Actualizar `Assets/Scripts/Gameplay/Combat/CLAUDE.md` para mencionar el
-      sistema de modos y qué archivos lee `modo:implementacion` al tocar combate
-- [ ] Validar el sistema con una conversación corta en cada modo (smoke test)
-- [ ] Commit + PR + merge
+**Sub-tareas independientes (paralelas, sin protegidos):**
 
-**Dependencias:** ninguna. Todo es trabajo de documentación.
-**Criterios de cierre:** los 4 modos están definidos y son activables. Los archivos
-`_tech_snapshot.md` y `_roadmap.md` reflejan el estado real del proyecto.
+#### Fase 3 — Extracción de CombatHudView (✅ CERRADA 2026-04-28)
+- [x] Spec en `modo:diseno`
+- [x] Implementación con los 10 pasos del spec
+- [x] Validación manual en BattleScene (14 casos de prueba)
+- [x] Revisión de código (`modo:revision`)
+- [x] Merge
+
+**Resultado:** CombatUIController de 980 → **842 loc** (-14%). CombatHudView.cs
+creado con **330 loc** (HUD textos, botones End Turn / Change World, highlight
+de avatares por turno). Comportamiento idéntico al anterior. Cero errores en
+consola.
+
+#### Fase 4 — Extracción de CombatBackgroundView (✅ CERRADA 2026-05-01)
+- [x] Spec en `modo:diseno`
+- [x] Implementación
+- [x] Revisión de código
+- [x] Validación manual en BattleScene
+- [ ] Merge *(pendiente del usuario)*
+
+**Resultado:** CombatUIController de 842 → **710 loc** (-16%). CombatBackgroundView.cs
+creado con **182 loc** (sky/ground, sprites/colores A/B, CoverFill, polling autónomo
+de CurrentWorld). `_owner` eliminado de CombatHudView.
+
+**Bug surfaced + fixed durante validación:** CombatHudView.cs no tenía
+`using RoguelikeCardBattler.Gameplay.Enemies;` (latente desde Fase 3, donde
+`BuildEnemyIntentLabel` se movió sin replicar el using). 6 errores CS0246/CS0103
+en consola al abrir Unity. Fix: agregada la línea de using. Ver `_insights.md`
+para el aprendizaje sobre validación de compilación en Unity.
+
+#### Tooling
+- [ ] Instalar `gh` CLI para automatizar creación de PRs desde terminal (no
+      requiere prompt — son 2-3 comandos en terminal)
+- [ ] Verificar que el otro developer también lo instala
+
+**Sub-tareas que se BUNDLEAN con M2 (tocan TurnManager protegido):**
+
+- ~~PhaseBased AI~~ — se implementa dentro de M2 al reescribir `SelectEnemyMove()`.
+- ~~`EffectType.Heal` + `HealAction`~~ — se implementa dentro de M2 al reescribir
+  el case dispatch de `CreateAction()`.
+- ~~`CalculateIntentValue` gaps~~ — se amplía dentro de M2.
+
+Razón: cada uno toca `TurnManager.cs` (PROTEGIDO). En lugar de abrir el archivo
+protegido 4 veces (una por cada deuda más una por M2), se abre 1 sola vez en
+M2 con todas las features cohesivas a la vez. Aprobación de Sebastián una sola
+vez en lugar de cuatro.
+
+**Dependencias:** ninguna específica para Fase 4 / gh CLI.
+**Criterios de cierre del milestone:** Fase 4 mergeada + gh CLI funcional.
+Las deudas bundleadas con M2 NO bloquean el cierre de M-tech — se cierran
+cuando M2 se cierra.
 
 ---
 
 ## Pendientes
 
-### M1 — Procesar GDD nuevo
-**Objetivo:** activar `modo:gdd` para procesar el documento que va a traer
-Sebastián. Generar el mapa de gaps (qué tenemos vs qué falta), llenar
-`_gdd.md` con la estructura final, y crear los milestones M2+ que el GDD implique.
+### M2 — TurnManager v2: mecánica core nueva + deuda técnica
 
-**Sub-tareas (desagregar al activar):**
-- Lectura completa del GDD nuevo
-- Identificar sistemas implementados / parciales / pendientes
-- Identificar contradicciones entre GDD y `GOLDEN_RULES.md` o código actual
-- Identificar decisiones de diseño que el GDD cierra (mover de
-  `DESIGN_DECISIONS.md` a `GOLDEN_RULES.md`)
-- Identificar decisiones nuevas que el GDD abre
-- Proponer 3-5 milestones nuevos (M2, M3, M4...) ordenados por dependencias
-- Sebastián aprueba la priorización
-- Actualizar `_gdd.md` y crear los milestones nuevos en este roadmap
+**Objetivo:** instalar el sistema de cargas (Contador de Estilo) y todas las
+mecánicas que el GDD v2 introduce sobre el motor de combate, en un único refactor
+coordinado de los archivos protegidos. Bundle gigante intencional.
 
-**Dependencias:** M0 cerrado.
-**Cuándo se activa:** cuando Sebastián diga "tengo el GDD, procesalo".
+**Por qué bundle:** todas las features tocan `TurnManager.cs` (PROTEGIDO).
+Hacerlas en PRs separados obliga a reabrir el archivo cada vez, reescribir tests
+varias veces y reconciliar cambios. Una sola serie de sub-PRs cohesivos es más
+limpio.
+
+**Features incluidas:**
+
+#### Mecánica core nueva (cierra DDs del GDD v2)
+- [ ] Eliminar Momentum (todas sus referencias en TurnManager + UI)
+- [ ] Implementar Contador de Estilo (cargas: +1 por SuperEficaz hecho, -1 por
+      SuperEficaz recibido, 5 cargas → 1 cambio extra no acumulable, reset cada
+      combate)
+- [ ] Cambios múltiples de mundo por combate (cap dinámico: 1 base + extras por
+      cargas / cartas / Retazos)
+- [ ] Tipo activo del jugador (campo derivado del mundo, viene de los 2 tipos
+      elegidos al inicio del run)
+- [ ] Daño enemigo SuperEficaz contra el jugador: aplicar multiplicador x1.5
+      (DD-018) — multiplicador configurable como constante
+- [ ] Hacer configurables los multiplicadores de efectividad (1.5 / 1.0 / 0.75)
+      como constantes en código
+- [ ] Cartas neutras al 90% del daño base (DD-002)
+
+#### Deuda técnica que se cierra aquí (bundle de M-tech)
+- [ ] PhaseBased AI: implementar case en `SelectEnemyMove()` (HP thresholds o
+      turn count)
+- [ ] `EffectType.Heal` + `HealAction` + case en `CreateAction()`
+- [ ] `CalculateIntentValue` ampliado para combinaciones nuevas (Defend+Heal,
+      Buff+StatusEffect, etc.)
+
+#### UI de M2
+- [ ] HUD: cambiar "Momentum: N" por "Cargas: N/5" (modificar CombatHudView ya
+      extraído)
+- [ ] HUD: indicador de tipo activo del jugador (label nuevo)
+- [ ] HUD: contador de switches dinámico (ya no es "X/1", es "X/?" según cargas)
+
+**Sistemas afectados:** TurnManager, PlayerCombatActor, RunState, ElementTypes,
+CombatHudView, tests existentes (WorldSwitchLimitTests, DamageEffectivenessTests,
+PlayerCombatActorTests deberán reescribirse).
+
+**Toca archivos protegidos:** **SÍ** — TurnManager + PlayerCombatActor.
+**REQUIERE APROBACIÓN EXPLÍCITA** antes de empezar implementación.
+
+**Dependencias:** M-tech Fase 4 cerrada (CombatHudView ya extraído facilita
+la modificación del HUD para cargas; CombatBackgroundView libera el monolito
+para tocar HUD/state sin pisar fondos).
+
+**Estrategia de PRs:** subdividir en 3-4 sub-PRs cohesivos:
+- Sub-PR A: tipo activo del jugador + multiplicadores configurables (sin tocar
+  comportamiento todavía)
+- Sub-PR B: efectividad bidireccional + daño x1.5 al jugador
+- Sub-PR C: Contador de Estilo + cambios múltiples (reemplaza Momentum)
+- Sub-PR D: PhaseBased AI + Heal + CalculateIntentValue (deuda técnica)
+
+**Complejidad:** alta. Es el cambio que más riesgo de regresión introduce en el
+motor de combate.
+
+**Criterios de cierre:** todos los tests pasan + comportamiento verificado en
+BattleScene + Momentum completamente eliminado del código.
 
 ---
 
-### M-tech — Deuda técnica acumulada (paralelo, no bloqueante)
-**Objetivo:** pagar la deuda técnica conocida antes de que el GDD nuevo la
-amplifique. Cada sub-tarea es relativamente independiente — pueden ejecutarse en
-ratos sueltos, no requieren un sprint dedicado.
+### M3 — Personalización del run
 
-**Sub-tareas:**
+**Objetivo:** instalar el ecosistema de personalización del run según GDD v2:
+Retazos como sistema base, Tienda funcional, Hoguera con heal/upgrade, y draft
+de carta especial dual al inicio.
 
-#### Extracción CombatUIController — Fase 3 (CombatHudView)
-- [ ] Diseñar contrato de `CombatHudView` (qué campos recibe, qué eventos escucha)
-- [ ] Crear `CombatHudView.cs` con: paneles HP, energía, momentum, mundo,
-      block overlays, intents, switches counter
-- [ ] Mover `UpdateInfoTexts()` y `UpdateAvatarHighlight()` a CombatHudView
-- [ ] CombatUIController delega via `_hudView.Sync()` en su Update()
-- [ ] Verificar en BattleScene: HUD se actualiza igual, zero console errors
+**Sub-tareas (desagregar al activar):**
+- Sistema de Retazos: `RelicDefinition` SO, hooks (`RelicEffectHook`) en eventos
+  clave (init combate, draw, daño hecho/recibido, switch de mundo, fin combate),
+  `RunState.Relics`, UI
+- Tienda (Shop): controller, view, scene/canvas, lógica de selección por mundo,
+  compra/eliminar cartas
+- Hoguera (Campfire): controller, view, decisión heal vs upgrade
+- Carta especial dual inicial: draft de 6 opciones filtradas por los 2 tipos
+  elegidos (DD-020), UI panel
+- **Cerrar DD-017** (Retazos de cambio en contenido base) durante el diseño
 
-#### Extracción CombatUIController — Fase 4 (CombatBackgroundView)
-- [ ] Crear `CombatBackgroundView.cs` con: sky/ground, sprites A/B,
-      colors A/B, CoverFill, transición en world change
-- [ ] Mover `CreateBackgroundLayers()`, `UpdateWorldVisuals()`, `CoverFill()`
-- [ ] CombatUIController delega world visuals al view extraído
-- [ ] Verificar en BattleScene: cambio de mundo muestra fondos correctos
+**Toca archivos protegidos:** parcial (TurnManager para hooks de Retazos en
+eventos del combate).
 
-#### Bugs/gaps en TurnManager (REQUIEREN aprobación explícita por archivo protegido)
-- [ ] **PhaseBased AI**: declarado en `EnemyEnums.AIPattern.PhaseBased` pero sin
-      case en `SelectEnemyMove()`. Implementar selección por fases (HP thresholds
-      o turn count) o eliminar del enum si no se va a usar.
-- [ ] **EffectType.Heal**: no existe. BossAct1 Regenerate usa Block como
-      workaround. Si el GDD nuevo introduce mecánicas de heal/recover, agregar
-      `EffectType.Heal` + `HealAction` + case en `CreateAction()`.
-- [ ] **CalculateIntentValue gaps**: solo maneja `Attack+Damage` y `Defend+Block`.
-      Si se agregan combinaciones nuevas (ej: Defend+Heal, Buff+StatusEffect),
-      ampliar el switch.
+**Dependencias:** M2 cerrado (Retazos de cambio dependen de cargas estables;
+hoguera depende de `EffectType.Heal`).
 
-#### Tooling
-- [ ] Instalar `gh` CLI para automatizar creación de PRs desde terminal
-- [ ] Verificar que el otro developer también lo instala
+**Complejidad:** alta. Retazos solos son alta complejidad por la cantidad de
+hooks y categorías.
 
-**Dependencias:** ninguna específica. Cada item es independiente. Las extracciones
-3-4 pueden ejecutarse antes o durante M1.
-**Prioridad:** baja-media. No bloquea ninguna feature, pero pagar antes del GDD
-nuevo evita acumulación.
+---
+
+### M4 — Resto del Acto 1 según GDD v2
+
+**Objetivo:** cerrar el contenido del Acto 1: mejora de cartas, eventos básicos
+y multidimensionales, enemigos transdimensionales y enemigos ancla.
+
+**Sub-tareas (desagregar al activar):**
+- Mejora de cartas (DD-013): toggle `IsUpgraded` en `CardDeckEntry`, campos
+  upgraded en `CardDefinition`, mejora ambos lados de cartas duales, UI
+- Eventos (DD-005): `EventDefinition` SO, controller, choice UI, sistema de
+  decisiones, eventos multidimensionales (elegir mundo)
+- Quests con MCguffin (DD-021 se cierra aquí): tracking en RunState, marca de
+  nodo destino en mapa, eventos de aceptar/robar
+- Enemigos transdimensionales (DD-014): campo `TypeWorldB` en `EnemyDefinition`,
+  resolución de tipo activo según `RunState.CurrentWorld`
+- Enemigos ancla (DD-014): flag `IsAnchor` en `EnemyDefinition`, bypass del
+  cambio de mundo en lógica
+
+**Toca archivos protegidos:** sí (TurnManager para tipo activo de transdim y
+ancla).
+
+**Dependencias:** M3 cerrado (eventos pueden otorgar Retazos / mejoras y
+necesitan el sistema funcionando).
+
+**Complejidad:** alta. El sistema de eventos con quests es trabajo significativo.
+
+---
+
+### M5 — Bosses con fases + Boss Acto 1 según GDD v2
+
+**Objetivo:** rediseñar el Boss del Acto 1 (Costura Maldita / UNIT-RB7) según
+DD-004 con fases, debuffs únicos y mecánica "Desfase Dimensional". Establecer
+el patrón para futuros bosses.
+
+**Sub-tareas (desagregar al activar):**
+- Sistema de fases en bosses (Fase 2 obligatoria al 50% HP)
+- Mecánica "Desfase Dimensional": contador de cartas jugadas en turno, cambio
+  automático cada 3 cartas (2 en Fase 2)
+- Debuff Sangrado (DD-019, exclusivo del boss medieval): pérdida de HP al jugar
+  ataque
+- Debuff Virus (DD-019, exclusivo del boss cyberpunk): bloqueo al 80%
+  efectividad
+- 2 tipos por boss (1 SuperEficaz contra el jugador, 1 debilidad)
+- Retazo único de boss vinculado narrativamente
+
+**Toca archivos protegidos:** sí (TurnManager + ActionQueue para hook
+post-ProcessAll y mutación de mundo desde IA).
+
+**Dependencias:** M2 cerrado (cambio de mundo robusto), M4 cerrado (transdim/
+ancla establecen el patrón de tipos múltiples).
+
+**Complejidad:** alta.
+
+---
+
+### M6 — Acto 2, Acto 3, Meta-progresión
+
+**Objetivo:** llevar el juego a su shape final: 3 actos, dificultad escalada
+según DD-011, XP entre runs, desbloqueos según DD-016.
+
+**Probable subdivisión:**
+- M6a — Acto 2 (HP enemigo, 2 tipos simultáneos, fases simples por umbral,
+  primer transdimensional, elites con 2 mecánicas)
+- M6b — Acto 3 (multifase, ancla, bosses que bloquean/fuerzan cambio,
+  restricciones de cambio)
+- M6c — Meta-progresión (XP, persistencia, desbloqueos, viñetas narrativas
+  iniciales — DD-015 entra aquí si está listo)
+
+**Toca archivos protegidos:** parcial (Acto 3 con bosses que bloquean cambio
+toca TurnManager).
+
+**Dependencias:** M5 cerrado (Boss Acto 1 funcional como plantilla).
+
+**Complejidad:** muy alta.
 
 ---
 
 ## Completados
+
+### M0 — Setup del sistema de modos
+**Fecha cierre:** 2026-04-28
+**Resumen:**
+- CLAUDE.md raíz reescrito con sistema de 4 modos (gdd, diseno, implementacion,
+  revision) + conversacional por defecto.
+- `_insights.md`, `_gdd.md` placeholder, `_tech_snapshot.md`, `_roadmap.md`
+  creados con plantillas y estado real del proyecto.
+- `Assets/Scripts/Gameplay/Combat/CLAUDE.md` actualizado para mencionar el
+  sistema de modos y restricciones específicas de combate.
+- Smoke test pendiente fue absorbido por uso real durante M1.
+
+### M1 — Procesar GDD v2
+**Fecha cierre:** 2026-04-28
+**Resumen:**
+- GDD v2 procesado por completo en sesión `modo:gdd`.
+- DDs cerradas en `DESIGN_DECISIONS.md`: DD-001 a DD-016 (todas excepto DD-015
+  postponed por narrativa). Reglas movidas a `GOLDEN_RULES.md`.
+- 5 DDs nuevas detectadas y resueltas en revisión post-GDD: DD-018 (daño enemigo
+  x1.5 con multiplicador configurable), DD-019 (Sangrado/Virus exclusivos del
+  boss), DD-020 (carta especial filtrada por tipos elegidos), DD-021 (MCguffin
+  diferido a M4). DD-017 (Retazos de cambio en contenido base) queda como única
+  abierta — se cierra al diseñar M3.
+- `GOLDEN_RULES.md` ampliado de 7 a 12 secciones: Contador de Estilo (reemplaza
+  Momentum), Mazo inicial, Mejora de cartas, Categorías dimensionales de
+  enemigos, Bosses, 6 tipos de nodos, Economía, Actos y Dificultad, Retazos,
+  Meta-progresión. Marcadores ✓ (implementado) / ⏳ (cerrado por diseño).
+- Roadmap reorganizado con M2-M6 nuevos.
 
 ### Higiene previa (pre-roadmap)
 **Fecha cierre:** 2026-04-27
@@ -157,20 +332,35 @@ nuevo evita acumulación.
 
 ---
 
+## Decisiones abiertas que afectan el roadmap
+
+- **DD-017** — Retazos de cambio en contenido base: se cierra al diseñar M3.
+  No bloquea M2.
+
+---
+
 ## Future work / Backlog (no milestone)
 
-Ideas que pueden volverse milestones cuando el GDD las priorice:
+Ideas que pueden volverse milestones cuando el GDD las priorice o cuando se
+cierren los milestones actuales:
 
-- **CombatUIController fases 5+**: extracción completa quedaría con ~400 loc en
-  CombatUIController (puro orquestador de BuildUI). Probablemente innecesario.
-- **Tests de integración**: actualmente solo hay EditMode tests. Play-mode tests
-  para flujo completo de combate serían útiles antes del GDD nuevo si se va a
-  refactorear mucho.
-- **Sistema de logging**: no hay infraestructura de logging. Cuando se debugee en
-  builds (no editor), va a hacer falta. Actualmente se usan `Debug.Log` con
+- **Refactor cross-cutting de los `Initialize()` de las views**: introducir un
+  struct `ViewRefs` compartido en lugar de 25+ parámetros. Tiene sentido HACER
+  después de Fase 4 cerrada (cuando las 3 views estén estables). ~30 min.
+- **Extracción CombatUIController Fase 5+**: extracción completa quedaría con
+  ~400 loc en CombatUIController (puro orquestador de BuildUI). Probablemente
+  innecesario — evaluar si después de Fase 4 hay algo que extraer aún.
+- **Tests de integración (Play-mode)**: actualmente solo hay EditMode tests.
+  Play-mode tests para flujo completo de combate serían útiles antes de M5
+  (bosses con fases tienen lógica difícil de unit-testear).
+- **Sistema de logging**: no hay infraestructura de logging. Cuando se debugee
+  en builds (no editor), va a hacer falta. Actualmente se usan `Debug.Log` con
   `#if UNITY_EDITOR`.
-- **Strategy pattern para IA enemiga**: la selección de movimientos está baked en
-  TurnManager. Para bosses con comportamiento complejo, va a hacer falta
-  abstraer. Posible milestone si el GDD pide bosses elaborados.
+- **Strategy pattern para IA enemiga**: la selección de movimientos está baked
+  en TurnManager. Para bosses con comportamiento complejo (M5) probablemente
+  haga falta abstraer.
 - **Translación de comentarios**: mezcla español/inglés sin criterio. Decisión
   pendiente: estandarizar a uno solo.
+- **DD-015 Narrativa**: viñetas, diálogo de hermanos, lore. Postponed hasta que
+  se aborde la capa de narrativa explícitamente. Probable que entre como parte
+  de M6c.

--- a/Docs/dev/_tech_snapshot.md
+++ b/Docs/dev/_tech_snapshot.md
@@ -7,8 +7,8 @@
 > En `modo:implementacion` se lee OBLIGATORIAMENTE antes de cualquier cambio que
 > afecte arquitectura o componentes críticos.
 >
-> **Última actualización:** 2026-04-27 — post extracción de CombatFeedbackView
-> y CardHandView (PR #83 mergeado a main)
+> **Última actualización:** 2026-05-01 — post extracción de CombatBackgroundView
+> (Fase 4); CombatUIController 980 → 710 loc
 
 ---
 
@@ -58,7 +58,7 @@ DontDestroyOnLoad.
 MainMenu Scene  →  MainMenuController
 RunScene        →  RunFlowController + RunSession (DDOL)
 BattleScene     →  BattleFlowController + RunSession (DDOL) + CombatUIController
-                                            (con CombatFeedbackView, CardHandView)
+                                            (con CombatFeedbackView, CardHandView, CombatHudView)
 ```
 
 ### Únicos DontDestroyOnLoad
@@ -101,7 +101,7 @@ Exclusivamente vía `RunSession.State` (= `RunState`). Flags principales:
 
 [CombatUIController.Start]
     └─ BuildUI() construye canvas en runtime (HUD, paneles, fondos)
-    └─ InitializeExtractedViews() crea CombatFeedbackView y CardHandView
+    └─ InitializeExtractedViews() crea CombatFeedbackView, CardHandView y CombatHudView
     └─ Cada view se suscribe a TurnManager events de forma independiente
 
 [Loop de combate]
@@ -174,9 +174,11 @@ Gameplay/
     ICombatActor.cs, IGameAction.cs, ActionContext.cs
     ElementTypes.cs              ← 7 tipos + matriz de efectividad
     SpriteFrameAnimatorUI.cs
-    CombatUIController.cs        ← 980 loc (era 1473)
+    CombatUIController.cs        ← 710 loc (era 1473)
     CombatFeedbackView.cs        ← 357 loc (extraído en Fase 1)
     CardHandView.cs              ← 400 loc (extraído en Fase 2)
+    CombatHudView.cs             ← 327 loc (extraído en Fase 3)
+    CombatBackgroundView.cs      ← 182 loc (extraído en Fase 4)
     CombatAmbientParticles.cs
     Actions/
       DamageAction.cs, BlockAction.cs, DrawCardsAction.cs
@@ -295,8 +297,8 @@ de tocar.
 - **No CI/CD** configurado. Tests se corren localmente vía Unity Test Runner.
 - **No gh CLI** instalado. PRs se crean manualmente desde la URL que devuelve `git push`.
 - **Comentarios mezclados español/inglés** sin criterio fijo (deuda menor, ver roadmap).
-- **CombatUIController sigue grande** (980 loc). Hay plan de extracción documentado
-  en `COMBAT_ARCHITECTURE.md` para Fases 3-4 (CombatHudView, CombatBackgroundView).
+- **CombatUIController** (710 loc post-Fase 4). Descomposición completa — es ahora
+  un orquestador puro de BuildUI y lifecycle. Listo para recibir features de M2.
 - **TurnManager tiene gaps conocidos** que requieren tocar el archivo protegido:
   - PhaseBased AI declarado en enum pero sin implementación en `SelectEnemyMove()`
   - `EffectType.Heal` no existe (BossAct1 Regenerate usa Block como workaround)

--- a/README.md
+++ b/README.md
@@ -1,23 +1,35 @@
 ## Roguelike Card Battler (Unity)
-Prototipo de deckbuilder roguelite 1v1 con tipos elementales, Momentum (free play al golpear debilidad) y cambio de mundo limitado por combate.
 
-### What’s implemented (Epic 1)
-- ElementType placeholder por color + matriz de efectividad.
-- Daño modificado por efectividad (WEAK/RESIST popups).
-- Momentum: golpes SuperEficaz otorgan free plays (HUD “Momentum: X”).
-- Cambio de mundo limitado a 1 por combate (override debug).
-- Tests EditMode corriendo en verde.
+Deckbuilder roguelite 1v1 con **mundos duales** (Medieval Oscuro / Cyberpunk),
+**tipos elementales asimétricos** y cambio de mundo como mecánica diferenciadora.
+Estética handmade (cartón, recortes, papel). Estado: prototipo en desarrollo activo.
+
+### Estado actual
+
+- **Combate 1v1 funcional**: turnos, energía, bloqueo, mano de cartas, `ActionQueue` determinista.
+- **Sistema de tipos asimétrico**: 6 tipos + None, matriz de efectividad (1.5x / 1.0x / 0.75x).
+- **Mundos duales**: cartas duales (sideA/sideB), cambio de mundo limitado por combate.
+- **Vertical Slice Acto 1**: mapa de nodos generado con seed, recompensas post-combate, boss del acto.
+- **UI de combate modular**: `CombatUIController` + 4 views especializados (`CombatFeedbackView`, `CardHandView`, `CombatHudView`, `CombatBackgroundView`).
+- **Tests EditMode** en verde.
 
 ### Quickstart
-- Abrir Unity y cargar `Assets/Scenes/BattleScene.unity`.
+
+- Abrir Unity 6.2 (6000.2.14f1) y cargar `Assets/Scenes/BattleScene.unity`.
 - Tests EditMode: `Window > General > Test Runner` → EditMode → Run All.
 
 ### Docs
-- Onboarding dev: `Docs/dev/DEV_ONBOARDING.md`
-- Índice de docs: `Docs/README.md`
-- Diseño base (Proyecto C): `Docs/design/Proyecto C.pdf`
+
+- **Identidad y reglas inmutables**: [`Docs/dev/GOLDEN_RULES.md`](Docs/dev/GOLDEN_RULES.md)
+- **GDD vigente**: [`Docs/design/_gdd.md`](Docs/design/_gdd.md)
+- **Decisiones de diseño abiertas**: [`Docs/design/DESIGN_DECISIONS.md`](Docs/design/DESIGN_DECISIONS.md)
+- **Roadmap activo**: [`Docs/dev/_roadmap.md`](Docs/dev/_roadmap.md)
+- **Snapshot técnico**: [`Docs/dev/_tech_snapshot.md`](Docs/dev/_tech_snapshot.md)
+- **Onboarding dev**: [`Docs/dev/DEV_ONBOARDING.md`](Docs/dev/DEV_ONBOARDING.md)
+- **Índice general de docs**: [`Docs/README.md`](Docs/README.md)
 
 ### Workflow
-- Ramas: `feat/*`, `docs/*`, `chore/*`.
-- PRs: usar `Closes #<issue>` para autocerrar el issue.
 
+- Ramas: `feat/*`, `docs/*`, `chore/*`, `refactor/*`.
+- PRs: usar `Closes #<issue>` para autocerrar el issue.
+- Sistema de modos para colaboración con asistente de IA: ver [`CLAUDE.md`](CLAUDE.md) en la raíz.


### PR DESCRIPTION
## Summary
Cierra **M1** (procesamiento del GDD v2) y avanza **M-tech** con las dos
últimas fases de descomposición del CombatUIController.

## Cambios
- **GDD v2 procesado**: DD-001 a DD-016 cerradas, `GOLDEN_RULES.md`
  ampliado a 12 secciones, DD-017 abierta para M3.
- **Fase 3** — `CombatHudView` (327 loc): textos del HUD, botones End
  Turn / Change World, highlight de avatares por turno.
- **Fase 4** — `CombatBackgroundView` (182 loc): sky/ground con polling
  autónomo de mundo, CoverFill, sprites/colores A/B.
- **CombatUIController**: 1473 → 710 loc (-52% acumulado).
- **README** actualizado con estado actual y links a docs vigentes.

## Test plan
- [x] Compila sin errores en Unity (verificado tras fix de using en
      CombatHudView que era latente desde Fase 3).
- [x] BattleScene funcional con combate completo (validación manual de Fase 4).
- [x] Code review aprobado por agente.

## Notas
- Próximo bloque: instalar `gh` CLI (cierra M-tech) y arrancar **M2**
  (TurnManager v2 — toca archivos protegidos, requiere aprobación).
