### PR TITLE
M2 Sub-PR C: StyleCounter replaces Momentum + bonus world switch + neutral cards 90%

### DIFF
--- a/Assets/Scripts/Gameplay/Combat/CombatFeedbackView.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatFeedbackView.cs
@@ -9,7 +9,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
 {
     /// <summary>
     /// Maneja toda la retroalimentación visual de combate: popups de efectividad
-    /// (WEAK/RESIST/MOMENTUM), shake de enemigos al recibir daño, flash de paneles,
+    /// (WEAK/RESIST/+ESTILO), shake de enemigos al recibir daño, flash de paneles,
     /// toast de límite de mano, y textos de victoria/derrota.
     ///
     /// Extraído de CombatUIController como parte de la descomposición en componentes
@@ -127,16 +127,16 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         }
 
         // ────────────────────────────────────────────────────────
-        // Efectividad: popups WEAK / RESIST / MOMENTUM +1
+        // Efectividad: popups WEAK / RESIST / +ESTILO
         // ────────────────────────────────────────────────────────
 
-        private void OnPlayerHitEffectiveness(Effectiveness effectiveness, bool momentumGranted)
+        private void OnPlayerHitEffectiveness(Effectiveness effectiveness, bool styleChargeGranted)
         {
             if (_hitFeedbackText == null) return;
 
             string message = effectiveness switch
             {
-                Effectiveness.SuperEficaz => momentumGranted ? "WEAK!\nMOMENTUM +1" : "WEAK!",
+                Effectiveness.SuperEficaz => styleChargeGranted ? "WEAK!\n+ESTILO" : "WEAK!",
                 Effectiveness.PocoEficaz => "RESIST",
                 _ => string.Empty
             };

--- a/Assets/Scripts/Gameplay/Combat/CombatHudView.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatHudView.cs
@@ -26,7 +26,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
 
         // Textos del HUD
         private Text _playerEnergyText;
-        private Text _freePlaysText;
+        private Text _styleChargesText;
         private Text _playerHpLabel;
         private Text _enemyHpLabel;
         private Text _enemyTypeLabel;
@@ -76,7 +76,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         public void Initialize(
             TurnManager turnManager,
             // Textos
-            Text playerEnergyText, Text freePlaysText,
+            Text playerEnergyText, Text styleChargesText,
             Text playerHpLabel, Text enemyHpLabel, Text enemyTypeLabel,
             Text playerBlockText, Text enemyBlockText,
             Text drawPileText, Text discardPileText,
@@ -97,7 +97,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         {
             _turnManager = turnManager;
             _playerEnergyText = playerEnergyText;
-            _freePlaysText = freePlaysText;
+            _styleChargesText = styleChargesText;
             _playerHpLabel = playerHpLabel;
             _enemyHpLabel = enemyHpLabel;
             _enemyTypeLabel = enemyTypeLabel;
@@ -151,15 +151,15 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             if (!_initialized || _turnManager == null) return;
 
             _playerEnergyText.text = $"Energy {_turnManager.PlayerEnergy}/{_turnManager.PlayerMaxEnergy}";
-            if (_freePlaysText != null)
+            if (_styleChargesText != null)
             {
-                _freePlaysText.text = $"Momentum: {_turnManager.FreePlays}";
+                _styleChargesText.text = $"Estilo: {_turnManager.StyleCharges}/5";
             }
             if (_worldSwitchesText != null)
             {
                 string switchesLabel = _turnManager.DebugUnlimitedWorldSwitches
                     ? "Switches: ∞"
-                    : $"Switches: {_turnManager.WorldSwitchesUsed}/{_turnManager.MaxWorldSwitchesPerCombat}";
+                    : $"Switches: {_turnManager.WorldSwitchesUsed}/{_turnManager.TotalAvailableWorldSwitches}";
                 _worldSwitchesText.text = switchesLabel;
             }
             _playerHpLabel.text = $"{_turnManager.PlayerHP}/{_turnManager.PlayerMaxHP}";
@@ -186,7 +186,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 _endTurnLabel.color = _endTurnButton.interactable ? Color.white : DisabledLabelColor;
             }
             bool worldSwitchAvailable = _turnManager.DebugUnlimitedWorldSwitches
-                || _turnManager.WorldSwitchesUsed < _turnManager.MaxWorldSwitchesPerCombat;
+                || _turnManager.WorldSwitchesUsed < _turnManager.TotalAvailableWorldSwitches;
             _changeWorldButton.interactable = playerTurn
                 && !_turnManager.IsCombatFinished
                 && worldSwitchAvailable;

--- a/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
@@ -294,7 +294,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 HudPanelColor);
             Image energyPanelImage = energyPanel.GetComponent<Image>();
             Text playerEnergyText = CreateText("PlayerEnergy", energyPanel, "Energy 0/0", 26, TextAnchor.UpperCenter);
-            Text freePlaysText = CreateText("FreePlays", energyPanel, "Momentum: 0", 18, TextAnchor.LowerCenter);
+            Text styleChargesText = CreateText("StyleCharges", energyPanel, "Estilo: 0/5", 18, TextAnchor.LowerCenter);
 
             RectTransform worldPanel = CreatePanel(
                 "WorldPanel",
@@ -397,7 +397,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             InitializeExtractedViews(
                 hitFeedbackText, handLimitText,
                 energyPanelImage, worldPanelImage,
-                playerEnergyText, freePlaysText,
+                playerEnergyText, styleChargesText,
                 playerHpLabel, enemyHpLabel, enemyTypeLabel,
                 playerBlockText, enemyBlockText,
                 drawPileText, discardPileText,
@@ -415,7 +415,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         private void InitializeExtractedViews(
             Text hitFeedbackText, Text handLimitText,
             Image energyPanelImage, Image worldPanelImage,
-            Text playerEnergyText, Text freePlaysText,
+            Text playerEnergyText, Text styleChargesText,
             Text playerHpLabel, Text enemyHpLabel, Text enemyTypeLabel,
             Text playerBlockText, Text enemyBlockText,
             Text drawPileText, Text discardPileText,
@@ -455,7 +455,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             _hudView = gameObject.AddComponent<CombatHudView>();
             _hudView.Initialize(
                 turnManager,
-                playerEnergyText, freePlaysText,
+                playerEnergyText, styleChargesText,
                 playerHpLabel, enemyHpLabel, enemyTypeLabel,
                 playerBlockText, enemyBlockText,
                 drawPileText, discardPileText,

--- a/Assets/Scripts/Gameplay/Combat/TurnManager.cs
+++ b/Assets/Scripts/Gameplay/Combat/TurnManager.cs
@@ -51,7 +51,9 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         private EnemyMove _plannedEnemyMove;
         [SerializeField] private WorldSide currentWorld = WorldSide.A;
         private int _worldSwitchesUsed;
-        private int _freePlays;
+        private int _styleCharges;
+        // Switches extra otorgados al llegar a 5 cargas de Estilo. No acumulable: máx 1 a la vez.
+        private int _bonusWorldSwitches;
         // Tipos elegidos al inicio del run (uno por mundo). Inyectados desde
         // RunState via ConfigureCombat; en escenas independientes (BattleScene
         // standalone, tests) caen al default del SerializeField.
@@ -101,15 +103,20 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         public Vector2 CurrentEnemyAvatarOffset => enemyDefinition != null ? enemyDefinition.AvatarOffset : Vector2.zero;
         public ElementType EnemyElementType => enemyDefinition != null ? enemyDefinition.ElementType : ElementType.None;
         public EnemyDefinition CurrentEnemyDefinition => enemyDefinition;
-        public int FreePlays => _freePlays;
+        public int StyleCharges => _styleCharges;
+        /// <summary>
+        /// Cap dinámico de cambios de mundo = base + bonus acumulado por Contador de Estilo.
+        /// Reemplaza MaxWorldSwitchesPerCombat como límite operativo en TryChangeWorld.
+        /// </summary>
+        public int TotalAvailableWorldSwitches => maxWorldSwitchesPerCombat + _bonusWorldSwitches;
         public int WorldSwitchesUsed => _worldSwitchesUsed;
         public int MaxWorldSwitchesPerCombat => maxWorldSwitchesPerCombat;
         public bool DebugUnlimitedWorldSwitches => debugUnlimitedWorldSwitches;
 
         /// <summary>
         /// Evento disparado al aplicar daño de carta del jugador al enemigo.
-        /// Entrega la efectividad (WEAK/RESIST/NEUTRAL) y si se otorgó Momentum (+1 free play).
-        /// Consumido por la UI para mostrar popups/labels.
+        /// Entrega la efectividad (WEAK/RESIST/NEUTRAL) y si se otorgó una carga de Estilo.
+        /// Consumido por CombatFeedbackView para mostrar popups WEAK/RESIST/+ESTILO.
         /// </summary>
         public event Action<Effectiveness, bool> PlayerHitEffectiveness;
 
@@ -182,9 +189,14 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             cardsPerTurn = Mathf.Max(1, cardsPerTurnCount);
         }
 
-        public void SetFreePlaysForTest(int value)
+        public void SetStyleChargesForTest(int value)
         {
-            _freePlays = Mathf.Max(0, value);
+            _styleCharges = Mathf.Clamp(value, 0, 5);
+        }
+
+        public void SetBonusWorldSwitchesForTest(int value)
+        {
+            _bonusWorldSwitches = Mathf.Max(0, value);
         }
 
         public void SetPlayerTypesForTest(ElementType worldAType, ElementType worldBType)
@@ -255,7 +267,8 @@ namespace RoguelikeCardBattler.Gameplay.Combat
 
             _player.HandLimitReached += OnPlayerHandLimitReached;
             _worldSwitchesUsed = 0;
-            _freePlays = 0;
+            _styleCharges = 0;
+            _bonusWorldSwitches = 0;
             _initialized = true;
 
             PlanNextEnemyMove();
@@ -490,8 +503,8 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 return 0;
             }
 
-            // Dirección 1: jugador ataca al enemigo. Mantiene Momentum y emite
-            // PlayerHitEffectiveness para popups WEAK/RESIST/MOMENTUM en UI.
+            // Dirección 1: jugador ataca al enemigo. Emite PlayerHitEffectiveness
+            // para popups WEAK/RESIST/+ESTILO en UI.
             if (source == _player && target == _enemy)
             {
                 return ApplyPlayerToEnemyEffectiveness(sourceElementType, baseAmount);
@@ -512,21 +525,34 @@ namespace RoguelikeCardBattler.Gameplay.Combat
 
         private int ApplyPlayerToEnemyEffectiveness(ElementType attackerType, int baseAmount)
         {
+            // Cartas sin tipo (None) aplican 90% del daño base (DD-002).
+            // No pasan por la tabla de efectividad ni modifican cargas.
+            if (attackerType == ElementType.None)
+            {
+                return Math.Max(0, Mathf.RoundToInt(baseAmount * EffectivenessMultipliers.NeutralCardDamage));
+            }
+
             ElementType defenderType = enemyDefinition != null ? enemyDefinition.ElementType : ElementType.None;
             Effectiveness effectiveness = ElementEffectiveness.GetEffectiveness(attackerType, defenderType);
             float multiplier = EffectivenessMultipliers.For(effectiveness);
-
             int finalAmount = Math.Max(0, Mathf.RoundToInt(baseAmount * multiplier));
 
-            bool momentumGranted = false;
+            // Contador de Estilo: +1 carga al hacer SuperEficaz con daño real.
+            // Al llegar a 5 cargas, otorgar 1 switch de mundo extra (no acumulable)
+            // y resetear las cargas.
+            bool styleChargeGranted = false;
             if (effectiveness == Effectiveness.SuperEficaz && finalAmount > 0)
             {
-                _freePlays++;
-                momentumGranted = true;
-                Debug.Log("MOMENTUM: Free Play +1");
+                _styleCharges++;
+                styleChargeGranted = true;
+                if (_styleCharges >= 5 && _bonusWorldSwitches == 0)
+                {
+                    _bonusWorldSwitches = 1;
+                    _styleCharges = 0;
+                }
             }
 
-            PlayerHitEffectiveness?.Invoke(effectiveness, momentumGranted);
+            PlayerHitEffectiveness?.Invoke(effectiveness, styleChargeGranted);
             return finalAmount;
         }
 
@@ -537,6 +563,12 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             float multiplier = EffectivenessMultipliers.For(effectiveness);
 
             int finalAmount = Math.Max(0, Mathf.RoundToInt(baseAmount * multiplier));
+
+            // Contador de Estilo: recibir un hit SuperEficaz enemigo resta 1 carga.
+            if (effectiveness == Effectiveness.SuperEficaz && _styleCharges > 0)
+            {
+                _styleCharges--;
+            }
 
             EnemyHitEffectiveness?.Invoke(effectiveness);
             return finalAmount;
@@ -606,7 +638,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 return false;
             }
 
-            if (!debugUnlimitedWorldSwitches && _worldSwitchesUsed >= maxWorldSwitchesPerCombat)
+            if (!debugUnlimitedWorldSwitches && _worldSwitchesUsed >= TotalAvailableWorldSwitches)
             {
                 Debug.LogWarning("World change limit reached for this combat.");
                 return false;
@@ -657,13 +689,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 return false;
             }
 
-            bool usedFreePlay = false;
-            if (_freePlays > 0)
-            {
-                _freePlays--;
-                usedFreePlay = true;
-            }
-            else if (!_player.SpendEnergy(activeCard.Cost))
+            if (!_player.SpendEnergy(activeCard.Cost))
             {
                 Debug.LogWarning("Not enough energy to play card.");
                 return false;
@@ -674,7 +700,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             ICombatActor target = explicitTarget ?? GetDefaultOpponent(_player);
             QueueEffects(activeCard.Effects, _player, target, activeCard.ElementType);
 
-            prepared = new PreparedCardPlay(cardEntry, activeCard, target, activeCard.Type == CardType.Attack, usedFreePlay);
+            prepared = new PreparedCardPlay(cardEntry, activeCard, target, activeCard.Type == CardType.Attack);
             return true;
         }
 
@@ -726,7 +752,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         }
 
         /// <summary>
-        /// Devuelve si una carta es jugable en el estado actual, considerando Momentum (free plays).
+        /// Devuelve si una carta es jugable en el estado actual.
         /// No tiene side effects ni consume recursos; úsalo desde UI y auto-end turn.
         /// </summary>
         public bool CanPlayCard(CardDeckEntry entry)
@@ -747,7 +773,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 return false;
             }
 
-            return _freePlays > 0 || _player.CanPayEnergy(activeCard.Cost);
+            return _player.CanPayEnergy(activeCard.Cost);
         }
 
         private int CalculateIntentValue(EnemyMove move)
