### PR TITLE
M2 Sub-PR B: bidirectional effectiveness + enemy SuperEficaz x1.5 (DD-018)

### DIFF
--- a/Assets/ScriptableObjects/Enemies/DarkMage.asset
+++ b/Assets/ScriptableObjects/Enemies/DarkMage.asset
@@ -71,5 +71,5 @@ MonoBehaviour:
     intentType: 1
   avatarScale: 1
   avatarOffset: {x: 0, y: 0}
-  elementType: 0
+  elementType: 3
   avatar: {fileID: 0}

--- a/Assets/ScriptableObjects/Enemies/Goblin.asset
+++ b/Assets/ScriptableObjects/Enemies/Goblin.asset
@@ -59,5 +59,5 @@ MonoBehaviour:
     intentType: 2
   avatarScale: 1
   avatarOffset: {x: 0, y: 0}
-  elementType: 0
+  elementType: 3
   avatar: {fileID: 0}

--- a/Assets/ScriptableObjects/Enemies/SkeletonWarrior.asset
+++ b/Assets/ScriptableObjects/Enemies/SkeletonWarrior.asset
@@ -59,5 +59,5 @@ MonoBehaviour:
     intentType: 1
   avatarScale: 1
   avatarOffset: {x: 0, y: 0}
-  elementType: 0
+  elementType: 3
   avatar: {fileID: 0}

--- a/Assets/Scripts/Gameplay/Combat/TurnManager.cs
+++ b/Assets/Scripts/Gameplay/Combat/TurnManager.cs
@@ -123,6 +123,14 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         /// </summary>
         public event Action<int> PlayerHandLimitReached;
 
+        /// <summary>
+        /// Evento disparado cuando el enemigo aplica daño al jugador y hubo efectividad
+        /// calculada (incluido Neutro). Sub-PR C lo consume para ajustar cargas del
+        /// Contador de Estilo (-1 si SuperEficaz). En Sub-PR B no hay suscriptores;
+        /// el evento existe pero queda silente hasta que la UI lo enchufe en C.
+        /// </summary>
+        public event Action<Effectiveness> EnemyHitEffectiveness;
+
         private void Start()
         {
             if (_externalConfigApplied)
@@ -482,18 +490,33 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 return 0;
             }
 
-            // Apply elemental modifiers only for player card damage against the enemy.
-            if (source != _player || target != _enemy)
+            // Dirección 1: jugador ataca al enemigo. Mantiene Momentum y emite
+            // PlayerHitEffectiveness para popups WEAK/RESIST/MOMENTUM en UI.
+            if (source == _player && target == _enemy)
             {
-                return baseAmount;
+                return ApplyPlayerToEnemyEffectiveness(sourceElementType, baseAmount);
             }
 
+            // Dirección 2 (DD-018, Sub-PR B): enemigo ataca al jugador. El defensor
+            // es PlayerActiveType (derivado del mundo activo). Sin Momentum — ese
+            // sistema desaparece en Sub-PR C. Emite EnemyHitEffectiveness para que
+            // Sub-PR C aplique cargas y la UI muestre feedback cuando se enchufe.
+            if (source == _enemy && target == _player)
+            {
+                return ApplyEnemyToPlayerEffectiveness(sourceElementType, baseAmount);
+            }
+
+            // Cualquier otra combinación (self-damage, tests sintéticos): sin modificadores.
+            return baseAmount;
+        }
+
+        private int ApplyPlayerToEnemyEffectiveness(ElementType attackerType, int baseAmount)
+        {
             ElementType defenderType = enemyDefinition != null ? enemyDefinition.ElementType : ElementType.None;
-            Effectiveness effectiveness = ElementEffectiveness.GetEffectiveness(sourceElementType, defenderType);
+            Effectiveness effectiveness = ElementEffectiveness.GetEffectiveness(attackerType, defenderType);
             float multiplier = EffectivenessMultipliers.For(effectiveness);
 
-            int adjusted = Mathf.RoundToInt(baseAmount * multiplier);
-            int finalAmount = Math.Max(0, adjusted);
+            int finalAmount = Math.Max(0, Mathf.RoundToInt(baseAmount * multiplier));
 
             bool momentumGranted = false;
             if (effectiveness == Effectiveness.SuperEficaz && finalAmount > 0)
@@ -504,6 +527,18 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             }
 
             PlayerHitEffectiveness?.Invoke(effectiveness, momentumGranted);
