### PR TITLE
M2 Sub-PR A: PlayerActiveType + EffectivenessMultipliers

### DIFF
--- a/Assets/Scripts/Gameplay/Combat/ElementTypes.cs
+++ b/Assets/Scripts/Gameplay/Combat/ElementTypes.cs
@@ -103,5 +103,31 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             }
         }
     }
+
+    /// <summary>
+    /// Multiplicadores de efectividad centralizados (DD-018). Antes vivían como
+    /// literales dentro de TurnManager.AdjustDamageForEffectiveness; ahora se
+    /// declaran aquí para que sub-PRs siguientes (efectividad bidireccional,
+    /// daño x1.5 al jugador, cartas neutras al 90%) los reutilicen sin
+    /// duplicación.
+    /// </summary>
+    public static class EffectivenessMultipliers
+    {
+        public const float SuperEficaz = 1.5f;
+        public const float Neutro = 1.0f;
+        public const float PocoEficaz = 0.75f;
+
+        // Cartas con tipo None aplican este multiplicador adicional al daño base
+        // (DD-002). Declarado en sub-PR A; sub-PR C lo aplica.
+        public const float NeutralCardDamage = 0.9f;
+
+        public static float For(Effectiveness effectiveness) =>
+            effectiveness switch
+            {
+                Effectiveness.SuperEficaz => SuperEficaz,
+                Effectiveness.PocoEficaz => PocoEficaz,
+                _ => Neutro
+            };
+    }
 }
 

--- a/Assets/Scripts/Gameplay/Combat/TurnManager.cs
+++ b/Assets/Scripts/Gameplay/Combat/TurnManager.cs
@@ -25,6 +25,9 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         [SerializeField, Min(1)] private int startingHandSize = 5;
         [SerializeField, Min(1)] private int cardsPerTurn = 5;
         [SerializeField, Min(1)] private int maxHandSize = 7;
+        [Header("Player Element Types (defaults; override via ConfigureCombat)")]
+        [SerializeField] private ElementType playerWorldATypeDefault = ElementType.Rojo;
+        [SerializeField] private ElementType playerWorldBTypeDefault = ElementType.Amarillo;
         [Header("World Switch Settings")]
         [SerializeField, Min(1)] private int maxWorldSwitchesPerCombat = 1;
         [SerializeField] private bool debugUnlimitedWorldSwitches = false;
@@ -49,6 +52,11 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         [SerializeField] private WorldSide currentWorld = WorldSide.A;
         private int _worldSwitchesUsed;
         private int _freePlays;
+        // Tipos elegidos al inicio del run (uno por mundo). Inyectados desde
+        // RunState via ConfigureCombat; en escenas independientes (BattleScene
+        // standalone, tests) caen al default del SerializeField.
+        private ElementType _playerWorldAType;
+        private ElementType _playerWorldBType;
         private bool _autoEndedThisTurn;
         private bool _resolvingCard;
 
@@ -80,6 +88,15 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         public EnemyIntentType PlannedEnemyIntentType => _plannedEnemyMove?.IntentType ?? EnemyIntentType.Unknown;
         public int PlannedEnemyIntentValue => CalculateIntentValue(_plannedEnemyMove);
         public WorldSide CurrentWorld => currentWorld;
+
+        /// <summary>
+        /// Tipo activo del jugador, derivado del mundo actual y los 2 tipos
+        /// elegidos al inicio del run. Sub-PR A solo lo expone — sub-PR B lo
+        /// consume para aplicar efectividad bidireccional al daño enemigo.
+        /// </summary>
+        public ElementType PlayerActiveType =>
+            currentWorld == WorldSide.A ? _playerWorldAType : _playerWorldBType;
+
         public float CurrentEnemyAvatarScale => enemyDefinition != null ? Mathf.Max(0.1f, enemyDefinition.AvatarScale) : 1f;
         public Vector2 CurrentEnemyAvatarOffset => enemyDefinition != null ? enemyDefinition.AvatarOffset : Vector2.zero;
         public ElementType EnemyElementType => enemyDefinition != null ? enemyDefinition.ElementType : ElementType.None;
@@ -162,6 +179,17 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             _freePlays = Mathf.Max(0, value);
         }
 