@@ -789,15 +815,13 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         public CardDefinition ActiveCard { get; }
         public ICombatActor Target { get; }
         public bool IsAttackCard { get; }
-        public bool UsedFreePlay { get; }
 
-        public PreparedCardPlay(CardDeckEntry entry, CardDefinition activeCard, ICombatActor target, bool isAttackCard, bool usedFreePlay)
+        public PreparedCardPlay(CardDeckEntry entry, CardDefinition activeCard, ICombatActor target, bool isAttackCard)
         {
             Entry = entry;
             ActiveCard = activeCard;
             Target = target;
             IsAttackCard = isAttackCard;
-            UsedFreePlay = usedFreePlay;
         }
     }
 }

--- a/Assets/Tests/EditMode/DamageEffectivenessTests.cs
+++ b/Assets/Tests/EditMode/DamageEffectivenessTests.cs
@@ -80,40 +80,6 @@ namespace RoguelikeCardBattler.Tests.EditMode
         }
 
         [Test]
-        public void FreePlay_AllowsCardWithoutEnergyAndConsumesCharge()
-        {
-            var damage = CreateEffect(EffectType.Damage, 5, EffectTarget.SingleEnemy);
-            var card = CreateCardWithElement(
-                "strike_cost1",
-                CardType.Attack,
-                CardTarget.SingleEnemy,
-                cost: 1,
-                elementType: ElementType.None,
-                damage);
-
-            var enemy = CreateEnemyDefinition(
-                "enemy_none",
-                "Enemy None",
-                maxHp: 10,
-                pattern: EnemyAIPattern.Sequence,
-                moves: new List<EnemyMove>(),
-                elementType: ElementType.None);
-
-            var manager = CreateTurnManager(card, enemy);
-            manager.SetTestConfig(maxHp: 30, energy: 0, startingHand: 1, cardsPerTurnCount: 1);
-            manager.InitializeCombat();
-            manager.SetFreePlaysForTest(1);
-
-            var cardEntry = manager.PlayerHand[0];
-            bool played = manager.PlayCard(cardEntry);
-
-            Assert.IsTrue(played, "Card should be playable using free play even with 0 energy.");
-            Assert.AreEqual(0, manager.FreePlays, "Free play should be consumed.");
-            Assert.AreEqual(0, manager.PlayerEnergy, "Energy should remain unchanged at 0.");
-            Assert.AreEqual(5, manager.EnemyHP, "Damage should still be applied.");
-        }
-
-        [Test]
         public void PlayerActiveType_FollowsCurrentWorld()
         {
             var damage = CreateEffect(EffectType.Damage, 0, EffectTarget.SingleEnemy);
@@ -232,7 +198,7 @@ namespace RoguelikeCardBattler.Tests.EditMode
         }
 
         [Test]