+            return finalAmount;
+        }
+
+        private int ApplyEnemyToPlayerEffectiveness(ElementType attackerType, int baseAmount)
+        {
+            ElementType defenderType = PlayerActiveType;
+            Effectiveness effectiveness = ElementEffectiveness.GetEffectiveness(attackerType, defenderType);
+            float multiplier = EffectivenessMultipliers.For(effectiveness);
+
+            int finalAmount = Math.Max(0, Mathf.RoundToInt(baseAmount * multiplier));
+
+            EnemyHitEffectiveness?.Invoke(effectiveness);
             return finalAmount;
         }
 

--- a/Assets/Tests/EditMode/DamageEffectivenessTests.cs
+++ b/Assets/Tests/EditMode/DamageEffectivenessTests.cs
@@ -150,6 +150,87 @@ namespace RoguelikeCardBattler.Tests.EditMode
             Assert.AreEqual(ElementType.Rojo, manager.PlayerActiveType);
         }
 
+        // ── Tests de efectividad Enemy → Player (DD-018, Sub-PR B) ──────────────
+
+        [Test]
+        public void EnemyDamage_SuperEffectiveAgainstPlayer_DealsIncreasedDamage()
+        {
+            // enemy=Amarillo, player=Rojo. Amarillo→Rojo es SuperEficaz.
+            // Daño base 10 → round(10 * 1.5) = 15. HP: 30 - 15 = 15.
+            var attackEffect = CreateEffect(EffectType.Damage, 10, EffectTarget.SingleEnemy);
+            var attackMove = CreateEnemyMove("attack", "Attack", "Ataca",
+                new List<EffectRef> { attackEffect }, weight: 1, intentType: EnemyIntentType.Attack);
+
+            var enemy = CreateEnemyDefinition(
+                "enemy_amarillo", "Enemy Amarillo", maxHp: 30,
+                pattern: EnemyAIPattern.Sequence,
+                moves: new List<EnemyMove> { attackMove },
+                elementType: ElementType.Amarillo);
+
+            var card = CreateCardWithElement("dummy", CardType.Skill, CardTarget.Self, cost: 99, ElementType.None);
+            var manager = CreateTurnManager(card, enemy);
+            manager.SetPlayerTypesForTest(ElementType.Rojo, ElementType.Amarillo);
+            manager.InitializeCombat();
+
+            int hpBefore = manager.PlayerHP;
+            manager.EndPlayerTurn();
+
+            Assert.AreEqual(hpBefore - 15, manager.PlayerHP); // round(10 * 1.5) = 15
+        }
+
+        [Test]
+        public void EnemyDamage_LessEffectiveAgainstPlayer_DealsReducedDamage()
+        {
+            // enemy=Rojo, player=Amarillo. Rojo→Amarillo es PocoEficaz.
+            // Daño base 10 → round(10 * 0.75) = round(7.5). Mathf.RoundToInt
+            // usa "round half away from zero" → 8. HP: 30 - 8 = 22.
+            var attackEffect = CreateEffect(EffectType.Damage, 10, EffectTarget.SingleEnemy);
+            var attackMove = CreateEnemyMove("attack", "Attack", "Ataca",
+                new List<EffectRef> { attackEffect }, weight: 1, intentType: EnemyIntentType.Attack);
+
+            var enemy = CreateEnemyDefinition(
+                "enemy_rojo", "Enemy Rojo", maxHp: 30,
+                pattern: EnemyAIPattern.Sequence,
+                moves: new List<EnemyMove> { attackMove },
+                elementType: ElementType.Rojo);
+
+            var card = CreateCardWithElement("dummy", CardType.Skill, CardTarget.Self, cost: 99, ElementType.None);
+            var manager = CreateTurnManager(card, enemy);
+            manager.SetPlayerTypesForTest(ElementType.Amarillo, ElementType.Rojo);
+            manager.InitializeCombat();
+
+            int hpBefore = manager.PlayerHP;
+            manager.EndPlayerTurn();
+
+            Assert.AreEqual(hpBefore - 8, manager.PlayerHP); // round(10 * 0.75) = 8
+        }
+
+        [Test]
+        public void EnemyDamage_NeutralAgainstPlayer_DealsBaseDamage()
+        {
+            // enemy=Rojo, player=Morado. Rojo→Morado es Neutro.
+            // Daño base 10 → 10. HP: 30 - 10 = 20.
+            var attackEffect = CreateEffect(EffectType.Damage, 10, EffectTarget.SingleEnemy);
+            var attackMove = CreateEnemyMove("attack", "Attack", "Ataca",
+                new List<EffectRef> { attackEffect }, weight: 1, intentType: EnemyIntentType.Attack);
+
+            var enemy = CreateEnemyDefinition(
+                "enemy_rojo_neutro", "Enemy Rojo", maxHp: 30,
+                pattern: EnemyAIPattern.Sequence,
+                moves: new List<EnemyMove> { attackMove },
+                elementType: ElementType.Rojo);
+
+            var card = CreateCardWithElement("dummy", CardType.Skill, CardTarget.Self, cost: 99, ElementType.None);
+            var manager = CreateTurnManager(card, enemy);
+            manager.SetPlayerTypesForTest(ElementType.Morado, ElementType.Amarillo);
+            manager.InitializeCombat();
+
+            int hpBefore = manager.PlayerHP;
+            manager.EndPlayerTurn();
+
+            Assert.AreEqual(hpBefore - 10, manager.PlayerHP); // Neutro: sin modificador
+        }
+
         [Test]
         public void SuperEffectiveHit_GrantsFreePlay()
         {

--- a/Docs/dev/GOLDEN_RULES.md
+++ b/Docs/dev/GOLDEN_RULES.md
@@ -100,7 +100,7 @@
 - Multiplicadores: SuperEficaz **1.5x**, Neutro **1.0x**, PocoEficaz **0.75x**
 - Multiplicadores configurables (constantes en codigo, ajustables sin cambiar logica)
 - ✓ Aplica a: dano de carta del jugador vs tipo del enemigo (multiplicador + cargas de Estilo)
-- ⏳ Aplica a: dano del enemigo vs tipo activo del jugador (multiplicador + cargas de Estilo, DD-018)
+- ✓ Aplica a: dano del enemigo vs tipo activo del jugador — multiplicador (DD-018, Sub-PR B). Cargas de Estilo pendientes (Sub-PR C, marcado ⏳ en §4).
 - NO aplica a: bloqueo, robo de cartas, ni ningun otro efecto fuera de dano
 - None vs cualquier tipo = Neutro (no genera ni quita cargas)
 - La tabla es ASIMETRICA: Rojo->Amarillo es SuperEficaz, pero Amarillo->Rojo es Neutro

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -66,8 +66,8 @@ limpio.
       cargas / cartas / Retazos)
 - [x] Tipo activo del jugador (campo derivado del mundo, viene de los 2 tipos
       elegidos al inicio del run) *(Sub-PR A — PR #86)*
-- [ ] Daño enemigo SuperEficaz contra el jugador: aplicar multiplicador x1.5
-      (DD-018) — multiplicador configurable como constante
+- [x] Daño enemigo SuperEficaz contra el jugador: aplicar multiplicador x1.5
+      (DD-018) — multiplicador configurable como constante *(Sub-PR B)*
 - [x] Hacer configurables los multiplicadores de efectividad (1.5 / 1.0 / 0.75)
       como constantes en código *(Sub-PR A — PR #86)*
 - [ ] Cartas neutras al 90% del daño base (DD-002)


### PR DESCRIPTION
## Summary
Sub-PR B de M2 (2 de 4). Primer sub-PR que cambia comportamiento de gameplay.

- **Efectividad bidireccional**: el daño enemigo ahora se ajusta por efectividad contra `PlayerActiveType` (derivado del mundo activo del jugador).
- **Multiplicador x1.5** para ataques enemigos SuperEficaz contra el jugador (DD-018).
- **Refactor de `AdjustDamageForEffectiveness`** → dispatcher + 2 helpers privados (`ApplyPlayerToEnemyEffectiveness`, `ApplyEnemyToPlayerEffectiveness`).
- **Evento `EnemyHitEffectiveness`** declarado y disparado; sin suscriptores todavía — Sub-PR C lo consume para cargas del Contador de Estilo.

## Cambios
- `TurnManager.cs`: +41/-6 loc
- `DamageEffectivenessTests.cs`: +81 loc (3 tests nuevos)
- `GOLDEN_RULES.md`: DD-018 marcada ✓ (multiplicador implementado)
- `_roadmap.md`: checkbox M2 DD-018 cerrado

## Test plan
- [x] 3 tests nuevos verdes: SuperEficaz x1.5, PocoEficaz x0.75 (→8), Neutro base
- [x] Tests existentes pasan sin modificación
- [ ] BattleScene validada manualmente (pendiente de usuario)

## Notas
- Cargas de Estilo (Contador de Estilo) siguen pendientes: Sub-PR C.
- Momentum sigue funcionando en dirección player→enemy hasta Sub-PR C.
- Balance de combate puede sentirse diferente — el ajuste fino es trabajo de M5.