+        public void SetPlayerTypesForTest(ElementType worldAType, ElementType worldBType)
+        {
+            _playerWorldAType = worldAType;
+            _playerWorldBType = worldBType;
+        }
+
+        public void SetCurrentWorldForTest(WorldSide world)
+        {
+            currentWorld = world;
+        }
+
         public void SetWorldSwitchesForTest(int used, int? maxPerCombat = null, bool? unlimited = null)
         {
             _worldSwitchesUsed = Mathf.Max(0, used);
@@ -190,6 +218,11 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 Debug.LogError("Enemy definition is missing.");
                 return;
             }
+
+            // Fallback a defaults del inspector cuando ConfigureCombat no inyectó
+            // tipos válidos (escenas standalone, tests sin override explícito).
+            if (_playerWorldAType == ElementType.None) _playerWorldAType = playerWorldATypeDefault;
+            if (_playerWorldBType == ElementType.None) _playerWorldBType = playerWorldBTypeDefault;
 
             int maxHp = _initialPlayerMaxHpOverride.HasValue
                 ? Mathf.Max(1, _initialPlayerMaxHpOverride.Value)
@@ -229,7 +262,9 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             EnemyDefinition enemy,
             int? playerCurrentHpOverride = null,
             int? playerMaxHpOverride = null,