-        public void SuperEffectiveHit_GrantsFreePlay()
+        public void SuperEffectiveHit_GrantsStyleCharge()
         {
             var damage = CreateEffect(EffectType.Damage, 10, EffectTarget.SingleEnemy);
             var card = CreateCardWithElement(
@@ -254,13 +220,150 @@ namespace RoguelikeCardBattler.Tests.EditMode
             var manager = CreateTurnManager(card, enemy);
             manager.InitializeCombat();
 
-            Assert.AreEqual(0, manager.FreePlays);
+            Assert.AreEqual(0, manager.StyleCharges);
 
             var cardEntry = manager.PlayerHand[0];
             bool played = manager.PlayCard(cardEntry);
 
             Assert.IsTrue(played);
-            Assert.AreEqual(1, manager.FreePlays, "Super effective hit should grant one free play.");
+            Assert.AreEqual(1, manager.StyleCharges, "Super effective hit should grant one style charge.");
+        }
+
+        // ── Tests de Contador de Estilo (Sub-PR C) ──────────────────────────────
+
+        [Test]
+        public void StyleCounter_DecreasesOnEnemySuperEffectiveHit()
+        {
+            // enemy=Amarillo, player=Rojo. Amarillo→Rojo es SuperEficaz → resta carga.
+            var attackEffect = CreateEffect(EffectType.Damage, 5, EffectTarget.SingleEnemy);
+            var attackMove = CreateEnemyMove("attack", "Attack", "Ataca",
+                new List<EffectRef> { attackEffect }, weight: 1, intentType: EnemyIntentType.Attack);
+
+            var enemy = CreateEnemyDefinition(
+                "enemy_amarillo", "Enemy Amarillo", maxHp: 30,
+                pattern: EnemyAIPattern.Sequence,
+                moves: new List<EnemyMove> { attackMove },
+                elementType: ElementType.Amarillo);
+
+            var card = CreateCardWithElement("dummy", CardType.Skill, CardTarget.Self, cost: 99, ElementType.None);
+            var manager = CreateTurnManager(card, enemy);
+            manager.SetPlayerTypesForTest(ElementType.Rojo, ElementType.Amarillo);
+            manager.InitializeCombat();
+            manager.SetStyleChargesForTest(2);
+
+            manager.EndPlayerTurn();
+
+            Assert.AreEqual(1, manager.StyleCharges, "Enemy super effective hit should decrease style charges by 1.");
+        }
+
+        [Test]
+        public void StyleCounter_NeverGoesBelowZero()
+        {
+            // enemy=Amarillo, player=Rojo. SuperEficaz con cargas en 0 → se queda en 0.
+            var attackEffect = CreateEffect(EffectType.Damage, 5, EffectTarget.SingleEnemy);
+            var attackMove = CreateEnemyMove("attack", "Attack", "Ataca",
+                new List<EffectRef> { attackEffect }, weight: 1, intentType: EnemyIntentType.Attack);
+
+            var enemy = CreateEnemyDefinition(
+                "enemy_amarillo_zero", "Enemy Amarillo", maxHp: 30,
+                pattern: EnemyAIPattern.Sequence,
+                moves: new List<EnemyMove> { attackMove },
+                elementType: ElementType.Amarillo);
+
+            var card = CreateCardWithElement("dummy", CardType.Skill, CardTarget.Self, cost: 99, ElementType.None);
+            var manager = CreateTurnManager(card, enemy);
+            manager.SetPlayerTypesForTest(ElementType.Rojo, ElementType.Amarillo);
+            manager.InitializeCombat();
+            // StyleCharges ya está en 0 por default.
+
+            manager.EndPlayerTurn();
+
+            Assert.AreEqual(0, manager.StyleCharges, "Style charges should not go below zero.");
+        }
+
+        [Test]
+        public void StyleCounter_At5ChargesGrantsBonusSwitch()
+        {
+            // player=Rojo, enemy=Azul. Rojo→Azul es SuperEficaz. Con 4 cargas + 1 hit → 5 → bonus switch.
+            var damage = CreateEffect(EffectType.Damage, 10, EffectTarget.SingleEnemy);
+            var card = CreateCardWithElement(
+                "strike_rojo", CardType.Attack, CardTarget.SingleEnemy,
+                cost: 0, elementType: ElementType.Rojo, damage);
+
+            var enemy = CreateEnemyDefinition(
+                "enemy_azul_bonus", "Enemy Azul", maxHp: 50,
+                pattern: EnemyAIPattern.Sequence,
+                moves: new List<EnemyMove>(),
+                elementType: ElementType.Azul);
+
+            var manager = CreateTurnManager(card, enemy);
+            manager.SetPlayerTypesForTest(ElementType.Rojo, ElementType.Amarillo);
+            manager.SetWorldSwitchesForTest(used: 0, maxPerCombat: 1, unlimited: false);
+            manager.InitializeCombat();
+            manager.SetStyleChargesForTest(4);
+
+            var cardEntry = manager.PlayerHand[0];
+            manager.PlayCard(cardEntry);
+
+            Assert.AreEqual(2, manager.TotalAvailableWorldSwitches, "5 charges should grant 1 bonus world switch (total 2).");
+            Assert.AreEqual(0, manager.StyleCharges, "Charges should reset to 0 after reaching 5.");
+        }
+
+        [Test]
+        public void StyleCounter_BonusSwitchNotAccumulated()
+        {
+            // Llegar a 5 cargas dos veces no acumula a 3 switches (máx 2).
+            var damage = CreateEffect(EffectType.Damage, 10, EffectTarget.SingleEnemy);
+            var card = CreateCardWithElement(
+                "strike_rojo_acc", CardType.Attack, CardTarget.SingleEnemy,
+                cost: 0, elementType: ElementType.Rojo, damage);
+
+            var enemy = CreateEnemyDefinition(
+                "enemy_azul_acc", "Enemy Azul", maxHp: 200,
+                pattern: EnemyAIPattern.Sequence,
+                moves: new List<EnemyMove>(),
+                elementType: ElementType.Azul);
+
+            var manager = CreateTurnManager(card, enemy);
+            manager.SetPlayerTypesForTest(ElementType.Rojo, ElementType.Amarillo);
+            manager.SetWorldSwitchesForTest(used: 0, maxPerCombat: 1, unlimited: false);
+
+            // Primer ciclo de 5 cargas: usar SetBonusWorldSwitchesForTest para simular
+            // que ya se otorgó un bonus (el bonus ya está en 1, bloqueando acumulación).
+            manager.InitializeCombat();
+            manager.SetBonusWorldSwitchesForTest(1);
+            manager.SetStyleChargesForTest(4);
+
+            // Siguiente hit SuperEficaz llevaría a 5 cargas, pero bonus ya es 1 → no se acumula.
+            var cardEntry = manager.PlayerHand[0];
+            manager.PlayCard(cardEntry);
+
+            Assert.AreEqual(2, manager.TotalAvailableWorldSwitches, "Bonus should stay at 1 (total 2), never accumulate to 2 (total 3).");
+        }
+
+        [Test]
+        public void StyleCounter_DoesNotIncreaseOnNeutralHit()
+        {
+            // player=Rojo, enemy=Morado. Rojo→Morado es Neutro → no da cargas.
+            var damage = CreateEffect(EffectType.Damage, 10, EffectTarget.SingleEnemy);
+            var card = CreateCardWithElement(
+                "strike_rojo_neutro", CardType.Attack, CardTarget.SingleEnemy,
+                cost: 0, elementType: ElementType.Rojo, damage);
+
+            var enemy = CreateEnemyDefinition(
+                "enemy_morado", "Enemy Morado", maxHp: 20,
+                pattern: EnemyAIPattern.Sequence,
+                moves: new List<EnemyMove>(),
+                elementType: ElementType.Morado);
+
+            var manager = CreateTurnManager(card, enemy);
+            manager.SetPlayerTypesForTest(ElementType.Rojo, ElementType.Amarillo);
+            manager.InitializeCombat();
+
+            var cardEntry = manager.PlayerHand[0];
+            manager.PlayCard(cardEntry);
+
+            Assert.AreEqual(0, manager.StyleCharges, "Neutral hit should not grant style charges.");
         }
     }
 }

