### PR TITLE
M2 UI: player active type label in HUD

### DIFF
--- a/Assets/Scripts/Gameplay/Combat/CombatHudView.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatHudView.cs
@@ -36,6 +36,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         private Text _discardPileText;
         private Text _enemyIntentText;
         private Text _worldLabel;
+        private Text _playerTypeText;
         private Text _worldSwitchesText;
 
         // Botones
@@ -81,7 +82,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             Text playerBlockText, Text enemyBlockText,
             Text drawPileText, Text discardPileText,
             Text enemyIntentText,
-            Text worldLabel, Text worldSwitchesText,
+            Text worldLabel, Text playerTypeText, Text worldSwitchesText,
             // Botones
             Button endTurnButton, Text endTurnLabel,
             Button changeWorldButton, Text changeWorldLabel,
@@ -107,6 +108,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             _discardPileText = discardPileText;
             _enemyIntentText = enemyIntentText;
             _worldLabel = worldLabel;
+            _playerTypeText = playerTypeText;
             _worldSwitchesText = worldSwitchesText;
             _endTurnButton = endTurnButton;
             _endTurnLabel = endTurnLabel;
@@ -177,6 +179,12 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             {
                 string worldLabel = _turnManager.CurrentWorld == TurnManager.WorldSide.A ? "A" : "B";
                 _worldLabel.text = $"World: {worldLabel}";
+            }
+
+            if (_playerTypeText != null)
+            {
+                ElementType activeType = _turnManager.PlayerActiveType;
+                _playerTypeText.text = activeType == ElementType.None ? "Tipo: —" : $"Tipo: {activeType}";
             }
 
             bool playerTurn = _turnManager.IsPlayerTurn();

--- a/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
@@ -304,6 +304,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 HudPanelColor);
             Image worldPanelImage = worldPanel.GetComponent<Image>();
             Text worldLabel = CreateText("WorldLabel", worldPanel, "World: A", 24, TextAnchor.UpperCenter);
+            Text playerTypeText = CreateText("PlayerType", worldPanel, "Tipo: —", 16, TextAnchor.MiddleCenter);
             Text worldSwitchesText = CreateText("WorldSwitches", worldPanel, "Switches: 0/0", 18, TextAnchor.LowerCenter);
 
             RectTransform handPanel = CreatePanel(
@@ -402,7 +403,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 playerBlockText, enemyBlockText,
                 drawPileText, discardPileText,
                 enemyIntentText,
-                worldLabel, worldSwitchesText,
+                worldLabel, playerTypeText, worldSwitchesText,
                 endTurnButton, endTurnLabel,
                 changeWorldButton, changeWorldLabel,
                 playerBlockOverlay, enemyBlockOverlay);
@@ -420,7 +421,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             Text playerBlockText, Text enemyBlockText,
             Text drawPileText, Text discardPileText,
             Text enemyIntentText,
-            Text worldLabel, Text worldSwitchesText,
+            Text worldLabel, Text playerTypeText, Text worldSwitchesText,
             Button endTurnButton, Text endTurnLabel,
             Button changeWorldButton, Text changeWorldLabel,
             Image playerBlockOverlay, Image enemyBlockOverlay)
@@ -460,7 +461,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 playerBlockText, enemyBlockText,
                 drawPileText, discardPileText,
                 enemyIntentText,
-                worldLabel, worldSwitchesText,
+                worldLabel, playerTypeText, worldSwitchesText,
                 endTurnButton, endTurnLabel,
                 changeWorldButton, changeWorldLabel,
                 playerBlockOverlay, enemyBlockOverlay,

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -82,8 +82,8 @@ limpio.
 #### UI de M2
 - [x] HUD: cambiar "Momentum: N" por "Estilo: N/5" (modificar CombatHudView ya
       extraído) *(Sub-PR C)*
-- [ ] HUD: indicador de tipo activo del jugador (label nuevo)
-- [ ] HUD: contador de switches dinámico (ya no es "X/1", es "X/?" según cargas)
+- [x] HUD: indicador de tipo activo del jugador (label nuevo) *(feat PR #90)*
+- [x] HUD: contador de switches dinámico (usa TotalAvailableWorldSwitches) *(Sub-PR C)*
 
 **Sistemas afectados:** TurnManager, PlayerCombatActor, RunState, ElementTypes,
 CombatHudView, tests existentes (WorldSwitchLimitTests, DamageEffectivenessTests,


### PR DESCRIPTION
## Resumen

Último item de UI pendiente de M2. Agrega label `"Tipo: X"` en el WorldPanel
del HUD mostrando el tipo elemental activo del jugador según el mundo actual.

## Cambio

El `WorldPanel` pasa de 2 a 3 textos:
- `"World: A"` — arriba (sin cambios)
- `"Tipo: Rojo"` — medio (nuevo, `TextAnchor.MiddleCenter`, 16pt)
- `"Switches: 0/1"` — abajo (sin cambios)

El label refleja `TurnManager.PlayerActiveType` (expuesto en Sub-PR A, PR #86)
cada frame vía `CombatHudView.Sync()`. Muestra `"Tipo: —"` si el tipo activo
es `ElementType.None` (BattleScene standalone sin run configurada).

## Archivos tocados

- `CombatUIController.cs` — crea `playerTypeText` local en `BuildUI()` y lo
  pasa por la cadena a `InitializeExtractedViews()` → `CombatHudView.Initialize()`.
- `CombatHudView.cs` — campo `_playerTypeText`, parámetro en `Initialize()`,
  bloque en `Sync()`.
- `_roadmap.md` — checkbox cerrado.

**No toca archivos protegidos.**

## Test plan

- [ ] Unity compila sin errores
- [ ] BattleScene: WorldPanel muestra "Tipo: Rojo" en Mundo A, "Tipo: Amarillo"
      en Mundo B (con tipos por defecto del inspector)
- [ ] Cambio de mundo actualiza el label inmediatamente (siguiente frame de Sync)
- [ ] CERO errores en consola

🤖 Generated with [Claude Code](https://claude.com/claude-code)