-            bool initializeImmediately = true)
+            bool initializeImmediately = true,
+            ElementType playerWorldAType = ElementType.None,
+            ElementType playerWorldBType = ElementType.None)
         {
             if (deck == null || deck.Count == 0)
             {
@@ -247,6 +282,10 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             enemyDefinition = enemy;
             _initialPlayerHpOverride = playerCurrentHpOverride;
             _initialPlayerMaxHpOverride = playerMaxHpOverride;
+            // None marca "sin override"; InitializeCombat aplica el default del
+            // SerializeField si los campos quedan en None.
+            _playerWorldAType = playerWorldAType;
+            _playerWorldBType = playerWorldBType;
             _externalConfigApplied = true;
 
             if (initializeImmediately)
@@ -451,12 +490,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
 
             ElementType defenderType = enemyDefinition != null ? enemyDefinition.ElementType : ElementType.None;
             Effectiveness effectiveness = ElementEffectiveness.GetEffectiveness(sourceElementType, defenderType);
-            float multiplier = effectiveness switch
-            {
-                Effectiveness.SuperEficaz => 1.5f,
-                Effectiveness.PocoEficaz => 0.75f,
-                _ => 1f
-            };
+            float multiplier = EffectivenessMultipliers.For(effectiveness);
 
             int adjusted = Mathf.RoundToInt(baseAmount * multiplier);
             int finalAmount = Math.Max(0, adjusted);

--- a/Assets/Scripts/Run/BattleFlowController.cs
+++ b/Assets/Scripts/Run/BattleFlowController.cs
@@ -175,7 +175,14 @@ namespace RoguelikeCardBattler.Run
 #if UNITY_EDITOR
             Debug.Log($"[BattleFlow] Deck size: {deck.Count}, Enemy: {enemyToUse.EnemyName}, IsBoss: {_isBossBattle}, HP: {currentHp}/{maxHp}");
 #endif
-            _turnManager.ConfigureCombat(deck, enemyToUse, currentHp, maxHp);
+            _turnManager.ConfigureCombat(
+                deck,
+                enemyToUse,
+                playerCurrentHpOverride: currentHp,
+                playerMaxHpOverride: maxHp,
+                initializeImmediately: true,
+                playerWorldAType: session.State.PlayerWorldAType,
+                playerWorldBType: session.State.PlayerWorldBType);
             _configured = true;
         }
 

--- a/Assets/Scripts/Run/RunState.cs
+++ b/Assets/Scripts/Run/RunState.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using RoguelikeCardBattler.Gameplay.Cards;
+using RoguelikeCardBattler.Gameplay.Combat;
 
 namespace RoguelikeCardBattler.Run
 {
@@ -28,6 +29,13 @@ namespace RoguelikeCardBattler.Run
         public NodeOutcome LastNodeOutcome { get; set; } = NodeOutcome.None;
         public bool RunFailed { get; set; }
         public bool ActoCompleted { get; set; } = false;
+
+        // Los 2 tipos elegidos al inicio del run (uno por mundo). Sub-PR A los
+        // declara con defaults Rojo/Amarillo; futuras pantallas de selección
+        // (M3) los sobreescribirán. TurnManager los lee en ConfigureCombat
+        // para derivar PlayerActiveType según el mundo activo.
+        public ElementType PlayerWorldAType { get; set; } = ElementType.Rojo;
+        public ElementType PlayerWorldBType { get; set; } = ElementType.Amarillo;
 
         public void EnsureInitialized(ActMap map)
         {
@@ -62,6 +70,8 @@ namespace RoguelikeCardBattler.Run
             LastNodeOutcome = NodeOutcome.None;
             RunFailed = false;
             ActoCompleted = false;
+            PlayerWorldAType = ElementType.Rojo;
+            PlayerWorldBType = ElementType.Amarillo;
             EnsureInitialized(map);
         }
 

--- a/Assets/Tests/EditMode/DamageEffectivenessTests.cs
+++ b/Assets/Tests/EditMode/DamageEffectivenessTests.cs
@@ -114,6 +114,43 @@ namespace RoguelikeCardBattler.Tests.EditMode
         }
 
         [Test]
+        public void PlayerActiveType_FollowsCurrentWorld()
+        {
+            var damage = CreateEffect(EffectType.Damage, 0, EffectTarget.SingleEnemy);
+            var card = CreateCardWithElement(
+                "filler",
+                CardType.Attack,
+                CardTarget.SingleEnemy,
+                cost: 0,
+                elementType: ElementType.None,
+                damage);
+
+            var enemy = CreateEnemyDefinition(
+                "enemy_none",
+                "Enemy None",
+                maxHp: 10,
+                pattern: EnemyAIPattern.Sequence,
+                moves: new List<EnemyMove>(),
+                elementType: ElementType.None);
+
+            var manager = CreateTurnManager(card, enemy);
+            manager.SetPlayerTypesForTest(ElementType.Rojo, ElementType.Amarillo);
+            manager.InitializeCombat();
+
+            // Mundo A → tipo de A (Rojo).
+            Assert.AreEqual(TurnManager.WorldSide.A, manager.CurrentWorld);
+            Assert.AreEqual(ElementType.Rojo, manager.PlayerActiveType);
+
+            // Mundo B → tipo de B (Amarillo).
+            manager.SetCurrentWorldForTest(TurnManager.WorldSide.B);
+            Assert.AreEqual(ElementType.Amarillo, manager.PlayerActiveType);
+
+            // Volver a A → vuelve al tipo de A.
+            manager.SetCurrentWorldForTest(TurnManager.WorldSide.A);
+            Assert.AreEqual(ElementType.Rojo, manager.PlayerActiveType);
+        }
+
+        [Test]
         public void SuperEffectiveHit_GrantsFreePlay()
         {
             var damage = CreateEffect(EffectType.Damage, 10, EffectTarget.SingleEnemy);

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -64,12 +64,12 @@ limpio.
       combate)
 - [ ] Cambios múltiples de mundo por combate (cap dinámico: 1 base + extras por
       cargas / cartas / Retazos)
-- [ ] Tipo activo del jugador (campo derivado del mundo, viene de los 2 tipos
-      elegidos al inicio del run)
+- [x] Tipo activo del jugador (campo derivado del mundo, viene de los 2 tipos
+      elegidos al inicio del run) *(Sub-PR A — PR #86)*
 - [ ] Daño enemigo SuperEficaz contra el jugador: aplicar multiplicador x1.5
       (DD-018) — multiplicador configurable como constante
-- [ ] Hacer configurables los multiplicadores de efectividad (1.5 / 1.0 / 0.75)
-      como constantes en código
+- [x] Hacer configurables los multiplicadores de efectividad (1.5 / 1.0 / 0.75)
+      como constantes en código *(Sub-PR A — PR #86)*
 - [ ] Cartas neutras al 90% del daño base (DD-002)
 
 #### Deuda técnica que se cierra aquí (bundle de M-tech)

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -7,10 +7,10 @@
 > En `modo:implementacion` se lee al inicio para saber qué milestone está activo
 > y qué sub-tareas quedan.
 >
-> **Fase actual:** post-procesamiento del GDD v2. Cerrando deuda técnica de UI antes de M2.
-> **Milestone activo:** M-tech — Deuda técnica acumulada (solo queda `gh` CLI)
-> **Próximo gran bloque:** M2 — TurnManager v2 (mecánica core nueva + bundle de deuda)
-> **Última actualización:** 2026-05-01 (post-validación Fase 4 CombatBackgroundView)
+> **Fase actual:** entrando a M2 — reescritura de la mecánica core sobre TurnManager.
+> **Milestone activo:** M2 — TurnManager v2 (mecánica core nueva + bundle de deuda)
+> **Próximo bloque:** M3 — Personalización del run (Retazos, Tienda, Hoguera)
+> **Última actualización:** 2026-05-01 (post-cierre M-tech, gh CLI instalado)
 
 ---
 
@@ -43,75 +43,6 @@
 ---
 
 ## Activo
-
-### M-tech — Deuda técnica acumulada
-
-**Objetivo:** terminar la descomposición de CombatUIController y pagar deuda
-técnica de tooling antes de entrar a M2 (que reescribe TurnManager). Las deudas
-que tocan archivos protegidos se **bundlean con M2** porque su PR va a tocar
-TurnManager igual — abrirlo dos veces sería desperdicio.
-
-**Por qué se mantiene activo:** Fase 4 es refactor puro de UI sin tocar
-protegidos. Pagarla ahora deja CombatUIController listo para recibir las
-features nuevas de M2 (Contador de Estilo en HUD, indicador de tipo activo,
-etc.) sin reabrir el monolito.
-
-**Sub-tareas independientes (paralelas, sin protegidos):**
-
-#### Fase 3 — Extracción de CombatHudView (✅ CERRADA 2026-04-28)
-- [x] Spec en `modo:diseno`
-- [x] Implementación con los 10 pasos del spec
-- [x] Validación manual en BattleScene (14 casos de prueba)
-- [x] Revisión de código (`modo:revision`)
-- [x] Merge
-
-**Resultado:** CombatUIController de 980 → **842 loc** (-14%). CombatHudView.cs
-creado con **330 loc** (HUD textos, botones End Turn / Change World, highlight
-de avatares por turno). Comportamiento idéntico al anterior. Cero errores en
-consola.
-
-#### Fase 4 — Extracción de CombatBackgroundView (✅ CERRADA 2026-05-01)
-- [x] Spec en `modo:diseno`
-- [x] Implementación
-- [x] Revisión de código
-- [x] Validación manual en BattleScene
-- [ ] Merge *(pendiente del usuario)*
-
-**Resultado:** CombatUIController de 842 → **710 loc** (-16%). CombatBackgroundView.cs
-creado con **182 loc** (sky/ground, sprites/colores A/B, CoverFill, polling autónomo
-de CurrentWorld). `_owner` eliminado de CombatHudView.
-
-**Bug surfaced + fixed durante validación:** CombatHudView.cs no tenía
-`using RoguelikeCardBattler.Gameplay.Enemies;` (latente desde Fase 3, donde
-`BuildEnemyIntentLabel` se movió sin replicar el using). 6 errores CS0246/CS0103
-en consola al abrir Unity. Fix: agregada la línea de using. Ver `_insights.md`
-para el aprendizaje sobre validación de compilación en Unity.
-
-#### Tooling
-- [ ] Instalar `gh` CLI para automatizar creación de PRs desde terminal (no
-      requiere prompt — son 2-3 comandos en terminal)
-- [ ] Verificar que el otro developer también lo instala
-
-**Sub-tareas que se BUNDLEAN con M2 (tocan TurnManager protegido):**
-
-- ~~PhaseBased AI~~ — se implementa dentro de M2 al reescribir `SelectEnemyMove()`.
-- ~~`EffectType.Heal` + `HealAction`~~ — se implementa dentro de M2 al reescribir
-  el case dispatch de `CreateAction()`.
-- ~~`CalculateIntentValue` gaps~~ — se amplía dentro de M2.
-
-Razón: cada uno toca `TurnManager.cs` (PROTEGIDO). En lugar de abrir el archivo
-protegido 4 veces (una por cada deuda más una por M2), se abre 1 sola vez en
-M2 con todas las features cohesivas a la vez. Aprobación de Sebastián una sola
-vez en lugar de cuatro.
-
-**Dependencias:** ninguna específica para Fase 4 / gh CLI.
-**Criterios de cierre del milestone:** Fase 4 mergeada + gh CLI funcional.
-Las deudas bundleadas con M2 NO bloquean el cierre de M-tech — se cierran
-cuando M2 se cierra.
-
----
-
-## Pendientes
 
 ### M2 — TurnManager v2: mecánica core nueva + deuda técnica
 
@@ -161,24 +92,32 @@ PlayerCombatActorTests deberán reescribirse).
 **Toca archivos protegidos:** **SÍ** — TurnManager + PlayerCombatActor.
 **REQUIERE APROBACIÓN EXPLÍCITA** antes de empezar implementación.
 
-**Dependencias:** M-tech Fase 4 cerrada (CombatHudView ya extraído facilita
-la modificación del HUD para cargas; CombatBackgroundView libera el monolito
-para tocar HUD/state sin pisar fondos).
+**Dependencias:** M-tech cerrada ✅ (CombatHudView ya extraído facilita la
+modificación del HUD para cargas; CombatBackgroundView libera el monolito
+para tocar HUD/state sin pisar fondos; gh CLI listo para PRs ágiles).
 
-**Estrategia de PRs:** subdividir en 3-4 sub-PRs cohesivos:
+**Estrategia de PRs:** subdividir en 4 sub-PRs cohesivos:
 - Sub-PR A: tipo activo del jugador + multiplicadores configurables (sin tocar
   comportamiento todavía)
 - Sub-PR B: efectividad bidireccional + daño x1.5 al jugador
 - Sub-PR C: Contador de Estilo + cambios múltiples (reemplaza Momentum)
 - Sub-PR D: PhaseBased AI + Heal + CalculateIntentValue (deuda técnica)
 
+**Validación obligatoria por sub-PR (lección de Fase 3-4, ver `_insights.md`):**
+- Compilación de Unity sin errores antes de marcar como mergeable.
+- Tests EditMode en verde.
+- BattleScene jugable y manualmente verificada.
+
 **Complejidad:** alta. Es el cambio que más riesgo de regresión introduce en el
 motor de combate.
 
 **Criterios de cierre:** todos los tests pasan + comportamiento verificado en
-BattleScene + Momentum completamente eliminado del código.
+BattleScene + Momentum completamente eliminado del código + UI del HUD refleja
+Cargas y tipo activo del jugador.
 
 ---
+
+## Pendientes
 
 ### M3 — Personalización del run
 
@@ -285,6 +224,30 @@ toca TurnManager).
 ---
 
 ## Completados
+
+### M-tech — Deuda técnica acumulada
+**Fecha cierre:** 2026-05-01
+**Resumen:**
+- **Fase 3 — `CombatHudView`** (327 loc): textos del HUD, botones End Turn /
+  Change World, highlight de avatares por turno. Mergeada en PR previo a #85.
+- **Fase 4 — `CombatBackgroundView`** (182 loc): sky/ground, sprites/colores
+  A/B, CoverFill, polling autónomo de `CurrentWorld` (decisión Opción B —
+  pensada para que cartas/Retazos futuros que cambien mundo refresquen fondos
+  sin coordinación). Mergeada en PR #85.
+- **CombatUIController**: 1473 → **710 loc** (-52% acumulado). Quedó como puro
+  orquestador (BuildUI + helpers de creación) + InitializeExtractedViews.
+- **`_owner` eliminado de CombatHudView**: andamio temporal de Fase 3 cerrado.
+  HudView ya no conoce a CombatUIController.
+- **Bug catcheado y fixeado**: CombatHudView no tenía `using
+  RoguelikeCardBattler.Gameplay.Enemies;` (latente desde Fase 3, surfaced al
+  abrir Unity post-Fase 4). 6 errores CS0246/CS0103 resueltos con la línea
+  faltante. Insight 1 registrado en `_insights.md` para que validación de
+  refactors abra Unity como criterio de cierre.
+- **`gh` CLI instalado y autenticado**: `winget install --id GitHub.cli`.
+  Habilita creación de PRs desde terminal sin copy-paste manual.
+- **Deudas técnicas BUNDLEADAS con M2** (no se cerraron aquí porque tocan
+  TurnManager protegido): PhaseBased AI, `EffectType.Heal`, `CalculateIntentValue`
+  gaps. Se resuelven dentro del refactor coordinado de M2.
 
 ### M0 — Setup del sistema de modos
 **Fecha cierre:** 2026-04-28


### PR DESCRIPTION
## Resumen

Sub-PR A de M2 (1 de 4). **Trabajo preparatorio puro — no cambia comportamiento observable.**
Instala la base que sub-PRs B/C/D necesitan para ampliar el motor de combate
sin volver a abrir TurnManager varias veces.

## Cambios

### Refactor
- **`EffectivenessMultipliers`** (clase nueva en `ElementTypes.cs`): centraliza
  los multiplicadores `1.5 / 1.0 / 0.75` que vivían como literales sueltos
  dentro de `TurnManager.AdjustDamageForEffectiveness`. Declara también
  `NeutralCardDamage = 0.9f` (DD-002) que sub-PR C consumirá para cartas neutras.
- **`TurnManager.AdjustDamageForEffectiveness`**: el switch literal pasa a
  `EffectivenessMultipliers.For(effectiveness)`. Mismo valor numérico — los
  tests existentes (DamageEffectivenessTests, ElementEffectivenessTests) pasan
  sin tocarse.

### Feature preparatoria
- **`TurnManager.PlayerActiveType`** (property nueva): devuelve el tipo del
  jugador según el mundo activo, derivado de los 2 tipos del run.
  **Nadie la consume todavía** — sub-PR B la usará para aplicar efectividad
  bidireccional al daño enemigo.
- **`TurnManager.ConfigureCombat`**: ampliado con 2 params opcionales
  (`playerWorldAType`, `playerWorldBType`). `None` = "sin override", cae al
  fallback del inspector. Backwards-compatible.
- **`RunState`**: 2 properties nuevas (`PlayerWorldAType`, `PlayerWorldBType`)
  con defaults `Rojo`/`Amarillo`. Las pantallas de selección de tipo del run
  en M3 las setearán.
- **`BattleFlowController`**: cierra el bridge `RunSession.State` →
  `TurnManager.ConfigureCombat` pasando los tipos.

### Test
- **`PlayerActiveType_FollowsCurrentWorld`**: verifica los 3 estados
  (A→Rojo, B→Amarillo, vuelta a A→Rojo). Usa helpers EditMode-only nuevos
  (`SetPlayerTypesForTest`, `SetCurrentWorldForTest`) consistentes con
  `SetFreePlaysForTest`.

## Archivos protegidos tocados

`Assets/Scripts/Gameplay/Combat/TurnManager.cs` — **aprobación previa otorgada**
en el spec del usuario (modo:diseño). PlayerCombatActor y ActionQueue intactos.

## Test plan

- [x] Compilación de Unity sin errores (validado por el usuario en BattleScene)
- [x] Test Runner > EditMode > Run All en verde (incluye el test nuevo)
- [x] BattleScene jugable y manualmente verificada:
  - Combate inicia, fondos Mundo A correctos
  - SuperEficaz → daño x1.5, popup WEAK, momentum +1
  - PocoEficaz → daño x0.75, popup RESIST
  - Change World → label/fondo cambian, switches counter sube
  - CERO errores en consola

## Lo que NO hace este sub-PR (intencional)

- ❌ No aplica `PlayerActiveType` a ninguna lógica de gameplay (eso es sub-PR B)
- ❌ No cambia el HUD (Momentum sigue visible — eso es sub-PR C)
- ❌ No elimina Momentum (eso es sub-PR C)
- ❌ No toca `PlayerCombatActor`, `ActionQueue`, ni los tests existentes

## Próximos sub-PRs de M2

- **Sub-PR B**: efectividad bidireccional + daño x1.5 al jugador (consume
  `PlayerActiveType` introducida acá)
- **Sub-PR C**: Contador de Estilo reemplaza Momentum + cambios múltiples de mundo
- **Sub-PR D**: deuda técnica (PhaseBased AI, EffectType.Heal,
  CalculateIntentValue gaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)