--- a/Assets/Tests/EditMode/WorldSwitchLimitTests.cs
+++ b/Assets/Tests/EditMode/WorldSwitchLimitTests.cs
@@ -75,6 +75,58 @@ namespace RoguelikeCardBattler.Tests.EditMode
             Assert.AreEqual(TurnManager.WorldSide.B, manager.CurrentWorld); // Toggles each time; odd count ends in B
             Assert.GreaterOrEqual(manager.WorldSwitchesUsed, 0); // counter may keep increasing even in unlimited mode
         }
+
+        // ── Tests de bonus switch por Contador de Estilo (Sub-PR C) ─────────────
+
+        [Test]
+        public void StyleBonus_GrantedBonus_AllowsExtraSwitch_ThenBlocks()
+        {
+            // Con maxPerCombat=1 y bonus=1 → TotalAvailable=2.
+            // Switch 1: éxito. Switch 2: éxito (usa el bonus). Switch 3: bloqueado.
+            var card = CreateCard("test", CardType.Attack, CardTarget.SingleEnemy, cost: 0);
+            var enemy = CreateEnemyDefinition(
+                "enemy", "Enemy", maxHp: 10,
+                pattern: EnemyAIPattern.Sequence,
+                moves: new List<EnemyMove>(),
+                elementType: ElementType.None);
+
+            var manager = CreateTurnManager(card, enemy);
+            manager.SetWorldSwitchesForTest(used: 0, maxPerCombat: 1, unlimited: false);
+            manager.InitializeCombat();
+            manager.SetBonusWorldSwitchesForTest(1);
+
+            bool first = manager.TryChangeWorld();
+            bool second = manager.TryChangeWorld();
+            bool third = manager.TryChangeWorld();
+
+            Assert.IsTrue(first, "First switch should succeed (base).");
+            Assert.IsTrue(second, "Second switch should succeed (bonus).");
+            Assert.IsFalse(third, "Third switch should be blocked (limit reached).");
+            Assert.AreEqual(2, manager.WorldSwitchesUsed);
+        }
+
+        [Test]
+        public void StyleBonus_AfterBothSwitches_TotalEqualsUsed()
+        {
+            // Después de consumir el bonus, TotalAvailableWorldSwitches == WorldSwitchesUsed.
+            var card = CreateCard("test", CardType.Attack, CardTarget.SingleEnemy, cost: 0);
+            var enemy = CreateEnemyDefinition(
+                "enemy", "Enemy", maxHp: 10,
+                pattern: EnemyAIPattern.Sequence,
+                moves: new List<EnemyMove>(),
+                elementType: ElementType.None);
+
+            var manager = CreateTurnManager(card, enemy);
+            manager.SetWorldSwitchesForTest(used: 0, maxPerCombat: 1, unlimited: false);
+            manager.InitializeCombat();
+            manager.SetBonusWorldSwitchesForTest(1);
+
+            manager.TryChangeWorld();
+            manager.TryChangeWorld();
+
+            Assert.AreEqual(manager.TotalAvailableWorldSwitches, manager.WorldSwitchesUsed,
+                "After consuming both switches, TotalAvailable should equal WorldSwitchesUsed.");
+        }
     }
 }
 

--- a/Docs/dev/GOLDEN_RULES.md
+++ b/Docs/dev/GOLDEN_RULES.md
@@ -57,17 +57,14 @@
 - Si se intenta robar con mano llena, se descarta
 
 ### Cambio de mundo
-- ⏳ 1 cambio gratuito por combate (base, no acumulable entre combates)
-- ⏳ Cambios adicionales pueden venir de:
-  - Sistema de Contador de Estilo (ver §4): 5 cargas otorgan 1 cambio extra (no acumulable)
-  - Cartas con efecto de cambio de mundo
-  - Items (Retazos, ver §10)
-- ⏳ Cambiar de mundo afecta:
+- ✓ 1 cambio base por combate (configurable via SerializeField)
+- ✓ Cambio extra por Contador de Estilo: 5 cargas otorgan 1 cambio extra (no acumulable) — cap dinámico via TotalAvailableWorldSwitches
+- ⏳ Cambios adicionales pendientes: cartas con efecto WorldSwitch, Items (Retazos, ver §10)
+- ✓ Cambiar de mundo afecta:
   - Que lado de las cartas duales esta activo
   - El tipo activo del jugador (= tipo asignado al mundo)
-  - El tipo activo de enemigos transdimensionales (ver §6)
-  - NO afecta enemigos ancla (ver §6)
-- ✓ Hoy implementado: 1 cambio por combate (placeholder, sera reemplazado en M2)
+  - El tipo activo de enemigos transdimensionales (ver §6) — ⏳ pendiente
+  - NO afecta enemigos ancla (ver §6) — ⏳ pendiente
 
 ---
 
@@ -77,7 +74,7 @@
 - 6 tipos: Rojo, Amarillo, Azul, Morado, Negro, Blanco + None
 - Los nombres son placeholder; la mecanica se mantiene
 
-### Tipo activo del jugador (⏳ DD-002, DD-007)
+### Tipo activo del jugador (✓ DD-002, DD-007 — Sub-PR A+B)
 - El jugador elige 2 tipos elementales al inicio del run, asignando uno a cada mundo
 - El tipo activo del jugador = tipo asignado al mundo en que esta parado
 - El cambio de mundo cambia instantaneamente el tipo activo del jugador
@@ -100,12 +97,12 @@
 - Multiplicadores: SuperEficaz **1.5x**, Neutro **1.0x**, PocoEficaz **0.75x**
 - Multiplicadores configurables (constantes en codigo, ajustables sin cambiar logica)
 - ✓ Aplica a: dano de carta del jugador vs tipo del enemigo (multiplicador + cargas de Estilo)
-- ✓ Aplica a: dano del enemigo vs tipo activo del jugador — multiplicador (DD-018, Sub-PR B). Cargas de Estilo pendientes (Sub-PR C, marcado ⏳ en §4).
+- ✓ Aplica a: dano del enemigo vs tipo activo del jugador — multiplicador + cargas de Estilo (DD-018, Sub-PR B+C).
 - NO aplica a: bloqueo, robo de cartas, ni ningun otro efecto fuera de dano
 - None vs cualquier tipo = Neutro (no genera ni quita cargas)
 - La tabla es ASIMETRICA: Rojo->Amarillo es SuperEficaz, pero Amarillo->Rojo es Neutro
 
-### Cartas neutras (⏳ DD-002)
+### Cartas neutras (✓ DD-002 — Sub-PR C)
 - Cartas sin afinidad de tipo (None)
 - Infligen 90% del dano base (multiplicador adicional al base, configurable)
 - NO generan ni quitan cargas de Contador de Estilo
@@ -113,7 +110,7 @@
 
 ---
 
-## 4. CONTADOR DE ESTILO (⏳ DD-001 — reemplaza Momentum)
+## 4. CONTADOR DE ESTILO (✓ DD-001 — Sub-PR C; reemplaza Momentum)
 
 > Recurso por combate. Reemplaza completamente el sistema antiguo de Momentum.
 

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -58,19 +58,19 @@ limpio.
 **Features incluidas:**
 
 #### Mecánica core nueva (cierra DDs del GDD v2)
-- [ ] Eliminar Momentum (todas sus referencias en TurnManager + UI)
-- [ ] Implementar Contador de Estilo (cargas: +1 por SuperEficaz hecho, -1 por
+- [x] Eliminar Momentum (todas sus referencias en TurnManager + UI) *(Sub-PR C)*
+- [x] Implementar Contador de Estilo (cargas: +1 por SuperEficaz hecho, -1 por
       SuperEficaz recibido, 5 cargas → 1 cambio extra no acumulable, reset cada
-      combate)
-- [ ] Cambios múltiples de mundo por combate (cap dinámico: 1 base + extras por
-      cargas / cartas / Retazos)
+      combate) *(Sub-PR C)*
+- [x] Cambios múltiples de mundo por combate (cap dinámico: 1 base + extras por
+      cargas / cartas / Retazos) *(Sub-PR C — cartas/Retazos quedan para M3)*
 - [x] Tipo activo del jugador (campo derivado del mundo, viene de los 2 tipos
       elegidos al inicio del run) *(Sub-PR A — PR #86)*
 - [x] Daño enemigo SuperEficaz contra el jugador: aplicar multiplicador x1.5
       (DD-018) — multiplicador configurable como constante *(Sub-PR B)*
 - [x] Hacer configurables los multiplicadores de efectividad (1.5 / 1.0 / 0.75)
       como constantes en código *(Sub-PR A — PR #86)*
-- [ ] Cartas neutras al 90% del daño base (DD-002)
+- [x] Cartas neutras al 90% del daño base (DD-002) *(Sub-PR C)*
 
 #### Deuda técnica que se cierra aquí (bundle de M-tech)
 - [ ] PhaseBased AI: implementar case en `SelectEnemyMove()` (HP thresholds o
@@ -80,8 +80,8 @@ limpio.
       Buff+StatusEffect, etc.)
 
 #### UI de M2
-- [ ] HUD: cambiar "Momentum: N" por "Cargas: N/5" (modificar CombatHudView ya
-      extraído)
+- [x] HUD: cambiar "Momentum: N" por "Estilo: N/5" (modificar CombatHudView ya
+      extraído) *(Sub-PR C)*
 - [ ] HUD: indicador de tipo activo del jugador (label nuevo)
 - [ ] HUD: contador de switches dinámico (ya no es "X/1", es "X/?" según cargas)
 


### PR DESCRIPTION
## Resumen

Sub-PR C de M2 (3 de 4). Elimina Momentum completamente e implementa el
Contador de Estilo (DD-001) con cap dinámico de switches, más cartas neutras
al 90% (DD-002). Validado en BattleScene por el usuario.

## Cambios

### Eliminado
- Sistema completo de Momentum: `_freePlays`, `FreePlays`, `SetFreePlaysForTest`,
  `UsedFreePlay` en `PreparedCardPlay`, bloque de free play en `TryPrepareCardPlay`.
- `CanPlayCard` ya solo verifica energía disponible.

### Contador de Estilo (`_styleCharges`, `_bonusWorldSwitches`)
- **+1 carga** cuando el jugador hace daño SuperEficaz al enemigo.
- **-1 carga** cuando el enemigo hace daño SuperEficaz al jugador (no baja de 0).
- Al llegar a **5 cargas**: otorga 1 switch de mundo extra, resetea cargas a 0.
  - No acumulable: si ya hay bonus disponible, otro ciclo de 5 cargas no genera otro.
- `TotalAvailableWorldSwitches = maxWorldSwitchesPerCombat + _bonusWorldSwitches`.
- `TryChangeWorld` usa `TotalAvailableWorldSwitches` como cap dinámico.
- `StyleCharges` property pública para la UI.
- Helpers de test: `SetStyleChargesForTest`, `SetBonusWorldSwitchesForTest`.

### Cartas neutras al 90% (DD-002)
- Cartas con `ElementType.None` aplican `NeutralCardDamage = 0.9f` (centralizado
  en `EffectivenessMultipliers` del Sub-PR A).
- No pasan por la tabla de efectividad. No generan ni quitan cargas.

### UI
- `CombatFeedbackView`: popup `"MOMENTUM +1"` → `"+ESTILO"`.
- `CombatHudView`: `_freePlaysText` → `_styleChargesText`, `Sync()` muestra
  `"Estilo: N/5"` y usa `TotalAvailableWorldSwitches` para el contador de switches.
- `CombatUIController`: variable local renombrada, texto inicial `"Estilo: 0/5"`.

### Tests
- Elimina `FreePlay_AllowsCardWithoutEnergyAndConsumesCharge`.
- Renombra `SuperEffectiveHit_GrantsFreePlay` → `SuperEffectiveHit_GrantsStyleCharge`.
- Agrega 5 tests de `StyleCounter` en `DamageEffectivenessTests`.
- Agrega 2 tests de bonus switch en `WorldSwitchLimitTests`.

### Docs
- `GOLDEN_RULES.md` §2/§3/§4: marcados como ✓.
- `_roadmap.md`: cerrados checkboxes de Momentum, StyleCounter, cambios múltiples,
  cartas neutras y HUD Estilo.

## Test plan

- [x] Compilación Unity sin errores
- [x] Test Runner EditMode Run All — todos verdes
- [x] BattleScene validada: "Estilo: 0/5" visible, cargas suben/bajan correctamente,
      bonus switch al llegar a 5, cartas None hacen ~90% del daño, CERO errores

## Archivos protegidos tocados

`TurnManager.cs` — aprobación previa otorgada.

## Lo que queda (Sub-PR D)

- PhaseBased AI (`SelectEnemyMove`)
- `EffectType.Heal` + `HealAction`
- `CalculateIntentValue` ampliado

🤖 Generated with [Claude Code](https://claude.com/claude-code)