### PR TITLE
feat(relics): Sub-PR 3A — foundations de hooks + dispatcher (M3)

### DIFF
--- a/Assets/Scripts/Gameplay/Combat/Actions/HealAction.cs.meta
+++ b/Assets/Scripts/Gameplay/Combat/Actions/HealAction.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5dea807f73d1f7d47a3310fb942a6297

--- a/Assets/Scripts/Gameplay/Combat/TurnManager.cs
+++ b/Assets/Scripts/Gameplay/Combat/TurnManager.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 using RoguelikeCardBattler.Gameplay.Cards;
 using RoguelikeCardBattler.Gameplay.Combat.Actions;
 using RoguelikeCardBattler.Gameplay.Enemies;
+using RoguelikeCardBattler.Gameplay.Relics;
+using RoguelikeCardBattler.Gameplay.Relics.Hooks;
+using RoguelikeCardBattler.Run;
 
 namespace RoguelikeCardBattler.Gameplay.Combat
 {
@@ -273,6 +276,17 @@ namespace RoguelikeCardBattler.Gameplay.Combat
 
             PlanNextEnemyMove();
             BeginPlayerTurn(useStartingHand: true);
+
+            // Hook OnCombatStart: insertado DESPUÉS de BeginPlayerTurn para que
+            // ClearBlock(_player) (parte de BeginPlayerTurn) no borre el bloque
+            // que un Retazo "+N bloque al iniciar combate" otorgue. En el primer
+            // turno ClearBlock es no-op (block = 0), así que disparar aquí es
+            // semánticamente correcto: combate inicializado, primer turno comenzó.
+            if (TryGetRelicContext(out RunState csRs, out RelicHookDispatcher csDisp))
+            {
+                CombatStartHookData csData = new CombatStartHookData(csRs, this, csDisp, enemyDefinition);
+                csDisp.Dispatch(RelicHook.OnCombatStart, csData);
+            }
         }
 
         /// <summary>
@@ -354,6 +368,14 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             _autoEndedThisTurn = false;
             _player.ResetEnergy();
             ClearBlock(_player);
+
+            // Hook OnPlayerTurnStart: post-ResetEnergy + ClearBlock, pre-DrawCards.
+            // Permite Retazos que modifican draw size, energía extra, etc.
+            if (TryGetRelicContext(out RunState ptRs, out RelicHookDispatcher ptDisp))
+            {
+                PlayerTurnStartHookData ptData = new PlayerTurnStartHookData(ptRs, this, ptDisp, currentWorld);
+                ptDisp.Dispatch(RelicHook.OnPlayerTurnStart, ptData);
+            }
 
             int cardsToDraw = useStartingHand ? startingHandSize : cardsPerTurn;
             if (cardsToDraw > 0)
@@ -567,6 +589,10 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         {
             // Cartas sin tipo (None) aplican 90% del daño base (DD-002).
             // No pasan por la tabla de efectividad ni modifican cargas.
+            // Nota (3A): el spec aprueba la dispatch de OnDamageDealt SOLO en el
+            // path tipado ("antes de PlayerHitEffectiveness?.Invoke", que no se
+            // invoca aquí). Si en 3B un Retazo necesita modificar daño de cartas
+            // None, surface inconsistencia y agregar la invocación con aprobación.
             if (attackerType == ElementType.None)
             {
                 return Math.Max(0, Mathf.RoundToInt(baseAmount * EffectivenessMultipliers.NeutralCardDamage));
@@ -578,18 +604,25 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             int finalAmount = Math.Max(0, Mathf.RoundToInt(baseAmount * multiplier));
 
             // Contador de Estilo: +1 carga al hacer SuperEficaz con daño real.
-            // Al llegar a 5 cargas, otorgar 1 switch de mundo extra (no acumulable)
-            // y resetear las cargas.
+            // Lógica de "5 cargas → +1 switch (no acumulable) + reset" centralizada
+            // en IncrementStyleCharges (golden rule §4) — la comparten este path
+            // orgánico y RelicGrantStyleCharge para Retazos.
             bool styleChargeGranted = false;
             if (effectiveness == Effectiveness.SuperEficaz && finalAmount > 0)
             {
-                _styleCharges++;
+                IncrementStyleCharges(1);
                 styleChargeGranted = true;
-                if (_styleCharges >= 5 && _bonusWorldSwitches == 0)
-                {
-                    _bonusWorldSwitches = 1;
-                    _styleCharges = 0;
-                }
+            }
+
+            // Hook OnDamageDealt: post-efectividad y post-style-charge, pre-event.
+            // Los Retazos pueden mutar finalAmount; el valor final es el que se
+            // pasa a new DamageAction(...). Cadena secuencial por AcquisitionOrder.
+            if (TryGetRelicContext(out RunState ddRs, out RelicHookDispatcher ddDisp))
+            {
+                DamageDealtHookData ddData = new DamageDealtHookData(
+                    ddRs, this, ddDisp, finalAmount, effectiveness, attackerType, _enemy);
+                ddDisp.Dispatch(RelicHook.OnDamageDealt, ddData);
+                finalAmount = Math.Max(0, ddData.Amount);
             }
 
             PlayerHitEffectiveness?.Invoke(effectiveness, styleChargeGranted);
@@ -608,6 +641,16 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             if (effectiveness == Effectiveness.SuperEficaz && _styleCharges > 0)
             {
                 _styleCharges--;
+            }
+
+            // Hook OnDamageTaken: post-efectividad, pre-event. Retazos defensivos
+            // ("daño recibido -1") mutan Amount aquí.
+            if (TryGetRelicContext(out RunState dtRs, out RelicHookDispatcher dtDisp))
+            {
+                DamageTakenHookData dtData = new DamageTakenHookData(
+                    dtRs, this, dtDisp, finalAmount, effectiveness, attackerType, _enemy);
+                dtDisp.Dispatch(RelicHook.OnDamageTaken, dtData);
+                finalAmount = Math.Max(0, dtData.Amount);
             }
 
             EnemyHitEffectiveness?.Invoke(effectiveness);
@@ -654,6 +697,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             {
                 _phase = CombatPhase.Victory;
                 Debug.Log("Player wins the combat.");
+                DispatchCombatEnd(victory: true);
                 return;
             }
 
@@ -661,6 +705,19 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             {
                 _phase = CombatPhase.Defeat;
                 Debug.Log("Player was defeated.");
+                DispatchCombatEnd(victory: false);
+            }
+        }
+
+        // Hook OnCombatEnd: invocado inmediatamente tras setear Victory/Defeat.
+        // Los Retazos mutan RunState directamente (Gold += N, etc.) — la
+        // ActionQueue ya no se procesa post-fin de combate ([CERRADO 3]).
+        private void DispatchCombatEnd(bool victory)
+        {
+            if (TryGetRelicContext(out RunState ceRs, out RelicHookDispatcher ceDisp))
+            {
+                CombatEndHookData ceData = new CombatEndHookData(ceRs, this, ceDisp, victory, enemyDefinition);
+                ceDisp.Dispatch(RelicHook.OnCombatEnd, ceData);
             }
         }
 
@@ -684,7 +741,16 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 return false;
             }
 
+            WorldSide previous = currentWorld;
             currentWorld = currentWorld == WorldSide.A ? WorldSide.B : WorldSide.A;
+
+            // Hook OnWorldSwitch: después de mutar currentWorld, antes de
+            // incrementar _worldSwitchesUsed. Permite Retazos de cambio (DD-017).
+            if (TryGetRelicContext(out RunState wsRs, out RelicHookDispatcher wsDisp))
+            {
+                WorldSwitchHookData wsData = new WorldSwitchHookData(wsRs, this, wsDisp, previous, currentWorld);
+                wsDisp.Dispatch(RelicHook.OnWorldSwitch, wsData);
+            }
 
             if (!debugUnlimitedWorldSwitches)
             {
@@ -759,6 +825,18 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             {
                 _actionQueue.ProcessAll();
                 _player.DiscardCard(prepared.Entry);
+
+                // Hook OnCardPlayed: post-ProcessAll y post-DiscardCard, pre-CheckCombatEndConditions
+                // ([CERRADO 2]). Si un Retazo encola daño extra que mata al enemigo,
+                // CheckCombatEndConditions detecta la victoria normalmente.
+                if (TryGetRelicContext(out RunState cpRs, out RelicHookDispatcher cpDisp))
+                {
+                    CardPlayedHookData cpData = new CardPlayedHookData(
+                        cpRs, this, cpDisp, prepared.ActiveCard, currentWorld,
+                        prepared.ActiveCard != null ? prepared.ActiveCard.Cost : 0);
+                    cpDisp.Dispatch(RelicHook.OnCardPlayed, cpData);
+                }
+
                 CheckCombatEndConditions();
             }
             finally
@@ -846,6 +924,120 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             }
 
             return total;
+        }
+
+        // ───────── Retazos: API delegada y plomería del dispatcher ─────────
+        // Los métodos RelicGrant*/RelicEnqueueExtraDamage son el contrato que
+        // RelicHookContext consume desde los IRelicEffect. Viven aquí porque
+        // todos mutan estado privado de combate (energía del jugador, cargas
+        // de Estilo, _bonusWorldSwitches, _actionQueue). Guards comunes:
+        // early-return si IsCombatFinished, validación actor != null donde aplique.
+
+        /// <summary>
+        /// Pull silencioso del dispatcher de RunSession. Devuelve false (no-op
+        /// limpio) si no hay sesión — caso de tests legacy / escenas standalone
+        /// que instancian TurnManager sin pasar por RunSession.
+        /// </summary>
+        private bool TryGetRelicContext(out RunState runState, out RelicHookDispatcher dispatcher)
+        {
+            RunSession session = RunSession.Instance;
+            if (session != null && session.RelicDispatcher != null)
+            {
+                runState = session.State;
+                dispatcher = session.RelicDispatcher;
+                return true;
+            }
+            runState = null;
+            dispatcher = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Aplica la regla §4 de GOLDEN_RULES (Contador de Estilo): incrementa
+        /// _styleCharges por amount; si llega a 5 con _bonusWorldSwitches == 0,
+        /// otorga 1 switch extra (no acumulable) y resetea las cargas a 0.
+        /// Llamado desde ApplyPlayerToEnemyEffectiveness (cuando un SuperEficaz
+        /// orgánico genera +1 carga) y desde RelicGrantStyleCharge (cuando un
+        /// Retazo otorga cargas vía RelicHookContext). Una sola fuente de
+        /// verdad para la regla del threshold.
+        /// </summary>
+        private void IncrementStyleCharges(int amount)
+        {
+            _styleCharges += amount;
+            if (_styleCharges >= 5 && _bonusWorldSwitches == 0)
+            {
+                _bonusWorldSwitches = 1;
+                _styleCharges = 0;
+            }
+        }
+
+        internal void RelicGrantBlock(ICombatActor actor, int amount)
+        {
+            if (IsCombatFinished || actor == null || amount <= 0) return;
+            actor.GainBlock(amount);
+        }
+
+        internal void RelicGrantHeal(ICombatActor actor, int amount)
+        {
+            if (IsCombatFinished || actor == null || amount <= 0) return;
+            actor.Heal(amount);
+        }
+
+        internal void RelicGrantDrawCards(ICombatActor actor, int amount)
+        {
+            if (IsCombatFinished || actor == null || amount <= 0) return;
+            actor.DrawCards(amount);
+        }
+
+        internal void RelicGrantEnergy(ICombatActor actor, int amount)
+        {
+            if (IsCombatFinished || amount <= 0) return;
+            // La energía es concepto del jugador; non-player actors son no-op.
+            if (actor == _player && _player != null)
+            {
+                _player.GainEnergy(amount);
+            }
+        }
+
+        internal void RelicGrantStyleCharge(int amount)
+        {
+            if (IsCombatFinished || amount <= 0) return;
+            IncrementStyleCharges(amount);
+        }
+
+        internal void RelicGrantBonusWorldSwitch()
+        {
+            if (IsCombatFinished) return;
+            // Respeta el "no acumulable" de la golden rule §4.
+            if (_bonusWorldSwitches == 0)
+            {
+                _bonusWorldSwitches = 1;
+            }
+        }
+
+        internal void RelicEnqueueExtraDamage(ICombatActor target, int amount, ElementType type)
+        {
+            if (IsCombatFinished || target == null || amount <= 0 || _actionQueue == null) return;
+            // Daño RAW: NO pasa por ApplyPlayerToEnemyEffectiveness, NO aplica
+            // multiplicador WEAK/RESIST, NO otorga ni resta cargas de Estilo,
+            // y NO re-dispara OnDamageDealt (deliberado: previene loops infinitos
+            // cuando dos Retazos se modifican mutuamente). Para daño extra que
+            // SÍ se beneficie de la efectividad, mutar data.Amount en OnDamageDealt.
+            // El parámetro 'type' es metadata para futuros usos (animaciones/UI
+            // en 3B); en 3A no se aplica al cálculo porque sería duplicar la
+            // efectividad orgánica.
+            Action<int> onEnemyDamage = null;
+            if (target == _enemy)
+            {
+                onEnemyDamage = dmg =>
+                {
+                    if (dmg > 0)
+                    {
+                        EnemyTookDamage?.Invoke(dmg);
+                    }
+                };
+            }
+            _actionQueue.Enqueue(new DamageAction(_player, target, amount, onEnemyDamage));
         }
     }
 

--- a/Assets/Scripts/Gameplay/Relics.meta
+++ b/Assets/Scripts/Gameplay/Relics.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 54846510df0e1c44db656dde5fdbf862
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Relics/Hooks.meta
+++ b/Assets/Scripts/Gameplay/Relics/Hooks.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ecddc46808f813240b5533b2f2acaa5f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Relics/Hooks/CardPlayedHookData.cs
+++ b/Assets/Scripts/Gameplay/Relics/Hooks/CardPlayedHookData.cs
@@ -1,0 +1,33 @@
+using RoguelikeCardBattler.Gameplay.Cards;
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Run;
+
+namespace RoguelikeCardBattler.Gameplay.Relics.Hooks
+{
+    /// <summary>
+    /// Disparado dentro de ResolvePreparedCardPlay, después de ProcessAll y
+    /// DiscardCard, antes de CheckCombatEndConditions ([CERRADO 2]). La carta
+    /// ya se resolvió: el Retazo puede contar/encolar acciones extra (que se
+    /// procesan en el siguiente ProcessAll natural del flujo) o mutar RunState.
+    /// </summary>
+    public class CardPlayedHookData : RelicHookContext
+    {
+        public CardDefinition Card { get; }
+        public TurnManager.WorldSide PlayedInWorld { get; }
+        public int EnergySpent { get; }
+
+        public CardPlayedHookData(
+            RunState runState,
+            TurnManager turnManager,
+            RelicHookDispatcher dispatcher,
+            CardDefinition card,
+            TurnManager.WorldSide playedInWorld,
+            int energySpent)
+            : base(runState, turnManager, dispatcher)
+        {
+            Card = card;
+            PlayedInWorld = playedInWorld;
+            EnergySpent = energySpent;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Relics/Hooks/CardPlayedHookData.cs.meta
+++ b/Assets/Scripts/Gameplay/Relics/Hooks/CardPlayedHookData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 14e66501f5a660342a50e323d7602baf

--- a/Assets/Scripts/Gameplay/Relics/Hooks/CombatEndHookData.cs
+++ b/Assets/Scripts/Gameplay/Relics/Hooks/CombatEndHookData.cs
@@ -1,0 +1,30 @@
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Gameplay.Enemies;
+using RoguelikeCardBattler.Run;
+
+namespace RoguelikeCardBattler.Gameplay.Relics.Hooks
+{
+    /// <summary>
+    /// Disparado dentro de CheckCombatEndConditions, inmediatamente después de
+    /// setear _phase = Victory o _phase = Defeat. Los Retazos mutan RunState
+    /// directamente desde aquí (ej: ctx.RunState.Gold += 5) — NO se encolan
+    /// acciones, la ActionQueue ya no se procesa post-fin de combate ([CERRADO 3]).
+    /// </summary>
+    public class CombatEndHookData : RelicHookContext
+    {
+        public bool Victory { get; }
+        public EnemyDefinition Enemy { get; }
+
+        public CombatEndHookData(
+            RunState runState,
+            TurnManager turnManager,
+            RelicHookDispatcher dispatcher,
+            bool victory,
+            EnemyDefinition enemy)
+            : base(runState, turnManager, dispatcher)
+        {
+            Victory = victory;
+            Enemy = enemy;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Relics/Hooks/CombatEndHookData.cs.meta
+++ b/Assets/Scripts/Gameplay/Relics/Hooks/CombatEndHookData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 36c2ee7923fb13749b6b0c95ad34f262

--- a/Assets/Scripts/Gameplay/Relics/Hooks/CombatStartHookData.cs
+++ b/Assets/Scripts/Gameplay/Relics/Hooks/CombatStartHookData.cs
@@ -1,0 +1,31 @@
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Gameplay.Enemies;
+using RoguelikeCardBattler.Run;
+
+namespace RoguelikeCardBattler.Gameplay.Relics.Hooks
+{
+    /// <summary>
+    /// Disparado dentro de InitializeCombat, DESPUÉS del primer BeginPlayerTurn
+    /// (para evitar que ClearBlock borre el bloque que un Retazo "+N bloque al
+    /// iniciar combate" haya otorgado — ver §Cambios en TurnManager del spec).
+    /// Observable: no tiene campos mutables.
+    /// Nota (3A): IsBoss/IsElite removidos — viven en NodeType del MapNode, no
+    /// en EnemyDefinition, y TurnManager hoy no recibe la referencia del nodo.
+    /// Cuando un Retazo concreto lo necesite, extender ConfigureCombat/
+    /// RunCombatConfig para inyectar el NodeType activo (ver _insights.md).
+    /// </summary>
+    public class CombatStartHookData : RelicHookContext
+    {
+        public EnemyDefinition Enemy { get; }
+
+        public CombatStartHookData(
+            RunState runState,
+            TurnManager turnManager,
+            RelicHookDispatcher dispatcher,
+            EnemyDefinition enemy)
+            : base(runState, turnManager, dispatcher)
+        {
+            Enemy = enemy;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Relics/Hooks/CombatStartHookData.cs.meta
+++ b/Assets/Scripts/Gameplay/Relics/Hooks/CombatStartHookData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1dbad76923b07a644875c625e9e06708

--- a/Assets/Scripts/Gameplay/Relics/Hooks/DamageDealtHookData.cs
+++ b/Assets/Scripts/Gameplay/Relics/Hooks/DamageDealtHookData.cs
@@ -1,0 +1,37 @@
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Run;
+
+namespace RoguelikeCardBattler.Gameplay.Relics.Hooks
+{
+    /// <summary>
+    /// Daño jugador → enemigo, post-efectividad y antes de encolar el DamageAction.
+    /// Mutable: los Retazos pueden modificar Amount; las mutaciones se encadenan
+    /// en orden de adquisición (asc) y el valor final es el que se pasa a
+    /// new DamageAction(...). Eff y AttackerType son contexto observable.
+    /// </summary>
+    public class DamageDealtHookData : RelicHookContext
+    {
+        // Campo público mutable: los Retazos modifican esto en su OnHook.
+        public int Amount;
+
+        public Effectiveness Eff { get; }
+        public ElementType AttackerType { get; }
+        public ICombatActor Target { get; }
+
+        public DamageDealtHookData(
+            RunState runState,
+            TurnManager turnManager,
+            RelicHookDispatcher dispatcher,
+            int amount,
+            Effectiveness eff,
+            ElementType attackerType,
+            ICombatActor target)
+            : base(runState, turnManager, dispatcher)
+        {
+            Amount = amount;
+            Eff = eff;
+            AttackerType = attackerType;
+            Target = target;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Relics/Hooks/DamageDealtHookData.cs.meta
+++ b/Assets/Scripts/Gameplay/Relics/Hooks/DamageDealtHookData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 03864ce1a09899c4fa218d7bf5465c88

--- a/Assets/Scripts/Gameplay/Relics/Hooks/DamageTakenHookData.cs
+++ b/Assets/Scripts/Gameplay/Relics/Hooks/DamageTakenHookData.cs
@@ -1,0 +1,35 @@
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Run;
+
+namespace RoguelikeCardBattler.Gameplay.Relics.Hooks
+{
+    /// <summary>
+    /// Daño enemigo → jugador, post-efectividad y antes de encolar el DamageAction.
+    /// Mutable: los Retazos defensivos ("daño recibido -1") modifican Amount.
+    /// Eff y AttackerType son contexto observable.
+    /// </summary>
+    public class DamageTakenHookData : RelicHookContext
+    {
+        public int Amount;
+
+        public Effectiveness Eff { get; }
+        public ElementType AttackerType { get; }
+        public ICombatActor Source { get; }
+
+        public DamageTakenHookData(
+            RunState runState,
+            TurnManager turnManager,
+            RelicHookDispatcher dispatcher,
+            int amount,
+            Effectiveness eff,
+            ElementType attackerType,
+            ICombatActor source)
+            : base(runState, turnManager, dispatcher)
+        {
+            Amount = amount;
+            Eff = eff;
+            AttackerType = attackerType;
+            Source = source;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Relics/Hooks/DamageTakenHookData.cs.meta
+++ b/Assets/Scripts/Gameplay/Relics/Hooks/DamageTakenHookData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 405339ae1c869f842aeb475af533ef56

--- a/Assets/Scripts/Gameplay/Relics/Hooks/PlayerTurnStartHookData.cs
+++ b/Assets/Scripts/Gameplay/Relics/Hooks/PlayerTurnStartHookData.cs
@@ -1,0 +1,27 @@
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Run;
+
+namespace RoguelikeCardBattler.Gameplay.Relics.Hooks
+{
+    /// <summary>
+    /// Disparado dentro de BeginPlayerTurn, después de ResetEnergy + ClearBlock
+    /// y antes de DrawCards. Permite Retazos que modifican draw size, energía
+    /// extra, etc. Observable: no muta campos.
+    /// Nota (3A): los Retazos que necesiten contar turnos mantienen su propio
+    /// contador en RelicInstance.Counters (lifecycle del propio Retazo).
+    /// </summary>
+    public class PlayerTurnStartHookData : RelicHookContext
+    {
+        public TurnManager.WorldSide CurrentWorld { get; }
+
+        public PlayerTurnStartHookData(
+            RunState runState,
+            TurnManager turnManager,
+            RelicHookDispatcher dispatcher,
+            TurnManager.WorldSide currentWorld)
+            : base(runState, turnManager, dispatcher)
+        {
+            CurrentWorld = currentWorld;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Relics/Hooks/PlayerTurnStartHookData.cs.meta
+++ b/Assets/Scripts/Gameplay/Relics/Hooks/PlayerTurnStartHookData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: be3bb81c2ee115841a014ce1848966b2

--- a/Assets/Scripts/Gameplay/Relics/Hooks/RelicHookContext.cs
+++ b/Assets/Scripts/Gameplay/Relics/Hooks/RelicHookContext.cs
@@ -1,0 +1,80 @@
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Run;
+
+namespace RoguelikeCardBattler.Gameplay.Relics.Hooks
+{
+    /// <summary>
+    /// Payload base que reciben todos los IRelicEffect. Cada *HookData extiende
+    /// esta clase y agrega campos específicos del evento (ver spec §Payloads).
+    /// La API de mutación es deliberadamente limitada: los Retazos NO reciben el
+    /// TurnManager entero, sino métodos puntuales que delegan a métodos internal
+    /// del TurnManager con guards (Victory/Defeat → no-op). Ampliar la API
+    /// requiere nueva sub-PR + actualización del spec ([CERRADO 4]).
+    /// </summary>
+    public class RelicHookContext
+    {
+        public RunState RunState { get; }
+        public TurnManager TurnManager { get; }
+        public RelicHookDispatcher Dispatcher { get; }
+
+        // El dispatcher setea esto antes de cada invocación a OnHook.
+        // Se expone público para que un Retazo pueda inspeccionar sus propios
+        // Counters durante el handler (ctx.CurrentRelic.Counters["..."]).
+        public RelicInstance CurrentRelic { get; internal set; }
+
+        protected RelicHookContext(RunState runState, TurnManager turnManager, RelicHookDispatcher dispatcher)
+        {
+            RunState = runState;
+            TurnManager = turnManager;
+            Dispatcher = dispatcher;
+        }
+
+        // API limitada de mutaciones permitidas a Retazos. Cada método es un
+        // pasamanos a TurnManager: el TurnManager aplica guards (Victory/Defeat)
+        // y la mutación real sobre el estado de combate. Si TurnManager es null
+        // (hook fuera de combate, ej. nodos en 3C/3D), los Grant* son no-op
+        // silenciosos — el Retazo escribe directo a RunState para esos casos.
+
+        public void GrantBlock(ICombatActor actor, int amount)
+        {
+            if (TurnManager == null || actor == null || amount <= 0) return;
+            TurnManager.RelicGrantBlock(actor, amount);
+        }
+
+        public void GrantHeal(ICombatActor actor, int amount)
+        {
+            if (TurnManager == null || actor == null || amount <= 0) return;
+            TurnManager.RelicGrantHeal(actor, amount);
+        }
+
+        public void GrantDrawCards(ICombatActor actor, int amount)
+        {
+            if (TurnManager == null || actor == null || amount <= 0) return;
+            TurnManager.RelicGrantDrawCards(actor, amount);
+        }
+
+        public void GrantEnergy(ICombatActor actor, int amount)
+        {
+            if (TurnManager == null || actor == null || amount <= 0) return;
+            TurnManager.RelicGrantEnergy(actor, amount);
+        }
+
+        public void GrantStyleCharge(int amount)
+        {
+            if (TurnManager == null || amount <= 0) return;
+            TurnManager.RelicGrantStyleCharge(amount);
+        }
+
+        public void GrantBonusWorldSwitch()
+        {
+            if (TurnManager == null) return;
+            TurnManager.RelicGrantBonusWorldSwitch();
+        }
+
+        public void EnqueueExtraDamage(ICombatActor target, int amount, ElementType type)
+        {
+            if (TurnManager == null || target == null || amount <= 0) return;
+            TurnManager.RelicEnqueueExtraDamage(target, amount, type);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Relics/Hooks/RelicHookContext.cs.meta
+++ b/Assets/Scripts/Gameplay/Relics/Hooks/RelicHookContext.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6a43d2c56046a134b840b7215d0ba7af

--- a/Assets/Scripts/Gameplay/Relics/Hooks/WorldSwitchHookData.cs
+++ b/Assets/Scripts/Gameplay/Relics/Hooks/WorldSwitchHookData.cs
@@ -1,0 +1,29 @@
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Run;
+
+namespace RoguelikeCardBattler.Gameplay.Relics.Hooks
+{
+    /// <summary>
+    /// Disparado dentro de TryChangeWorld, después de mutar currentWorld y antes
+    /// de incrementar _worldSwitchesUsed. Observable: From/To del cambio.
+    /// Nota (3A): WasFreeSwitch removido — el pool base+bonus es fungible en
+    /// TryChangeWorld y el campo era semánticamente ambiguo.
+    /// </summary>
+    public class WorldSwitchHookData : RelicHookContext
+    {
+        public TurnManager.WorldSide From { get; }
+        public TurnManager.WorldSide To { get; }
+
+        public WorldSwitchHookData(
+            RunState runState,
+            TurnManager turnManager,
+            RelicHookDispatcher dispatcher,
+            TurnManager.WorldSide from,
+            TurnManager.WorldSide to)
+            : base(runState, turnManager, dispatcher)
+        {
+            From = from;
+            To = to;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Relics/Hooks/WorldSwitchHookData.cs.meta
+++ b/Assets/Scripts/Gameplay/Relics/Hooks/WorldSwitchHookData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5b2592a16ff84e54b8634d1a172f0f8a

--- a/Assets/Scripts/Gameplay/Relics/IRelicEffect.cs
+++ b/Assets/Scripts/Gameplay/Relics/IRelicEffect.cs
@@ -1,0 +1,15 @@
+using RoguelikeCardBattler.Gameplay.Relics.Hooks;
+
+namespace RoguelikeCardBattler.Gameplay.Relics
+{
+    /// <summary>
+    /// Contrato ejecutable de un Retazo. Cada implementación lleva [System.Serializable]
+    /// para que el SO RelicDefinition pueda serializarla vía [SerializeReference]
+    /// (ver spec, [CERRADO 1]). El método se invoca una vez por evento, recibiendo
+    /// el hook que se está disparando para que un mismo efecto pueda escuchar varios.
+    /// </summary>
+    public interface IRelicEffect
+    {
+        void OnHook(RelicHook hook, RelicHookContext ctx);
+    }
+}

--- a/Assets/Scripts/Gameplay/Relics/IRelicEffect.cs.meta
+++ b/Assets/Scripts/Gameplay/Relics/IRelicEffect.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 89d15aeef79f7574b8be22f36cff2079

--- a/Assets/Scripts/Gameplay/Relics/RelicCategory.cs
+++ b/Assets/Scripts/Gameplay/Relics/RelicCategory.cs
@@ -1,0 +1,15 @@
+namespace RoguelikeCardBattler.Gameplay.Relics
+{
+    /// <summary>
+    /// Clasificación de Retazos según GOLDEN_RULES §10.
+    /// Neutral: efectos genéricos no atados al cambio de mundo.
+    /// Switch: se activan en o modifican cambios de mundo (DD-017).
+    /// World: ligados a un mundo específico (A o B).
+    /// </summary>
+    public enum RelicCategory
+    {
+        Neutral,
+        Switch,
+        World
+    }
+}

--- a/Assets/Scripts/Gameplay/Relics/RelicCategory.cs.meta
+++ b/Assets/Scripts/Gameplay/Relics/RelicCategory.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ec9f437da9aee6640831702bae073c86

--- a/Assets/Scripts/Gameplay/Relics/RelicDefinition.cs
+++ b/Assets/Scripts/Gameplay/Relics/RelicDefinition.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+namespace RoguelikeCardBattler.Gameplay.Relics
+{
+    /// <summary>
+    /// SO base de un Retazo. El efecto se serializa inline vía [SerializeReference]
+    /// (spec [CERRADO 1]): cada implementación de IRelicEffect lleva [System.Serializable]
+    /// y sus parámetros se guardan como campos de la clase. Type-safe, sin reflexión.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Roguelike/Relic", fileName = "NewRelic")]
+    public class RelicDefinition : ScriptableObject
+    {
+        public string DisplayName;
+        [TextArea] public string Description;
+        [TextArea] public string FlavorText;
+        public Sprite Icon;
+        public RelicCategory Category;
+        public RelicHook[] Hooks;
+        [SerializeReference] public IRelicEffect Effect;
+    }
+}

--- a/Assets/Scripts/Gameplay/Relics/RelicDefinition.cs.meta
+++ b/Assets/Scripts/Gameplay/Relics/RelicDefinition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5e9460e14f04d5b4395c28ee75c95a52

--- a/Assets/Scripts/Gameplay/Relics/RelicHook.cs
+++ b/Assets/Scripts/Gameplay/Relics/RelicHook.cs
@@ -1,0 +1,21 @@
+namespace RoguelikeCardBattler.Gameplay.Relics
+{
+    /// <summary>
+    /// Lista cerrada de eventos que un Retazo puede escuchar. Ampliarla requiere
+    /// nueva sub-PR + tests + actualización del spec en Docs/dev/specs/m3_hooks_spec.md.
+    /// Los call sites de OnCampfireOptionsBuilt y OnShopStockBuilt se implementan
+    /// en sub-PRs 3C/3D respectivamente; en 3A solo viven en este enum.
+    /// </summary>
+    public enum RelicHook
+    {
+        OnCombatStart,
+        OnPlayerTurnStart,
+        OnDamageDealt,
+        OnDamageTaken,
+        OnWorldSwitch,
+        OnCombatEnd,
+        OnCardPlayed,
+        OnCampfireOptionsBuilt,
+        OnShopStockBuilt
+    }
+}

--- a/Assets/Scripts/Gameplay/Relics/RelicHook.cs.meta
+++ b/Assets/Scripts/Gameplay/Relics/RelicHook.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 90c5d3c9d183f1a49bf55413d4e7319e

--- a/Assets/Scripts/Gameplay/Relics/RelicHookDispatcher.cs
+++ b/Assets/Scripts/Gameplay/Relics/RelicHookDispatcher.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+using RoguelikeCardBattler.Gameplay.Relics.Hooks;
+using RoguelikeCardBattler.Run;
+
+namespace RoguelikeCardBattler.Gameplay.Relics
+{
+    /// <summary>
+    /// Bus único por el que TurnManager y los NodeControllers (3C/3D) emiten
+    /// eventos de Retazos. Filtra por hook, ordena por AcquisitionOrder
+    /// ascendente y ejecuta cada efecto pasando el payload tipado. Vive en
+    /// RunSession (cruza escenas con la run). Sin Retazos = cero overhead.
+    /// </summary>
+    public class RelicHookDispatcher
+    {
+        private readonly RunState _runState;
+
+        // Default OFF para no spammear consola. Cuando se prende, los logs
+        // van por Debug.Log directo (no detrás de #if UNITY_EDITOR) para que
+        // funcionen también en builds de desarrollo ([CERRADO 5]).
+        public bool LogDispatches { get; set; } = false;
+
+        public RelicHookDispatcher(RunState runState)
+        {
+            _runState = runState ?? throw new ArgumentNullException(nameof(runState));
+        }
+
+        public void Dispatch<TData>(RelicHook hook, TData data) where TData : RelicHookContext
+        {
+            if (data == null) return;
+
+            IReadOnlyList<RelicInstance> subscribers = GetSubscribers(hook);
+            if (subscribers.Count == 0) return;
+
+            if (LogDispatches)
+            {
+                Debug.Log($"[Relics] {hook} → {subscribers.Count} subscribers ({JoinNames(subscribers)})");
+            }
+
+            for (int i = 0; i < subscribers.Count; i++)
+            {
+                RelicInstance instance = subscribers[i];
+                IRelicEffect effect = instance.Effect;
+                if (effect == null) continue;
+
+                data.CurrentRelic = instance;
+                try
+                {
+                    effect.OnHook(hook, data);
+                }
+                catch (Exception e)
+                {
+                    // Un Retazo defectuoso no debe abortar el resto de la cadena
+                    // ni el flujo del combate. Logueamos y seguimos.
+                    Debug.LogError($"[Relics] {hook} threw in '{NameOf(instance)}': {e}");
+                }
+            }
+
+            data.CurrentRelic = null;
+        }
+
+        public IReadOnlyList<RelicInstance> GetSubscribers(RelicHook hook)
+        {
+            List<RelicInstance> result = new List<RelicInstance>();
+            IReadOnlyList<RelicInstance> all = _runState.Relics;
+            for (int i = 0; i < all.Count; i++)
+            {
+                RelicInstance r = all[i];
+                if (r == null || r.Definition == null || r.Definition.Hooks == null) continue;
+                if (Array.IndexOf(r.Definition.Hooks, hook) < 0) continue;
+                result.Add(r);
+            }
+            result.Sort(CompareByAcquisitionOrder);
+            return result;
+        }
+
+        private static int CompareByAcquisitionOrder(RelicInstance a, RelicInstance b)
+        {
+            return a.AcquisitionOrder.CompareTo(b.AcquisitionOrder);
+        }
+
+        private static string JoinNames(IReadOnlyList<RelicInstance> list)
+        {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (i > 0) sb.Append(", ");
+                sb.Append(NameOf(list[i]));
+            }
+            return sb.ToString();
+        }
+
+        private static string NameOf(RelicInstance r)
+        {
+            if (r == null || r.Definition == null) return "<null>";
+            return string.IsNullOrEmpty(r.Definition.DisplayName)
+                ? r.Definition.name
+                : r.Definition.DisplayName;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Relics/RelicHookDispatcher.cs.meta
+++ b/Assets/Scripts/Gameplay/Relics/RelicHookDispatcher.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d2d56027e9a8ff34b8844ec932b85e3b

--- a/Assets/Scripts/Gameplay/Relics/RelicInstance.cs
+++ b/Assets/Scripts/Gameplay/Relics/RelicInstance.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace RoguelikeCardBattler.Gameplay.Relics
+{
+    /// <summary>
+    /// Wrapper runtime de un RelicDefinition. Vive en RunState.Relics.
+    /// AcquisitionOrder define el orden de ejecución en el dispatcher (asc).
+    /// Counters son estado mutable per-instance cuyo lifecycle queda en manos
+    /// del propio Retazo: el dispatcher NO los toca (ni resetea, ni inicializa,
+    /// ni inspecciona). Cada IRelicEffect es responsable del namespacing y del
+    /// reset de sus claves (ej: limpiar en OnPlayerTurnStart si son por turno).
+    /// </summary>
+    public class RelicInstance
+    {
+        public RelicDefinition Definition { get; }
+        public int AcquisitionOrder { get; }
+        public Dictionary<string, int> Counters { get; }
+
+        public IRelicEffect Effect => Definition != null ? Definition.Effect : null;
+
+        public RelicInstance(RelicDefinition definition, int acquisitionOrder)
+        {
+            Definition = definition;
+            AcquisitionOrder = acquisitionOrder;
+            Counters = new Dictionary<string, int>();
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Relics/RelicInstance.cs.meta
+++ b/Assets/Scripts/Gameplay/Relics/RelicInstance.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3b89f8b844837c6458885b93581f1aa7

--- a/Assets/Scripts/Run/RunSession.cs
+++ b/Assets/Scripts/Run/RunSession.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEngine;
 using RoguelikeCardBattler.Gameplay.Enemies;
+using RoguelikeCardBattler.Gameplay.Relics;
 
 namespace RoguelikeCardBattler.Run
 {
@@ -14,6 +15,12 @@ namespace RoguelikeCardBattler.Run
         public RunState State { get; } = new RunState();
         public ActMap Map { get; private set; }
         public RunCombatConfig CombatConfig { get; private set; }
+
+        // Bus de eventos de Retazos. Se instancia con referencia al State actual
+        // y persiste con la RunSession (cruza escenas). Sobrevive a State.Reset
+        // porque lee Relics por referencia: tras un reset, la lista queda vacía
+        // y GetSubscribers devuelve 0 hasta ganar nuevos Retazos.
+        public RelicHookDispatcher RelicDispatcher { get; private set; }
         [SerializeField] private EnemyDefinition bossAct1Enemy;
         [SerializeField] private Act1MapConfig mapConfig;
         [SerializeField] private EnemyPoolConfig enemyPoolConfig;
@@ -54,6 +61,7 @@ namespace RoguelikeCardBattler.Run
             }
             State.EnsureInitialized(Map);
             AssignBossAct1();
+            RelicDispatcher = new RelicHookDispatcher(State);
         }
 
         /// <summary>

--- a/Assets/Scripts/Run/RunState.cs
+++ b/Assets/Scripts/Run/RunState.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using RoguelikeCardBattler.Gameplay.Cards;
 using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Gameplay.Relics;
 
 namespace RoguelikeCardBattler.Run
 {
@@ -37,6 +38,11 @@ namespace RoguelikeCardBattler.Run
         public ElementType PlayerWorldAType { get; set; } = ElementType.Rojo;
         public ElementType PlayerWorldBType { get; set; } = ElementType.Amarillo;
 
+        // Inventario de Retazos del run. RelicHookDispatcher (en RunSession) los lee
+        // por hook al disparar eventos. El orden de la lista define AcquisitionOrder
+        // de cada instance (asc = adquirido primero = corre primero en cadena).
+        public List<RelicInstance> Relics { get; } = new List<RelicInstance>();
+
         public void EnsureInitialized(ActMap map)
         {
             if (map == null)
@@ -72,6 +78,7 @@ namespace RoguelikeCardBattler.Run
             ActoCompleted = false;
             PlayerWorldAType = ElementType.Rojo;
             PlayerWorldBType = ElementType.Amarillo;
+            Relics.Clear();
             EnsureInitialized(map);
         }
 

--- a/Assets/Tests/EditMode/ActionQueueTests.cs
+++ b/Assets/Tests/EditMode/ActionQueueTests.cs
@@ -36,6 +36,11 @@ namespace RoguelikeCardBattler.Tests.EditMode
             {
                 Log.Add($"Draw:{amount}");
             }
+
+            public void Heal(int amount)
+            {
+                Log.Add($"Heal:{amount}");
+            }
         }
 
         [Test]

--- a/Assets/Tests/EditMode/HealActionTests.cs.meta
+++ b/Assets/Tests/EditMode/HealActionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c477632277c5afa4f865b0bb86a799d8

--- a/Assets/Tests/EditMode/RelicHookDispatcherTests.cs
+++ b/Assets/Tests/EditMode/RelicHookDispatcherTests.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Gameplay.Relics;
+using RoguelikeCardBattler.Gameplay.Relics.Hooks;
+using RoguelikeCardBattler.Run;
+
+namespace RoguelikeCardBattler.Tests.EditMode
+{
+    /// <summary>
+    /// Tests de plomería del dispatcher de Retazos (Sub-PR 3A). Cubren los 8
+    /// casos del spec en Docs/dev/specs/m3_hooks_spec.md §"Casos de prueba".
+    /// Tests de integración con TurnManager se cubren en 3B con Retazos reales.
+    /// </summary>
+    public class RelicHookDispatcherTests
+    {
+        // Stub que graba qué hook recibió y deja al test inyectar lógica extra
+        // (mutación de payload, escritura en counters) vía Callback.
+        private class RecordingEffect : IRelicEffect
+        {
+            public readonly List<RelicHook> Calls = new List<RelicHook>();
+            public Action<RelicHook, RelicHookContext> Callback;
+
+            public void OnHook(RelicHook hook, RelicHookContext ctx)
+            {
+                Calls.Add(hook);
+                Callback?.Invoke(hook, ctx);
+            }
+        }
+
+        private static RelicDefinition MakeDef(string name, IRelicEffect effect, params RelicHook[] hooks)
+        {
+            RelicDefinition def = ScriptableObject.CreateInstance<RelicDefinition>();
+            def.DisplayName = name;
+            def.Effect = effect;
+            def.Hooks = hooks;
+            return def;
+        }
+
+        private static PlayerTurnStartHookData MakeTurnStartData(RunState rs, RelicHookDispatcher disp)
+        {
+            // TurnManager null: válido — los tests no exigen API de mutación.
+            return new PlayerTurnStartHookData(rs, null, disp, TurnManager.WorldSide.A);
+        }
+
+        [Test]
+        public void Dispatch_WithNoRelics_DoesNotThrow()
+        {
+            RunState rs = new RunState();
+            RelicHookDispatcher disp = new RelicHookDispatcher(rs);
+
+            Assert.DoesNotThrow(() => disp.Dispatch(RelicHook.OnPlayerTurnStart, MakeTurnStartData(rs, disp)));
+            Assert.AreEqual(0, disp.GetSubscribers(RelicHook.OnPlayerTurnStart).Count);
+        }
+
+        [Test]
+        public void Dispatch_SingleSubscriber_InvokesOnceWithCorrectHook()
+        {
+            RunState rs = new RunState();
+            RelicHookDispatcher disp = new RelicHookDispatcher(rs);
+            RecordingEffect effect = new RecordingEffect();
+            rs.Relics.Add(new RelicInstance(MakeDef("Opening", effect, RelicHook.OnCombatStart), 0));
+
+            disp.Dispatch(RelicHook.OnCombatStart, new CombatStartHookData(rs, null, disp, null));
+
+            Assert.AreEqual(1, effect.Calls.Count);
+            Assert.AreEqual(RelicHook.OnCombatStart, effect.Calls[0]);
+        }
+
+        [Test]
+        public void Dispatch_MultipleSubscribers_RunInAcquisitionOrder()
+        {
+            RunState rs = new RunState();
+            RelicHookDispatcher disp = new RelicHookDispatcher(rs);
+            List<string> order = new List<string>();
+            RecordingEffect a = new RecordingEffect { Callback = (_, __) => order.Add("A") };
+            RecordingEffect b = new RecordingEffect { Callback = (_, __) => order.Add("B") };
+            RecordingEffect c = new RecordingEffect { Callback = (_, __) => order.Add("C") };
+
+            // Adquiridos en orden A → B → C.
+            rs.Relics.Add(new RelicInstance(MakeDef("A", a, RelicHook.OnPlayerTurnStart), 0));
+            rs.Relics.Add(new RelicInstance(MakeDef("B", b, RelicHook.OnPlayerTurnStart), 1));
+            rs.Relics.Add(new RelicInstance(MakeDef("C", c, RelicHook.OnPlayerTurnStart), 2));
+
+            disp.Dispatch(RelicHook.OnPlayerTurnStart, MakeTurnStartData(rs, disp));
+
+            CollectionAssert.AreEqual(new[] { "A", "B", "C" }, order);
+        }
+
+        [Test]
+        public void Dispatch_IrrelevantHook_DoesNotInvoke()
+        {
+            RunState rs = new RunState();
+            RelicHookDispatcher disp = new RelicHookDispatcher(rs);
+            RecordingEffect effect = new RecordingEffect();
+            rs.Relics.Add(new RelicInstance(MakeDef("DamageOnly", effect, RelicHook.OnDamageDealt), 0));
+
+            disp.Dispatch(RelicHook.OnPlayerTurnStart, MakeTurnStartData(rs, disp));
+
+            Assert.AreEqual(0, effect.Calls.Count);
+        }
+
+        [Test]
+        public void Dispatch_MutablePayload_ChainsAcrossSubscribers()
+        {
+            RunState rs = new RunState();
+            RelicHookDispatcher disp = new RelicHookDispatcher(rs);
+            RecordingEffect a = new RecordingEffect { Callback = (_, ctx) => ((DamageDealtHookData)ctx).Amount += 1 };
+            RecordingEffect b = new RecordingEffect { Callback = (_, ctx) => ((DamageDealtHookData)ctx).Amount += 1 };
+            rs.Relics.Add(new RelicInstance(MakeDef("A", a, RelicHook.OnDamageDealt), 0));
+            rs.Relics.Add(new RelicInstance(MakeDef("B", b, RelicHook.OnDamageDealt), 1));
+
+            DamageDealtHookData data = new DamageDealtHookData(
+                rs, null, disp, 10, Effectiveness.Neutro, ElementType.Rojo, null);
+            disp.Dispatch(RelicHook.OnDamageDealt, data);
+
+            Assert.AreEqual(12, data.Amount);
+        }
+
+        [Test]
+        public void Dispatch_RelicWithMultipleHooks_FiresOnEach()
+        {
+            RunState rs = new RunState();
+            RelicHookDispatcher disp = new RelicHookDispatcher(rs);
+            RecordingEffect effect = new RecordingEffect();
+            rs.Relics.Add(new RelicInstance(
+                MakeDef("Bracket", effect, RelicHook.OnCombatStart, RelicHook.OnCombatEnd), 0));
+
+            disp.Dispatch(RelicHook.OnCombatStart, new CombatStartHookData(rs, null, disp, null));
+            disp.Dispatch(RelicHook.OnCombatEnd, new CombatEndHookData(rs, null, disp, true, null));
+
+            Assert.AreEqual(2, effect.Calls.Count);
+            Assert.AreEqual(RelicHook.OnCombatStart, effect.Calls[0]);
+            Assert.AreEqual(RelicHook.OnCombatEnd, effect.Calls[1]);
+        }
+
+        [Test]
+        public void Counters_PersistAcrossDispatches_DispatcherDoesNotReset()
+        {
+            RunState rs = new RunState();
+            RelicHookDispatcher disp = new RelicHookDispatcher(rs);
+            RecordingEffect effect = new RecordingEffect
+            {
+                Callback = (_, ctx) =>
+                {
+                    Dictionary<string, int> counters = ctx.CurrentRelic.Counters;
+                    int prev = counters.TryGetValue("x", out int v) ? v : 0;
+                    counters["x"] = prev + 1;
+                }
+            };
+            RelicInstance instance = new RelicInstance(
+                MakeDef("Counter", effect, RelicHook.OnPlayerTurnStart), 0);
+            rs.Relics.Add(instance);
+
+            disp.Dispatch(RelicHook.OnPlayerTurnStart, MakeTurnStartData(rs, disp));
+            disp.Dispatch(RelicHook.OnPlayerTurnStart, MakeTurnStartData(rs, disp));
+            disp.Dispatch(RelicHook.OnPlayerTurnStart, MakeTurnStartData(rs, disp));
+
+            Assert.AreEqual(3, instance.Counters["x"]);
+        }
+
+        [Test]
+        public void GetSubscribers_FiltersByHookAndOrdersByAcquisition()
+        {
+            RunState rs = new RunState();
+            RelicHookDispatcher disp = new RelicHookDispatcher(rs);
+
+            // 5 Retazos mixtos: 3 escuchan OnPlayerTurnStart (R2, R3, R5).
+            rs.Relics.Add(new RelicInstance(MakeDef("R1", new RecordingEffect(), RelicHook.OnDamageDealt), 0));
+            rs.Relics.Add(new RelicInstance(MakeDef("R2", new RecordingEffect(), RelicHook.OnPlayerTurnStart), 1));
+            rs.Relics.Add(new RelicInstance(MakeDef("R3", new RecordingEffect(),
+                RelicHook.OnDamageDealt, RelicHook.OnPlayerTurnStart), 2));
+            rs.Relics.Add(new RelicInstance(MakeDef("R4", new RecordingEffect(), RelicHook.OnCombatEnd), 3));
+            rs.Relics.Add(new RelicInstance(MakeDef("R5", new RecordingEffect(), RelicHook.OnPlayerTurnStart), 4));
+
+            IReadOnlyList<RelicInstance> subs = disp.GetSubscribers(RelicHook.OnPlayerTurnStart);
+            Assert.AreEqual(3, subs.Count);
+            Assert.AreEqual("R2", subs[0].Definition.DisplayName);
+            Assert.AreEqual("R3", subs[1].Definition.DisplayName);
+            Assert.AreEqual("R5", subs[2].Definition.DisplayName);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/RelicHookDispatcherTests.cs.meta
+++ b/Assets/Tests/EditMode/RelicHookDispatcherTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8200906fc0a014a40864c2c1515eaf00

--- a/Docs/design/DESIGN_DECISIONS.md
+++ b/Docs/design/DESIGN_DECISIONS.md
@@ -8,9 +8,9 @@
 
 ## Estado actual
 
-GDD v2 (procesado el 2026-04-28) cerro **DD-001 a DD-016**. Las reglas resultantes viven en `GOLDEN_RULES.md`. En la revision post-GDD se abrieron **DD-017 a DD-021** y se cerraron todas excepto DD-017.
+GDD v2 (procesado el 2026-04-28) cerro **DD-001 a DD-016**. Las reglas resultantes viven en `GOLDEN_RULES.md`. En la revision post-GDD se abrieron **DD-017 a DD-021** y se cerraron todas excepto DD-017. **DD-017 fue cerrada el 2026-05-07** durante el diseño de M3.
 
-**Hoy queda abierta una sola decision: DD-017.**
+**Hoy no quedan decisiones de diseño abiertas.** Solo queda `DD-015` (narrativa) en estado `postponed`.
 
 ---
 
@@ -47,35 +47,11 @@ GDD v2 (procesado el 2026-04-28) cerro **DD-001 a DD-016**. Las reglas resultant
 
 ---
 
-## Abiertas
+## Cerradas en diseño de M3 (2026-05-07)
 
-### DD-017: Retazos de cambio en contenido base o post-launch
-
-#### Pregunta
-El GDD v2 (linea 129, dentro de DD-012) define 3 categorias de Retazos: neutros, de cambio y de mundo. Para los **Retazos de cambio** (los que se activan cada vez que el jugador ejecuta un cambio de mundo) el GDD textualmente dice: *"Estado actual: pendiente de decision de implementacion para contenido base"*.
-
-La pregunta es: cuando se implemente el sistema de Retazos (M3), ¿incluimos Retazos de cambio en el pool del **contenido base** del juego, o los dejamos para **contenido posterior** junto con los Retazos de mundo (que ya estan diferidos)?
-
-#### Opciones
-
-**A) Si, incluir Retazos de cambio en el contenido base.**
-- Pro: refuerzan la mecanica diferenciadora del juego (el cambio de mundo) desde el primer run.
-- Pro: dan otro vector de identidad de build ("build basada en cambiar mucho").
-- Contra: requiere disenar y balancear ~10-15 Retazos de cambio adicionales para que la categoria tenga variedad.
-- Contra: aumenta complejidad cognitiva del primer run.
-
-**B) No, dejarlos para contenido posterior.**
-- Pro: M3 entrega un sistema completo de Retazos sin sobrecargar el balance.
-- Pro: los Retazos de cambio quedan como "novedad" para una primera expansion / actualizacion.
-- Contra: el primer run no muestra una de las categorias mas vinculadas a la mecanica core.
-- Contra: hay que decidir si el UI menciona la categoria como "vacia por ahora" o la esconde.
-
-**C) Hibrido: 2-3 Retazos de cambio en base como demo de la categoria.**
-- Pro: existe la categoria sin la carga de balance de A.
-- Contra: poca variedad para que el jugador construya builds alrededor.
-
-#### Estado: POR DECIDIR
-**No bloqueante hoy.** La decision se puede cerrar al disenar M3 (sistema de Retazos), no antes.
+| DD  | Tema | Resolucion |
+|-----|------|------------|
+| DD-017 | Retazos de cambio en contenido base o post-launch | **Opción C — Híbrido**: 2-3 Retazos de cambio se incluyen en el contenido base como demo de la categoría. Razón: la categoría existe (refuerza la mecánica diferenciadora del cambio de mundo desde el primer run) sin la carga de diseñar y balancear 10-15 Retazos. Si en playtest la categoría es divertida, M4/M5 amplían el pool; si no, no se invirtió tiempo de más. Aplicado en Sub-PR 3B de M3 |
 
 ---
 
@@ -86,5 +62,5 @@ Tema: vinetas narrativas, dialogo de los hermanos, lore. **Postponed** hasta que
 
 ---
 
-> Ultima actualizacion: 2026-04-28
+> Ultima actualizacion: 2026-05-07 (DD-017 cerrada en diseño de M3)
 > Cuando una decision se cierra, su regla resultante se mueve a GOLDEN_RULES.md y se marca su entrada aqui con la referencia a la seccion correspondiente.

--- a/Docs/dev/_insights.md
+++ b/Docs/dev/_insights.md
@@ -31,6 +31,69 @@
 <!-- Los insights se agregan aquí en orden cronológico (más reciente arriba). -->
 <!-- No editar insights pasados sin pedido explícito. -->
 
+## Insight 5 — Scope estricto en archivos protegidos puede dejar comportamiento no obvio en paths secundarios — 2026-05-08
+
+**Contexto:** durante implementación de M3 Sub-PR 3A, el agente respetó "7 puntos exactos de inserción en TurnManager" y no agregó el hook `OnDamageDealt` en el branch de cartas neutras (`ElementType.None`) dentro de `ApplyPlayerToEnemyEffectiveness` (líneas 588-630). Eso hubiera sido un 8º punto fuera del alcance aprobado del spec. La decisión es conservadora y correcta para el alcance — pero deja un comportamiento que para el jugador será contraintuitivo cuando lleguen los primeros Retazos en 3B.
+
+**Idea:** un Retazo de la categoría "Modificador de daño" (ej: "+5 daño al primer ataque") hoy se dispararía en cartas con afinidad de tipo (Strike Rojo, Strike Amarillo, etc.) pero **NO** en cartas neutras. El jugador no tiene forma de saberlo sin leer el código.
+
+La lección: **scope estricto sobre archivos protegidos protege contra scope creep, pero puede dejar comportamiento no obvio en paths secundarios del mismo flujo**. La implementación queda correcta según el spec aprobado, pero la sub-PR siguiente que la consuma se va a chocar con el comportamiento al diseñar contenido. Si en la sesión de diseño se anticipa la necesidad, conviene incluir explícitamente todos los paths del flujo (no solo el "principal") en la lista aprobada — o documentar el límite del scope con la consecuencia de gameplay para que la siguiente sesión de diseño lo tenga en cuenta sin descubrirlo en testeo.
+
+**Conexión con sistemas:** sistema de Retazos (M3 Sub-PR 3B), TurnManager (archivo protegido), efectividad de cartas neutras (DD-002, GOLDEN_RULES §3 y §5).
+
+**Potencial:** dos opciones se evaluaron al diseñar Retazos placeholder en 3B:
+- **Opción A (ELEGIDA por Sebastián, 2026-05-08):** los Retazos de daño afectan también cartas neutras. Implica agregar el dispatch en el path `attackerType == ElementType.None` como 8º punto de inserción en TurnManager con aprobación explícita en 3B. Razón: para el jugador es contraintuitivo que un Retazo "+5 al primer ataque" no se active con Strike neutro. Cartas neutras siguen aplicando 90% del daño base (DD-002, GOLDEN_RULES §5) — el modificador del Retazo se suma sobre ese 90%.
+- **Opción B (descartada):** Retazos de daño solo afectan cartas con afinidad. Hubiera mantenido cartas neutras como "estabilidad pura sin combos" pero generaba ambigüedad en el texto del Retazo.
+
+**Estado:** discutido — Opción A confirmada. Implementación pendiente: en Sub-PR 3B, agregar el `Dispatch(RelicHook.OnDamageDealt, ...)` también en el branch de cartas None de `ApplyPlayerToEnemyEffectiveness` con aprobación de archivo protegido. El 8º punto de inserción se justifica porque la sub-PR 3B es la primera que va a tener Retazos concretos consumiendo el hook.
+
+---
+
+## Insight 4 — Payloads de hooks de Retazos: 5 campos diferidos por falta de cableado — 2026-05-08
+
+**Contexto:** durante la implementación de M3 Sub-PR 3A (foundations de hooks + dispatcher), tres rondas de revisión técnica del spec detectaron campos en los payloads cuyo dato fuente no existe todavía en la arquitectura del juego o cuya semántica es ambigua en el contexto actual. Se decidió quitarlos de 3A en lugar de cablear infraestructura nueva sin un Retazo concreto que la consuma.
+
+**Idea:** los 5 campos diferidos, cada uno con su causa raíz y qué desbloquea agregarlo. Cuando un Retazo concreto los pida, agregar el campo va junto con el cableado correspondiente — no antes.
+
+| Campo removido | Payload | Causa de diferimiento | Cableado pendiente para reactivarlo |
+|---|---|---|---|
+| `int TurnNumber` | `PlayerTurnStartHookData` | TurnManager no tiene contador de turno; agregarlo era cambio fuera de los 7 puntos aprobados del archivo protegido | Agregar `_turnNumber++` en `BeginPlayerTurn` (con aprobación de archivo protegido) y exponer vía `TurnManager.TurnNumber`. Workaround: `RelicInstance.Counters` |
+| `int TurnsTaken` | `CombatEndHookData` | Mismo: requiere contador de turno en TurnManager | Mismo cableado que `TurnNumber`. Workaround: `RelicInstance.Counters` |
+| `bool WasFreeSwitch` | `WorldSwitchHookData` | Semánticamente ambiguo: en M3 todos los switches son "gratis" porque el pool base+bonus es fungible en `TryChangeWorld`. El campo no distingue nada significativo | Si el diseño futuro introduce switches con coste no fungible (ej: oro, HP), entonces el flag tiene sentido — y ese mismo cambio define qué significa "free" |
+| `bool IsBoss` | `CombatStartHookData` | Boss/Elite vive en `NodeType` del MapNode, no en `EnemyDefinition`; TurnManager hoy no recibe la referencia del nodo activo | Extender `RunCombatConfig`/`ConfigureCombat` para inyectar el `NodeType` (o un par de bools) del nodo que abrió el combate. Lo conoce `BattleFlowController` |
+| `bool IsElite` | `CombatStartHookData` | Mismo que IsBoss | Mismo cableado que IsBoss |
+
+**Conexión con sistemas:** sistema de hooks/dispatcher de Retazos (M3 Sub-PR 3A), TurnManager (archivo protegido), RunCombatConfig/BattleFlowController (cableado de combate desde el run), diseño de Retazos placeholder (M3 Sub-PR 3B).
+
+**Potencial:** la lección de proceso es que los specs de infraestructura tienden a sobre-especificar payloads anticipando todos los Retazos imaginables. Mejor regla: el payload solo lleva campos que (a) ya están disponibles en el call site sin cableado nuevo, o (b) tienen un Retazo concreto que los justifique y cuyo cableado entra en la misma sub-PR. Para reacomodar el roadmap, considerar: ¿alguno de los 5 campos es requisito del pool inicial de Retazos placeholder de 3B? Si sí, su cableado entra como sub-tarea de 3B (no de 3A); si no, queda diferido a la sub-PR donde aparezca el Retazo que lo necesite.
+
+**Estado:** crudo — los 5 campos quedan removidos en 3A, listos para reincorporar cuando 3B (o posterior) defina los Retazos que los necesitan.
+
+---
+
+## Insight 3 — Retazos: diseñar por categoría de hook, no por idea suelta — 2026-05-07
+
+**Contexto:** durante el diseño de M3, al pensar cómo abordar los Retazos placeholder iniciales (DD-012). Sin contenido base heredado, había que diseñar desde cero el primer pool de Retazos del juego.
+
+**Idea:** diseñar Retazos partiendo de "qué evento del combate disparan" (categoría de hook) en lugar de partir de "qué efecto se nos ocurre". 6 categorías cubren toda la superficie del combate:
+
+| Categoría | Cuándo se dispara | Ejemplo placeholder |
+|---|---|---|
+| Apertura de combate | Empieza el combate | "Empezás cada combate con 4 de bloqueo" |
+| Inicio de turno | Empieza tu turno | "Robás 1 carta extra al inicio del turno" |
+| Modificador de daño | Hacés/recibís daño | "Tu primer ataque del combate hace +5 daño" |
+| Acumulador / trigger | Después de N acciones | "Cada 3 cartas Skill jugadas en un turno → +1 energía siguiente turno" |
+| Economía / fin de combate | Termina combate o muere enemigo | "+5 oro al final de cada combate" |
+| Cambio de mundo | Ejecutás un switch | "Al cambiar de mundo, ganás 5 de bloqueo" |
+
+**Conexión con sistemas:** Retazos (M3 Sub-PR 3B), sistema de hooks/dispatcher (M3 Sub-PR 3A), eventos del combate (M4 eventos, M5 bosses con fases).
+
+**Potencial:** garantiza que el pool de Retazos del lanzamiento cubra toda la superficie del combate sin diseñar 23 efectos redundantes. Las 6 categorías alimentan directamente el spec de hooks: cada categoría → un hook específico. El diseño de Retazos y el diseño de hooks se construyen sobre la misma base. Aplica también a opciones extensibles de Hoguera/Tienda (`OnCampfireOptionsBuilt`, `OnShopStockBuilt`) — el mismo principio: el sistema expone hooks, las features que vienen después se cuelgan ahí.
+
+**Estado:** crudo — pendiente de aplicar al spec formal de hooks (Sub-PR 3A) y al diseño de Retazos placeholder (Sub-PR 3B).
+
+---
+
 ## Insight 2 — Ampliar contrato de interfaz requiere grep por implementadores, no por nombre del miembro — 2026-05-07
 
 **Contexto:** durante Sub-PR D de M2 se agregó `Heal(int)` al contrato de `ICombatActor`. Se actualizaron las dos implementaciones de producción (`PlayerCombatActor`, `EnemyCombatActor`) pero quedó sin actualizar el mock privado `TestActor` dentro de `ActionQueueTests.cs`. El error CS0535 recién apareció al abrir Unity post-commit; el commit ya estaba pusheado y el PR #91 abierto. Bloqueó compilación entera (Safe Mode).

--- a/Docs/dev/_insights.md
+++ b/Docs/dev/_insights.md
@@ -31,6 +31,20 @@
 <!-- Los insights se agregan aquí en orden cronológico (más reciente arriba). -->
 <!-- No editar insights pasados sin pedido explícito. -->
 
+## Insight 2 — Ampliar contrato de interfaz requiere grep por implementadores, no por nombre del miembro — 2026-05-07
+
+**Contexto:** durante Sub-PR D de M2 se agregó `Heal(int)` al contrato de `ICombatActor`. Se actualizaron las dos implementaciones de producción (`PlayerCombatActor`, `EnemyCombatActor`) pero quedó sin actualizar el mock privado `TestActor` dentro de `ActionQueueTests.cs`. El error CS0535 recién apareció al abrir Unity post-commit; el commit ya estaba pusheado y el PR #91 abierto. Bloqueó compilación entera (Safe Mode).
+
+**Idea:** cuando se amplía el contrato de una interfaz, el grep que captura todos los puntos a tocar NO es por el nombre del miembro nuevo (`Heal`) — porque los lugares que faltan implementarlo todavía no lo mencionan. El grep correcto es por la declaración de implementación (`: ICombatActor`, `: IInterface\b`). Esto encuentra mocks de test, clases stub, y cualquier implementador que el code review por nombre del miembro nuevo no captura.
+
+**Conexión con sistemas:** proceso de desarrollo / validación. Aplica a cualquier cambio de contrato (interfaces, clases abstractas, virtuals nuevos).
+
+**Potencial:** sumarlo al checklist de `modo:implementacion` cuando se toca una interfaz: antes de commitear, hacer `grep ": NombreInterfaz"` y verificar que todos los implementadores tengan el miembro nuevo. Especialmente importante en proyectos con tests que usan mocks privados — esos no aparecen en búsquedas por nombre del archivo de la interfaz. Es una versión específica del Insight 1 (abrir Unity siempre antes de cerrar): si el grep por implementadores se hubiera hecho, no hubiera hecho falta llegar a Unity para descubrirlo.
+
+**Estado:** aplicado — fix puntual de `TestActor.Heal()` commiteado encima de Sub-PR D.
+
+---
+
 ## Insight 1 — Validación de fase de extracción debe abrir Unity, no solo revisar el diff — 2026-05-01
 
 **Contexto:** durante la validación de la Fase 4 (extracción de CombatBackgroundView), al abrir Unity por primera vez post-merge me salió el editor en Safe Mode con 6 errores CS0246/CS0103 en CombatHudView.cs. El error venía latente desde Fase 3: `BuildEnemyIntentLabel()` se movió de CombatUIController a CombatHudView pero el `using RoguelikeCardBattler.Gameplay.Enemies;` no se replicó. Como el code review de Fase 3 fue por inspección de diff y no abriendo Unity, el error pasó. Recién apareció en Fase 4 cuando volví a abrir el editor.

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -7,10 +7,10 @@
 > En `modo:implementacion` se lee al inicio para saber qué milestone está activo
 > y qué sub-tareas quedan.
 >
-> **Fase actual:** entrando a M2 — reescritura de la mecánica core sobre TurnManager.
-> **Milestone activo:** M2 — TurnManager v2 (mecánica core nueva + bundle de deuda)
-> **Próximo bloque:** M3 — Personalización del run (Retazos, Tienda, Hoguera)
-> **Última actualización:** 2026-05-04 (M2 Sub-PRs A/B/C/UI cerrados; Sub-PR D pendiente)
+> **Fase actual:** M2 cerrado completo (motor v2 estable). Diseño de M3 cerrado.
+> **Milestone activo:** M3 — Personalización del run (Retazos, Tienda, Hoguera, NewRunScene, mapa horizontal)
+> **Próximo bloque:** M4 — Resto del Acto 1 (mejora cartas con UI, eventos, transdimensionales, ancla)
+> **Última actualización:** 2026-05-07 (M2 cerrado; M3 activado con 6 sub-PRs acordados)
 
 ---
 
@@ -44,108 +44,154 @@
 
 ## Activo
 
-### M2 — TurnManager v2: mecánica core nueva + deuda técnica
+### M3 — Personalización del run
 
-**Objetivo:** instalar el sistema de cargas (Contador de Estilo) y todas las
-mecánicas que el GDD v2 introduce sobre el motor de combate, en un único refactor
-coordinado de los archivos protegidos. Bundle gigante intencional.
+**Objetivo:** entregar el ecosistema completo que convierte una secuencia de combates
+en un run con identidad: Retazos como sistema base de pasivos, Tienda y Hoguera
+funcionales como nodos del mapa, NewRunScene como flujo inicial (elección de tipos +
+draft de carta especial dual), y mapa con scroll horizontal según GDD.
 
-**Por qué bundle:** todas las features tocan `TurnManager.cs` (PROTEGIDO).
-Hacerlas en PRs separados obliga a reabrir el archivo cada vez, reescribir tests
-varias veces y reconciliar cambios. Una sola serie de sub-PRs cohesivos es más
-limpio.
+**Por qué bundle:** los 4 sistemas comparten una capa de infraestructura nueva
+(sistema de hooks/dispatcher de Retazos). Hacer cada sistema en milestones separados
+implicaría diseñar la infra varias veces o duplicar código. M3 instala la base + 4
+features que la usan + 1 refactor de UX (mapa horizontal).
 
-**Features incluidas:**
+**Decisiones cerradas durante diseño (2026-05-07):**
+- DD-017 → opción C: 2-3 Retazos de cambio en contenido base como demo de la categoría.
+- Tienda + Hoguera = paneles sobre RunScene (no escenas nuevas) con parallax 2D.
+- Hoguera con opciones extensibles vía hooks (Retazos pueden agregar opciones tipo
+  "excavar para encontrar Retazo común").
+- Tienda con stock extensible vía hooks (Retazos pueden modificar stock/precios).
+- Consumibles diferidos: no hay sistema base, se decide en futura sesión si entran
+  a M3 o M4.
+- NewRunScene = escena dedicada (no canvas en MainMenu) entre MainMenu y RunScene.
+  Razón: cambio de contexto (música, fondo, atmósfera) refuerza el "estoy empezando
+  algo"; mantiene MainMenu liviano para meta-progresión futura.
+- Mapa horizontal incluido en M3 como refactor del scroll vertical actual (DD-005).
+- Inventario de Retazos = fila de iconos en HUD (estilo StS), visible siempre en
+  combate y mapa para reforzar identidad de build.
 
-#### Mecánica core nueva (cierra DDs del GDD v2)
-- [x] Eliminar Momentum (todas sus referencias en TurnManager + UI) *(Sub-PR C)*
-- [x] Implementar Contador de Estilo (cargas: +1 por SuperEficaz hecho, -1 por
-      SuperEficaz recibido, 5 cargas → 1 cambio extra no acumulable, reset cada
-      combate) *(Sub-PR C)*
-- [x] Cambios múltiples de mundo por combate (cap dinámico: 1 base + extras por
-      cargas / cartas / Retazos) *(Sub-PR C — cartas/Retazos quedan para M3)*
-- [x] Tipo activo del jugador (campo derivado del mundo, viene de los 2 tipos
-      elegidos al inicio del run) *(Sub-PR A — PR #86)*
-- [x] Daño enemigo SuperEficaz contra el jugador: aplicar multiplicador x1.5
-      (DD-018) — multiplicador configurable como constante *(Sub-PR B)*
-- [x] Hacer configurables los multiplicadores de efectividad (1.5 / 1.0 / 0.75)
-      como constantes en código *(Sub-PR A — PR #86)*
-- [x] Cartas neutras al 90% del daño base (DD-002) *(Sub-PR C)*
+**Diseño de Retazos:** las 6 categorías de hook definidas en Insight 3 de
+`_insights.md` son la base. Se diseñan partiendo de "qué evento del combate
+disparan", no de "qué efecto se nos ocurre".
 
-#### Deuda técnica que se cierra aquí (bundle de M-tech)
-- [ ] PhaseBased AI: implementar case en `SelectEnemyMove()` (HP thresholds o
-      turn count)
-- [ ] `EffectType.Heal` + `HealAction` + case en `CreateAction()`
-- [ ] `CalculateIntentValue` ampliado para combinaciones nuevas (Defend+Heal,
-      Buff+StatusEffect, etc.)
+**Sub-PRs (orden):**
 
-#### UI de M2
-- [x] HUD: cambiar "Momentum: N" por "Estilo: N/5" (modificar CombatHudView ya
-      extraído) *(Sub-PR C)*
-- [x] HUD: indicador de tipo activo del jugador (label nuevo) *(feat PR #90)*
-- [x] HUD: contador de switches dinámico (usa TotalAvailableWorldSwitches) *(Sub-PR C)*
+#### Sub-PR 3A — Foundations: hooks + dispatcher de Retazos
+- [x] **PASO 1 (sin código):** sesión `modo:diseno` dedicada al spec de hooks
+      (output: `Docs/dev/specs/m3_hooks_spec.md`). Define cada hook, signature,
+      datos que pasa, orden de ejecución, interacción con ActionQueue. **NO codear
+      hasta que el spec esté cerrado.**
+- [x] `RelicDefinition` SO + `IRelicEffect` interface + `RelicHook` enum
+- [x] `RelicHookDispatcher`: bus que TurnManager invoca en eventos clave
+- [x] Hooks expuestos (mínimo): OnCombatStart, OnPlayerTurnStart, OnDamageDealt,
+      OnDamageTaken, OnWorldSwitch, OnCombatEnd, OnCardPlayed,
+      OnCampfireOptionsBuilt, OnShopStockBuilt — los 7 de combate con payload;
+      los 2 de nodos solo declarados (call sites en 3C/3D, payloads diferidos)
+- [x] `RunState.Relics: List<RelicInstance>` + reset
+- [x] `RunSession.RelicDispatcher`: instanciado en Awake, persiste con la run
+- [x] `RelicHookContext` + API limitada (7 métodos: GrantBlock, GrantHeal,
+      GrantDrawCards, GrantEnergy, GrantStyleCharge, GrantBonusWorldSwitch,
+      EnqueueExtraDamage) con guards Victory/Defeat
+- [x] TurnManager: 7 invocaciones + 7 métodos `internal Relic*` + extracción
+      `IncrementStyleCharges` (golden rule §4 con una sola fuente de verdad)
+- [x] Tests EditMode: dispatcher invoca hooks en orden correcto, sin Retazos no
+      rompe nada, suscripciones múltiples se ejecutan en orden de adquisición
+      (8 casos en `RelicHookDispatcherTests.cs`)
+- **Toca archivos protegidos:** **SÍ** — TurnManager. **APROBACIÓN DADA** (7 puntos
+  + extracción `IncrementStyleCharges` aprobados explícitamente por Sebastián).
+- **5 campos de payload diferidos** (ver Insight 4): `TurnNumber`, `TurnsTaken`,
+  `WasFreeSwitch`, `IsBoss`, `IsElite`. Se reincorporan en la sub-PR donde un
+  Retazo concreto los justifique + cableen el dato fuente.
 
-**Sistemas afectados:** TurnManager, PlayerCombatActor, RunState, ElementTypes,
-CombatHudView, tests existentes (WorldSwitchLimitTests, DamageEffectivenessTests,
-PlayerCombatActorTests deberán reescribirse).
+#### Sub-PR 3B — Retazos: contenido placeholder + UI inventario
+- [ ] Diseño formal de ~23 Retazos placeholder (sesión `modo:diseno` específica)
+  - 15 neutros distribuidos por las 6 categorías de Insight 3
+  - 5 de Elite (drop garantizado al ganar Elite)
+  - 1 de Boss (drop tras vencer BossAct1, vinculado narrativamente)
+  - 2-3 de cambio (DD-017 opción C)
+- [ ] `RelicInventoryView`: fila de iconos en HUD de combate y de RunMapView
+      (mismo lugar en ambas vistas)
+- [ ] Tooltip al hover/tap con nombre + descripción + texto narrativo
+- [ ] Pulse + brillo cuando se obtiene uno nuevo (game feel barato, alto impacto)
+- [ ] Hook de drop al ganar Elite/Boss
+- [ ] Tests EditMode: cada Retazo aplica su efecto en el hook correcto
 
-**Toca archivos protegidos:** **SÍ** — TurnManager + PlayerCombatActor.
-**REQUIERE APROBACIÓN EXPLÍCITA** antes de empezar implementación.
+#### Sub-PR 3C — Hoguera (Campfire)
+- [ ] `CampfireNodeController` + `CampfireView` (panel sobre RunScene)
+- [ ] Opciones base: **Descansar** (heal X HP) | **Mejorar carta** (1 carta del mazo)
+- [ ] Mejora de cartas: toggle `IsUpgraded` en `CardDeckEntry` + campos upgraded
+      en `CardDefinition` (DD-013: cartas duales upgrade ambos lados)
+- [ ] Hook `OnCampfireOptionsBuilt` para que Retazos puedan agregar opciones
+- [ ] Parallax 2-3 capas placeholder (cielo nocturno + montañas + tronco con fuego)
+- [ ] Música ambiente distinta a combate
+- [ ] Tests: heal aplica HP correcto; upgrade marca flag y respeta dualidad;
+      opciones extra de Retazos aparecen en la lista
 
-**Dependencias:** M-tech cerrada ✅ (CombatHudView ya extraído facilita la
-modificación del HUD para cargas; CombatBackgroundView libera el monolito
-para tocar HUD/state sin pisar fondos; gh CLI listo para PRs ágiles).
+#### Sub-PR 3D — Tienda (Shop)
+- [ ] `ShopNodeController` + `ShopView` (panel sobre RunScene)
+- [ ] Stock generado por seed: cartas, Retazos, opción "Eliminar carta del mazo"
+- [ ] Filtrado de cartas por los 2 tipos elegidos al inicio del run
+- [ ] Hook `OnShopStockBuilt` para que Retazos puedan modificar stock/precios
+- [ ] Economía: precios desde SO config; gold del RunState
+- [ ] Parallax 2-3 capas placeholder (pared del local + estanterías + mostrador)
+- [ ] Vendedor con personalidad por mundo (placeholder ahora, arte después)
+- [ ] Consumibles **diferidos** (decidir en sesión futura si entran o se van a M4)
+- [ ] Tests: stock determinista por seed; compra resta gold y agrega item;
+      remove carta funciona; precios modificados por Retazos respetan tope mínimo
 
-**Estrategia de PRs:** subdividir en 4 sub-PRs cohesivos:
-- Sub-PR A: tipo activo del jugador + multiplicadores configurables (sin tocar
-  comportamiento todavía)
-- Sub-PR B: efectividad bidireccional + daño x1.5 al jugador
-- Sub-PR C: Contador de Estilo + cambios múltiples (reemplaza Momentum)
-- Sub-PR D: PhaseBased AI + Heal + CalculateIntentValue (deuda técnica)
+#### Sub-PR 3E — NewRunScene
+- [ ] Escena dedicada `Assets/Scenes/NewRunScene.unity` con `NewRunController.cs`
+- [ ] **Paso 1:** Selección de 2 tipos elementales (uno por mundo)
+- [ ] **Paso 2:** Draft de carta especial dual (6 opciones filtradas: 3 Mundo A
+      + 3 Mundo B según tipos elegidos en Paso 1, DD-020)
+- [ ] **Paso 3:** Confirmación + carga de RunScene
+- [ ] Feel: cards entrando con fade desde sus mundos, texto de peso ("esta carta
+      te acompañará todo el run"), sonido al confirmar
+- [ ] La carta seleccionada se inyecta en el mazo inicial del run
+- [ ] Botón volver a MainMenu en cada paso
+- [ ] Tests: draft genera 6 opciones válidas filtradas por tipos; carta
+      seleccionada entra al deck; cancelar vuelve a MainMenu sin estado sucio
 
-**Validación obligatoria por sub-PR (lección de Fase 3-4, ver `_insights.md`):**
+#### Sub-PR 3F — Mapa horizontal (refactor scroll)
+- [ ] Refactor `RunMapView` para scroll lateral (izquierda → derecha) por DD-005
+- [ ] Adaptar generación de `RunMapGenerator` a layout horizontal
+- [ ] Adaptar UI de nodos y aristas (`RunMapNodeView`, `RunMapEdgeView`) al
+      nuevo eje
+- [ ] `RelicInventoryView` integrado en HUD del mapa (consistencia con HUD de
+      combate)
+- [ ] Tests: misma seed = mismo mapa (no romper determinismo en el refactor)
+
+**Sistemas afectados:** TurnManager (hooks), RunState (Relics), RunFlowController
+(NewRunScene flow + Tienda/Hoguera nodes), RunMapView/Generator (horizontal),
+CombatUIController (RelicInventoryView). Nuevos: RelicHookDispatcher,
+RelicDefinition, IRelicEffect, NewRunController, CampfireNodeController,
+ShopNodeController, RelicInventoryView.
+
+**Toca archivos protegidos:** **SÍ** — TurnManager (hooks en eventos clave).
+**REQUIERE APROBACIÓN EXPLÍCITA** antes de empezar implementación de Sub-PR 3A.
+
+**Dependencias:** M2 cerrado ✅ (motor de combate v2 estable; hooks pueden
+colgarse en eventos confiables como Contador de Estilo, daño bidireccional,
+HealAction, PhaseBased AI).
+
+**Validación obligatoria por sub-PR:**
 - Compilación de Unity sin errores antes de marcar como mergeable.
 - Tests EditMode en verde.
-- BattleScene jugable y manualmente verificada.
+- Validación visual en la escena correspondiente (combate / hoguera / tienda /
+  new run / mapa).
 
-**Complejidad:** alta. Es el cambio que más riesgo de regresión introduce en el
-motor de combate.
+**Complejidad:** alta. Sub-PR 3A es la más crítica arquitectónicamente; el resto
+depende de que su contrato esté bien definido (lección reforzada por Insight 3).
 
-**Criterios de cierre:** todos los tests pasan + comportamiento verificado en
-BattleScene + Momentum completamente eliminado del código + UI del HUD refleja
-Cargas y tipo activo del jugador.
+**Criterios de cierre M3:** todos los sub-PRs mergeados + run completo jugable
+de inicio a fin (NewRunScene → mapa horizontal → combates con Retazos visibles
+y activos → Tienda y Hoguera funcionales → Boss con drop de Retazo único +
+zero console errors + tests EditMode al 100%.
 
 ---
 
 ## Pendientes
-
-### M3 — Personalización del run
-
-**Objetivo:** instalar el ecosistema de personalización del run según GDD v2:
-Retazos como sistema base, Tienda funcional, Hoguera con heal/upgrade, y draft
-de carta especial dual al inicio.
-
-**Sub-tareas (desagregar al activar):**
-- Sistema de Retazos: `RelicDefinition` SO, hooks (`RelicEffectHook`) en eventos
-  clave (init combate, draw, daño hecho/recibido, switch de mundo, fin combate),
-  `RunState.Relics`, UI
-- Tienda (Shop): controller, view, scene/canvas, lógica de selección por mundo,
-  compra/eliminar cartas
-- Hoguera (Campfire): controller, view, decisión heal vs upgrade
-- Carta especial dual inicial: draft de 6 opciones filtradas por los 2 tipos
-  elegidos (DD-020), UI panel
-- **Cerrar DD-017** (Retazos de cambio en contenido base) durante el diseño
-
-**Toca archivos protegidos:** parcial (TurnManager para hooks de Retazos en
-eventos del combate).
-
-**Dependencias:** M2 cerrado (Retazos de cambio dependen de cargas estables;
-hoguera depende de `EffectType.Heal`).
-
-**Complejidad:** alta. Retazos solos son alta complejidad por la cantidad de
-hooks y categorías.
-
----
 
 ### M4 — Resto del Acto 1 según GDD v2
 
@@ -225,6 +271,32 @@ toca TurnManager).
 
 ## Completados
 
+### M2 — TurnManager v2: mecánica core nueva + deuda técnica
+**Fecha cierre:** 2026-05-07
+**Resumen:**
+- **Sub-PR A (PR #86):** tipo activo del jugador derivado del mundo, multiplicadores
+  de efectividad como constantes configurables (1.5/1.0/0.75).
+- **Sub-PR B (PR #88):** efectividad bidireccional. Daño enemigo SuperEficaz contra
+  el tipo activo del jugador aplica multiplicador x1.5 (DD-018). Cargas de Estilo
+  enchufadas al lado defensivo.
+- **Sub-PR C (PR #89):** Contador de Estilo reemplaza Momentum por completo.
+  +1 carga por SuperEficaz hecho, -1 por SuperEficaz recibido, 5 cargas → 1 cambio
+  extra (no acumulable). Cap dinámico de switches via `TotalAvailableWorldSwitches`.
+  Cartas neutras al 90% del daño base. UI HUD actualizada (Estilo: N/5).
+- **UI auxiliar (PR #90):** label de tipo activo del jugador en WorldPanel del HUD.
+- **Sub-PR D (PR #91 + hotfix):** PhaseBased AI implementado en `SelectEnemyMove()`
+  con rangos `MinHpPercent`/`MaxHpPercent` en `EnemyMove`. `EffectType.Heal` +
+  `HealAction` end-to-end (interfaz, ambos actors, action, case en CreateAction,
+  tests). `CalculateIntentValue` cubre Defend+Heal. BossAct1 elementType asignado.
+  Hotfix de `ActionQueueTests.TestActor.Heal()` post-merge para desbloquear Safe Mode
+  → registrado como Insight 2 (grep por implementadores al ampliar interfaces).
+- **Bonus de cleanup (Sub-PR D):** referencias a Momentum en comentarios eliminadas
+  de TurnManager, CombatHudView, CombatUIController y `Combat/CLAUDE.md`. Doc del
+  combate al día con el motor v2.
+
+**Insights generados durante M2:** Insight 2 (interfaces) e Insight 3 (Retazos por
+categoría de hook) registrados en `_insights.md`.
+
 ### M-tech — Deuda técnica acumulada
 **Fecha cierre:** 2026-05-01
 **Resumen:**
@@ -297,8 +369,9 @@ toca TurnManager).
 
 ## Decisiones abiertas que afectan el roadmap
 
-- **DD-017** — Retazos de cambio en contenido base: se cierra al diseñar M3.
-  No bloquea M2.
+- Ninguna activa al 2026-05-07. **DD-017 cerrada** durante diseño de M3 → opción C
+  (2-3 Retazos de cambio en contenido base como demo de la categoría). Detalle en
+  `DESIGN_DECISIONS.md`.
 
 ---
 

--- a/Docs/dev/_tech_snapshot.md
+++ b/Docs/dev/_tech_snapshot.md
@@ -7,8 +7,8 @@
 > En `modo:implementacion` se lee OBLIGATORIAMENTE antes de cualquier cambio que
 > afecte arquitectura o componentes críticos.
 >
-> **Última actualización:** 2026-05-01 — post extracción de CombatBackgroundView
-> (Fase 4); CombatUIController 980 → 710 loc
+> **Última actualización:** 2026-05-08 — M3 Sub-PR 3A (foundations de Retazos):
+> nuevo módulo `Gameplay/Relics/` + `RelicHookDispatcher` ownership en `RunSession`
 
 ---
 
@@ -62,7 +62,9 @@ BattleScene     →  BattleFlowController + RunSession (DDOL) + CombatUIControll
 ```
 
 ### Únicos DontDestroyOnLoad
-- `RunSession` (gameplay)
+- `RunSession` (gameplay) — owner del `RelicHookDispatcher` (instanciado en
+  `Awake`, persiste con la run, lee `RunState.Relics` por referencia → sobrevive
+  a `State.Reset`)
 - `AudioManager` (audio bootstrap)
 - `SceneTransitionManager` (fade entre escenas)
 
@@ -188,6 +190,19 @@ Gameplay/
     EnemyDefinition.cs           ← SO de enemigo
     EnemyMove.cs                 ← struct de movimiento + IntentType enum
     EnemyEnums.cs                ← AIPattern (RandomWeighted, Sequence, PhaseBased)
+  Relics/                        ← Sub-PR 3A — sistema de Retazos
+    RelicCategory.cs             ← enum (Neutral, Switch, World)
+    RelicHook.cs                 ← enum de los 9 eventos expuestos
+    IRelicEffect.cs              ← contrato ejecutable
+    RelicDefinition.cs           ← SO con [SerializeReference] sobre IRelicEffect
+    RelicInstance.cs             ← runtime wrapper (AcquisitionOrder + Counters)
+    RelicHookDispatcher.cs       ← bus que TurnManager invoca; flag LogDispatches
+    Hooks/
+      RelicHookContext.cs        ← payload base + API limitada de 7 métodos
+      CombatStartHookData.cs, PlayerTurnStartHookData.cs
+      DamageDealtHookData.cs, DamageTakenHookData.cs   ← Amount mutable
+      WorldSwitchHookData.cs, CombatEndHookData.cs, CardPlayedHookData.cs
+      [Campfire/Shop hook data: diferidos a 3C/3D junto con sus tipos]
 
 Save/
   ISaveService.cs
@@ -197,7 +212,7 @@ Save/
   SaveSmokeTest.cs
 ```
 
-### Tests (`Assets/Tests/EditMode/`) — 8 archivos
+### Tests (`Assets/Tests/EditMode/`) — 10 archivos
 
 ```
 CombatTestBase.cs                ← helper compartido
@@ -208,6 +223,8 @@ ElementEffectivenessTests.cs
 PlayerCombatActorTests.cs
 DefinitionTypeDefaultsTests.cs
 WorldSwitchLimitTests.cs
+HealActionTests.cs               ← M2 Sub-PR D
+RelicHookDispatcherTests.cs      ← M3 Sub-PR 3A (8 casos de plomería)
 ```
 
 ### ScriptableObjects (`Assets/ScriptableObjects/`)
@@ -237,7 +254,7 @@ aprobación explícita de Sebastián antes de proceder:
 
 | Archivo | LOC | Por qué está protegido |
 |---------|-----|------------------------|
-| `TurnManager.cs` | 735 | Flujo de turnos, efectividad, energía, momentum, IA enemiga, world switch |
+| `TurnManager.cs` | ~960 | Flujo de turnos, efectividad, energía, Contador de Estilo, IA enemiga, world switch, hooks de Retazos (3A) + API delegada |
 | `ActionQueue.cs` | 85 | Orden determinista de ejecución (FIFO) |
 | `PlayerCombatActor.cs` | 236 | Mecánicas del jugador en combate |
 

--- a/Docs/dev/specs/m3_hooks_spec.md
+++ b/Docs/dev/specs/m3_hooks_spec.md
@@ -1,0 +1,699 @@
+# Spec — Sistema de hooks + dispatcher de Retazos (M3 Sub-PR 3A)
+
+> **Status:** cerrado en diseño (2026-05-07), refinado tras 3 rondas de revisión
+> técnica. Ronda 1 cerró 8 hallazgos de feedback (1 crítico, 4 mayores, 3 menores)
+> incluyendo semántica de `EnqueueExtraDamage`, lifecycle de `Counters`, guards
+> en `Grant*`, herencia de payloads, lógica completa de `GrantStyleCharge`, fix
+> de inserción de `OnCombatStart` post-`ClearBlock` y rename
+> `RelicEffectHook` → `RelicHook`. Ronda 2 cerró 3 inconsistencias residuales
+> (cleanup de `#if UNITY_EDITOR` en validación manual, encoding fix en tabla
+> de inserción, instanciación explícita del dispatcher en `RunSession.Awake`).
+> Ronda 3 (durante implementación, 2026-05-08) cerró 4 inconsistencias detectadas
+> al codear: payloads de nodos diferidos a 3C/3D, y campos `TurnNumber`/
+> `TurnsTaken`/`WasFreeSwitch` removidos por requerir cambios fuera de los 7
+> puntos aprobados de `TurnManager`. Listo para `modo:implementacion` con
+> aprobación explícita ya dada por Sebastián a los 7 puntos de inserción en
+> `TurnManager`.
+> **Fecha:** 2026-05-08
+> **Modo:** `modo:diseno`
+
+---
+
+## Origen
+
+- **Roadmap:** M3 Sub-PR 3A (`Docs/dev/_roadmap.md`).
+- **Insight base:** Insight 3 — diseñar Retazos por categoría de hook (`Docs/dev/_insights.md`).
+- **Decisiones cerradas hoy (2026-05-07):**
+  - DD-017 — opción C (2-3 Retazos de cambio en contenido base).
+  - Hoguera y Tienda extensibles vía hooks (`OnCampfireOptionsBuilt`, `OnShopStockBuilt`).
+  - Inventario de Retazos = fila de iconos en HUD (estilo StS).
+- **GOLDEN_RULES §10:** Retazos como pasivos persistentes, sin límite, 3 categorías
+  (neutros, de cambio, de mundo).
+
+---
+
+## Objetivo
+
+Instalar la infraestructura mínima para que **Retazos** (pasivos persistentes
+del run) puedan reaccionar a eventos del combate, del mapa y de los nodos
+(Hoguera, Tienda) **sin acoplarse al sistema que los dispara**. El `TurnManager`,
+`RunFlowController`, `CampfireNodeController` y `ShopNodeController` solo emiten
+eventos a un dispatcher; los Retazos individuales se cuelgan ahí.
+
+Esta sub-PR **NO incluye contenido de Retazos** (eso es Sub-PR 3B). Solo el
+contrato + la plomería + tests de plomería.
+
+---
+
+## Comportamiento esperado
+
+Desde la perspectiva del jugador no hay nada visible en Sub-PR 3A: es
+infraestructura. La validación es que sin Retazos en `RunState.Relics` el combate
+y los nodos se comporten **exactamente igual que antes** (los hooks se invocan,
+nadie escucha, nada cambia).
+
+Desde la perspectiva del developer:
+
+1. Crear un `RelicDefinition` SO declarando 1+ hooks que escucha.
+2. Implementar el efecto en una clase `IRelicEffect` (uno por Retazo).
+3. Al ganar un Retazo, se agrega un `RelicInstance` a `RunState.Relics`.
+4. `RelicHookDispatcher` (singleton del run) suscribe automáticamente los
+   efectos según los hooks declarados.
+5. Cuando `TurnManager` dispara `OnPlayerTurnStart`, el dispatcher recorre los
+   suscriptores en orden de adquisición y ejecuta cada efecto pasándole un
+   payload tipado.
+
+---
+
+## Sistemas afectados
+
+- **Combate:** `TurnManager` debe emitir 7 hooks de combate en puntos
+  específicos del flujo. **REQUIERE APROBACIÓN** (archivo protegido).
+- **Run:** `RunState` agrega `List<RelicInstance> Relics`.
+- **RunSession:** instancia el `RelicHookDispatcher` en `Awake` con referencia
+  al `RunState` actual. El dispatcher persiste con `RunSession` (cruza escenas).
+  Al resetear el run via `RunState.Reset(map)`, el dispatcher persiste pero
+  `Relics` queda vacío y `GetSubscribers` devuelve 0 hasta que se gane uno.
+- **RunFlow:** `RunFlowController` no se toca en 3A (los hooks de Tienda/Hoguera
+  los invocan los controllers de esos nodos en sub-PRs 3C/3D).
+- **UI:** ningún cambio en 3A. El inventario visual es 3B.
+- **ScriptableObjects:** nuevo tipo `RelicDefinition`.
+- **Tests:** nuevo archivo `RelicHookDispatcherTests.cs`.
+
+---
+
+## Archivos a crear
+
+```
+Assets/Scripts/Gameplay/Relics/
+  RelicDefinition.cs            ← SO base de un Retazo (datos + referencia al efecto)
+  RelicCategory.cs              ← enum: Neutral, Switch, World (alineado con GOLDEN_RULES §10)
+  RelicHook.cs            ← enum con los 9 hooks expuestos
+  IRelicEffect.cs               ← interface ejecutable: void OnHook(RelicHookContext ctx)
+  RelicInstance.cs              ← runtime wrapper: RelicDefinition + estado mutable (counters por turno, etc.)
+  RelicHookDispatcher.cs        ← bus que TurnManager/Nodes invocan
+  Hooks/
+    RelicHookContext.cs         ← payload base (RunState, dispatcher, hook ejecutándose)
+    CombatStartHookData.cs      ← payload de OnCombatStart
+    PlayerTurnStartHookData.cs
+    DamageDealtHookData.cs      ← payload mutable (ver §Contratos)
+    DamageTakenHookData.cs      ← payload mutable
+    WorldSwitchHookData.cs
+    CombatEndHookData.cs
+    CardPlayedHookData.cs
+
+Assets/Tests/EditMode/
+  RelicHookDispatcherTests.cs
+```
+
+**Payloads diferidos a sub-PRs futuras:**
+`CampfireOptionsHookData.cs` y `ShopStockHookData.cs` **NO se crean en 3A**.
+Se crean junto con el call site correspondiente (3C crea `CampfireOptionsHookData`
+acompañando a `CampfireOption`; 3D crea `ShopStockHookData` acompañando a
+`ShopItem`). Razón: los tipos `CampfireOption` y `ShopItem` son responsabilidad
+de 3C/3D y crear sus payloads ahora forzaría decidir su shape antes de tiempo.
+El enum `RelicHook` mantiene `OnCampfireOptionsBuilt` y `OnShopStockBuilt`
+declarados en 3A; el dispatcher es genérico
+(`Dispatch<TData> where TData : RelicHookContext`) y acepta cualquier payload
+que herede de `RelicHookContext`, así que no necesita conocer los tipos
+concretos hasta que 3C/3D los introduzcan junto con sus call sites.
+
+## Archivos a modificar
+
+- `Assets/Scripts/Run/RunState.cs` — agregar `List<RelicInstance> Relics` +
+  reset en `Reset(map)`.
+- `Assets/Scripts/Run/RunSession.cs` — exponer/owner del `RelicHookDispatcher`
+  (vive en `RunSession` para que cruce escenas con la run).
+- `Assets/Scripts/Gameplay/Combat/TurnManager.cs` — **PROTEGIDO** — invocar
+  hooks en 7 puntos del flujo. Detalle en §Contratos.
+
+## Archivos protegidos involucrados
+
+- [x] `TurnManager.cs` — necesita: 7 invocaciones a `RelicHookDispatcher` en
+      puntos exactos. **REQUIERE APROBACIÓN ANTES DE IMPLEMENTAR.**
+- [ ] `ActionQueue.cs` — no se toca. Los hooks viven **fuera** de `ProcessAll()`
+      (ver §Interacción con ActionQueue).
+- [ ] `PlayerCombatActor.cs` — no se toca.
+
+---
+
+## Contratos
+
+### Datos
+
+#### `RelicCategory` (enum)
+
+```csharp
+public enum RelicCategory
+{
+    Neutral,   // efectos genéricos no atados al cambio de mundo
+    Switch,    // se activan en/modifican cambios de mundo (DD-017)
+    World      // ligados a un mundo específico (A o B)
+}
+```
+
+#### `RelicHook` (enum)
+
+Lista cerrada para Sub-PR 3A. Ampliar requiere nueva sub-PR + tests + actualización
+de este spec.
+
+```csharp
+public enum RelicHook
+{
+    OnCombatStart,           // dentro de InitializeCombat, DESPUÉS del primer BeginPlayerTurn (para no ser borrado por ClearBlock)
+    OnPlayerTurnStart,       // dentro de BeginPlayerTurn, después de ResetEnergy + ClearBlock, antes de DrawCards
+    OnDamageDealt,           // jugador → enemigo, después de calcular efectividad, antes de encolar DamageAction (mutable)
+    OnDamageTaken,           // enemigo → jugador, después de calcular efectividad, antes de encolar DamageAction (mutable)
+    OnWorldSwitch,           // dentro de TryChangeWorld, después de mutar currentWorld, antes de incrementar _worldSwitchesUsed
+    OnCombatEnd,             // dentro de CheckCombatEndConditions, una vez detectada Victory/Defeat
+    OnCardPlayed,            // dentro de ResolvePreparedCardPlay, después de ProcessAll y DiscardCard, antes de CheckCombatEndConditions
+    OnCampfireOptionsBuilt,  // antes de mostrar UI de Hoguera (Sub-PR 3C la invoca)
+    OnShopStockBuilt         // antes de mostrar UI de Tienda (Sub-PR 3D la invoca)
+}
+```
+
+Mapeo Insight 3 ↔ hooks:
+
+| Categoría Insight 3 | Hook(s) |
+|---------------------|---------|
+| Apertura de combate | `OnCombatStart` |
+| Inicio de turno | `OnPlayerTurnStart` |
+| Modificador de daño | `OnDamageDealt`, `OnDamageTaken` |
+| Acumulador / trigger | `OnCardPlayed` (counter en `RelicInstance`) + `OnPlayerTurnStart` (reset/check) |
+| Economía / fin de combate | `OnCombatEnd` |
+| Cambio de mundo | `OnWorldSwitch` |
+
+#### `RelicDefinition` (SO)
+
+```csharp
+[CreateAssetMenu(menuName = "Roguelike/Relic")]
+public class RelicDefinition : ScriptableObject
+{
+    public string DisplayName;
+    [TextArea] public string Description;
+    [TextArea] public string FlavorText;     // texto narrativo
+    public Sprite Icon;
+    public RelicCategory Category;
+    public RelicHook[] Hooks;          // hooks que escucha (subset del enum)
+    [SerializeReference] public IRelicEffect Effect;  // ver [CERRADO 1] abajo
+}
+```
+
+**[CERRADO 1] Opción C — `[SerializeReference]` sobre `IRelicEffect`** dentro del SO.
+Cada Retazo declara su efecto inline en el asset. Type-safe, sin reflexión, y
+Unity 6.2 lo soporta de forma nativa. Cada implementación de `IRelicEffect`
+debe llevar `[Serializable]`. Cuando un efecto necesite parámetros (ej:
+"+N daño al primer ataque"), se serializan como campos de la clase del efecto.
+
+```csharp
+[CreateAssetMenu(menuName = "Roguelike/Relic")]
+public class RelicDefinition : ScriptableObject
+{
+    public string DisplayName;
+    [TextArea] public string Description;
+    [TextArea] public string FlavorText;
+    public Sprite Icon;
+    public RelicCategory Category;
+    public RelicHook[] Hooks;
+    [SerializeReference] public IRelicEffect Effect;
+}
+```
+
+#### `RelicInstance` (runtime, no SO)
+
+```csharp
+public class RelicInstance
+{
+    public RelicDefinition Definition { get; }
+    public IRelicEffect Effect => Definition.Effect;  // viene del SO via [SerializeReference]
+    public int AcquisitionOrder { get; }              // determina orden de ejecución
+    public Dictionary<string, int> Counters { get; }  // estado mutable per-instance
+                                                       // ej: "cardsPlayedThisTurn"
+}
+```
+
+**Lifecycle de `Counters`:** son responsabilidad del propio Retazo. Cada
+`IRelicEffect` decide cuándo resetearlos suscribiéndose a los hooks
+correspondientes (ej: clear en `OnPlayerTurnStart` para counters por turno;
+en `OnCombatEnd` para counters por combate). El dispatcher **NO** toca
+counters — no resetea, no inicializa, no inspecciona. Esto evita que dos
+Retazos colisionen por usar el mismo nombre de counter con asunciones
+distintas: cada efecto es responsable del namespacing y del ciclo de vida de
+sus propias claves.
+
+Vive en `RunState.Relics`. No se serializa a disco en M3 (no hay save/load
+de runs en curso).
+
+#### `RunState.Relics`
+
+```csharp
+public List<RelicInstance> Relics { get; } = new List<RelicInstance>();
+```
+
+Reset incluido en `RunState.Reset(map)`.
+
+#### `IRelicEffect`
+
+```csharp
+public interface IRelicEffect
+{
+    void OnHook(RelicHook hook, RelicHookContext ctx);
+}
+```
+
+Cada Retazo recibe **el hook que se está disparando** (un mismo efecto puede
+escuchar varios hooks declarados en `Definition.Hooks`). El método se llama
+una sola vez por Retazo por evento.
+
+#### Payloads (`*HookData`)
+
+Distinguir **observables** vs **mutables**:
+
+| Hook | Payload | Mutable? | Campos clave |
+|------|---------|----------|--------------|
+| `OnCombatStart` | `CombatStartHookData` | No | `EnemyDefinition Enemy`, `bool IsBoss`, `bool IsElite` |
+| `OnPlayerTurnStart` | `PlayerTurnStartHookData` | No | `WorldSide CurrentWorld` |
+| `OnDamageDealt` | `DamageDealtHookData` | **Sí** | `int Amount` (mutable), `Effectiveness Eff`, `ElementType AttackerType`, `ICombatActor Target` |
+| `OnDamageTaken` | `DamageTakenHookData` | **Sí** | `int Amount` (mutable), `Effectiveness Eff`, `ElementType AttackerType`, `ICombatActor Source` |
+| `OnWorldSwitch` | `WorldSwitchHookData` | No | `WorldSide From`, `WorldSide To` |
+| `OnCombatEnd` | `CombatEndHookData` | No | `bool Victory`, `EnemyDefinition Enemy` |
+| `OnCardPlayed` | `CardPlayedHookData` | No | `CardDefinition Card`, `WorldSide PlayedInWorld`, `int EnergySpent` |
+| `OnCampfireOptionsBuilt` | (creado en 3C) | **Sí** | payload se crea junto con `CampfireOption` en Sub-PR 3C |
+| `OnShopStockBuilt` | (creado en 3D) | **Sí** | payload se crea junto con `ShopItem` en Sub-PR 3D |
+
+**Campos removidos en ronda 3 de revisión (2026-05-08):**
+- `int TurnNumber` (estaba en `PlayerTurnStartHookData`): TurnManager no tiene
+  contador de turno y agregarlo requiere cambios fuera de los 7 puntos
+  aprobados. Retazos que necesiten "primer turno" o "cada N turnos" usan
+  `RelicInstance.Counters` (incrementar en `OnPlayerTurnStart`, leer/resetear
+  según necesidad — el lifecycle de Counters ya documenta esto).
+- `int TurnsTaken` (estaba en `CombatEndHookData`): mismo argumento que
+  `TurnNumber`. Retazos que necesiten "ganaste en menos de N turnos" usan
+  Counters (incrementar en `OnPlayerTurnStart`, leer en `OnCombatEnd`).
+- `bool WasFreeSwitch` (estaba en `WorldSwitchHookData`): semánticamente
+  ambiguo dado que en M3 todos los switches son "gratis" (no cuestan recursos)
+  y el pool de switches base+bonus es fungible en `TryChangeWorld`. Retazos
+  como "primer cambio del combate" usan Counters. Si en sub-PRs futuras se
+  requiere diferenciar base vs bonus, se reabre con cambio dedicado a
+  `TryChangeWorld`.
+
+**Todos los payloads heredan de `RelicHookContext`.** Cada `*HookData` extiende
+`RelicHookContext` y agrega los campos específicos del evento. La signature de
+`Dispatch<TData>(...) where TData : RelicHookContext` lo hace explícito a nivel
+de tipos. No se usa composición (no hay `Ctx` adentro del payload).
+
+```csharp
+// Definición completa en [CERRADO 4] más abajo.
+public class RelicHookContext
+{
+    public RunState RunState { get; }
+    public TurnManager TurnManager { get; }
+    public RelicHookDispatcher Dispatcher { get; }
+    public RelicInstance CurrentRelic { get; }
+    // + API limitada de mutaciones — ver [CERRADO 4]
+}
+```
+
+Para `OnDamageDealt`/`OnDamageTaken`, los Retazos pueden mutar `Amount` antes
+de que se encole el `DamageAction`. La cadena de mutaciones es secuencial en
+orden de adquisición (`AcquisitionOrder` ascendente). El valor final es el que
+se pasa a `new DamageAction(...)`.
+
+### APIs públicas
+
+#### `RelicHookDispatcher`
+
+```csharp
+public class RelicHookDispatcher
+{
+    public RelicHookDispatcher(RunState runState);
+
+    // Llamado por TurnManager y por NodeControllers
+    public void Dispatch<TData>(RelicHook hook, TData data) where TData : RelicHookContext;
+
+    // Para tests / debug
+    public IReadOnlyList<RelicInstance> GetSubscribers(RelicHook hook);
+}
+```
+
+`Dispatch`:
+1. Filtra `_runState.Relics` donde `Definition.Hooks.Contains(hook)`.
+2. Ordena por `AcquisitionOrder` ascendente.
+3. Por cada `RelicInstance` ejecuta `instance.Effect.OnHook(hook, data)`.
+4. Si el payload es mutable, las mutaciones se acumulan entre Retazos.
+
+#### Cambios en `TurnManager.cs` (PROTEGIDO — REQUIERE APROBACIÓN)
+
+7 invocaciones, en este orden de aparición en el archivo:
+
+| Punto | Hook | Justificación |
+|-------|------|---------------|
+| `InitializeCombat()`, **después de** `BeginPlayerTurn(useStartingHand: true)` (último statement del método) | `OnCombatStart` | Crítico: se inserta DESPUÉS de `BeginPlayerTurn` para evitar que `ClearBlock(_player)` (línea 356 de `TurnManager`) borre el bloque que un Retazo "+4 bloque al iniciar combate" haya otorgado. En el primer turno `ClearBlock` es no-op (block = 0), así que invocar el hook después es semánticamente correcto: el combate ya está inicializado, el primer turno comenzó, y el GrantBlock del Retazo aplica sobre estado limpio. |
+| `BeginPlayerTurn()`, después de `ClearBlock(_player)` y **antes de** `_player.DrawCards(...)` | `OnPlayerTurnStart` | Permite Retazos que modifican draw size, energía extra, etc. |
+| `ApplyPlayerToEnemyEffectiveness()`, después de calcular `finalAmount` y **antes de** `PlayerHitEffectiveness?.Invoke(...)` | `OnDamageDealt` | El daño post-efectividad es el que el jugador "siente", y los Retazos deben poder mutarlo antes de la cola. |
+| `ApplyEnemyToPlayerEffectiveness()`, después de calcular `finalAmount` y antes de `EnemyHitEffectiveness?.Invoke(...)` | `OnDamageTaken` | Permite Retazos defensivos ("daño recibido -1"). |
+| `TryChangeWorld()`, después de mutar `currentWorld` y **antes de** `_worldSwitchesUsed++` | `OnWorldSwitch` | El payload conoce el mundo destino y si fue gratis. |
+| `ResolvePreparedCardPlay()`, después de `_actionQueue.ProcessAll()` y `_player.DiscardCard(...)`, antes de `CheckCombatEndConditions()` | `OnCardPlayed` | La carta ya se resolvió; el Retazo puede contar/encolar más acciones. |
+| `CheckCombatEndConditions()`, **inmediatamente después de** setear `_phase = Victory` o `_phase = Defeat` | `OnCombatEnd` | Permite drops, +oro, heal post-combate. |
+
+**[CERRADO 2] `OnCardPlayed` se dispara ANTES** de `CheckCombatEndConditions()`.
+Razón: un Retazo "+5 oro por carta jugada" debe contar la última carta del
+combate también. Si un Retazo encola daño extra que mata al enemigo, el
+`CheckCombatEndConditions` posterior detecta la victoria normalmente.
+
+**[CERRADO 3] `OnCombatEnd` muta `RunState` directamente.** Nada de encolar
+acciones post-combate. El efecto del Retazo escribe directo:
+`ctx.RunState.Gold += 5`, `ctx.RunState.PlayerCurrentHP = Mathf.Min(...)`. La
+`ActionQueue` ya no se procesa una vez detectado Victory/Defeat, por lo que
+encolar ahí sería frágil.
+
+### Eventos
+
+Sub-PR 3A no introduce nuevos `event Action<>` en `TurnManager`. El dispatcher
+es el único bus para Retazos. Los eventos existentes
+(`PlayerHitEffectiveness`, `EnemyTookDamage`, etc.) siguen sirviendo a la UI
+sin cambios.
+
+---
+
+## Interacción con ActionQueue
+
+**Regla:** los hooks **NO** se ejecutan dentro de `ActionQueue.ProcessAll()`.
+Se invocan en `TurnManager` antes de `Enqueue` (para hooks de daño) o entre
+`ProcessAll` y la siguiente fase (para `OnCardPlayed`, `OnCombatEnd`).
+
+Razones:
+1. `ActionQueue` es determinista FIFO y no debe tener side-effects de Retazos
+   que reentren a `Enqueue` desde adentro de un `Execute`.
+2. Mantiene `ActionQueue.cs` sin cambios (sigue protegido y simple).
+3. Si un Retazo necesita encolar una acción (ej: "al recibir daño, +1 bloque"),
+   lo hace mutando el `Amount` del payload o llamando un método de la API
+   limitada (`ctx.GrantBlock(...)`, `ctx.EnqueueExtraDamage(...)`). La
+   encolación entra en el siguiente `ProcessAll()` del flujo natural.
+
+**`EnqueueExtraDamage` no pasa por efectividad ni re-dispara hooks.** El daño
+encolado por este método es daño "raw": (a) no aplica multiplicador WEAK/RESIST,
+(b) no otorga ni resta cargas de Estilo, y (c) **no re-dispara `OnDamageDealt`**.
+Esto último es deliberado y previene loops infinitos cuando dos Retazos se
+modifican mutuamente. Para daño extra que SÍ se beneficie de la efectividad,
+mutar `data.Amount` en `OnDamageDealt` en vez de usar `EnqueueExtraDamage`.
+
+**[CERRADO 4] API limitada en `RelicHookContext`.** Los Retazos NO reciben el
+`TurnManager` entero. Reciben un contexto con métodos puntuales que internamente
+delegan a `TurnManager`. Lista cerrada para Sub-PR 3A — ampliar requiere nueva
+sub-PR + actualización de este spec.
+
+```csharp
+public class RelicHookContext
+{
+    public RunState RunState { get; }
+    public TurnManager TurnManager { get; }       // null fuera de combate
+    public RelicHookDispatcher Dispatcher { get; }
+    public RelicInstance CurrentRelic { get; }
+
+    // API limitada de mutaciones permitidas a Retazos:
+    public void GrantBlock(ICombatActor actor, int amount);
+    public void GrantHeal(ICombatActor actor, int amount);
+    public void GrantDrawCards(ICombatActor actor, int amount);
+    public void GrantEnergy(ICombatActor actor, int amount);
+    public void GrantStyleCharge(int amount);
+    public void GrantBonusWorldSwitch();
+    public void EnqueueExtraDamage(ICombatActor target, int amount, ElementType type);
+}
+```
+
+Cobertura por categoría del Insight 3:
+
+| Categoría / ejemplo | Mecanismo |
+|---|---|
+| "+4 bloque al empezar combate" | `GrantBlock(player, 4)` en `OnCombatStart` |
+| "Robás 1 carta extra" | `GrantDrawCards(player, 1)` en `OnPlayerTurnStart` |
+| "+1 energía al inicio del turno" | `GrantEnergy(player, 1)` en `OnPlayerTurnStart` |
+| "+5 al primer ataque del combate" | mutar `DamageDealtHookData.Amount` + counter |
+| "Cada 3 cartas Skill → +1 energía siguiente turno" | counter en `OnCardPlayed` + `GrantEnergy` en `OnPlayerTurnStart` siguiente |
+| "+5 oro al final de combate" | `ctx.RunState.Gold += 5` (mutación directa, [CERRADO 3]) |
+| "Al cambiar de mundo, +5 bloque" | `GrantBlock(player, 5)` en `OnWorldSwitch` |
+| "Heal 3 al matar enemigo" | `GrantHeal(player, 3)` en `OnCombatEnd` (Victory) |
+| "+1 carga de Estilo al cambiar de mundo" | `GrantStyleCharge(1)` en `OnWorldSwitch` |
+| "Tu primer cambio de mundo encola 5 daño extra" | `EnqueueExtraDamage(enemy, 5, type)` en `OnWorldSwitch` |
+
+Implementación en `TurnManager`: cada método del contexto delega a un método
+`internal` o `public` del `TurnManager` que muta el estado de forma controlada.
+
+**Semántica precisa de cada método:**
+
+- **`GrantStyleCharge(amount)`** aplica la **misma lógica** que
+  `ApplyPlayerToEnemyEffectiveness` (líneas 583-593 de `TurnManager`):
+  incrementa `_styleCharges`; si llega a 5 con `_bonusWorldSwitches == 0`,
+  otorga el bonus switch y resetea las cargas a 0. Esto preserva la golden
+  rule §4 (Contador de Estilo). NO basta con clampear a 5 — sin el reset +
+  bonus el jugador queda con cargas estancadas.
+- **`GrantBonusWorldSwitch()`** setea `_bonusWorldSwitches = 1` solo si está
+  en 0 (respeta el "no acumulable").
+- **`GrantBlock` / `GrantHeal` / `GrantDrawCards` / `GrantEnergy`** delegan
+  directo a `actor.GainBlock(n)` / `actor.Heal(n)` / `actor.DrawCards(n)` /
+  `_player.GainEnergy(n)` (este último puede requerir nuevo método en
+  `PlayerCombatActor` — confirmar en revisión de código; si ya existe,
+  reusar).
+- **`EnqueueExtraDamage(target, amount, type)`** encola un `DamageAction`
+  directo en `_actionQueue`. **Importante:** este `DamageAction` **NO** pasa
+  por `ApplyPlayerToEnemyEffectiveness` (es daño "raw"), por lo tanto:
+  - No aplica multiplicador de efectividad (WEAK/RESIST).
+  - No otorga ni resta cargas de Estilo.
+  - **No re-dispara `OnDamageDealt`** (esto es deliberado: previene loops
+    infinitos cuando dos Retazos se modifican mutuamente).
+  - Si un Retazo quiere daño extra que **sí** se beneficie de la efectividad,
+    debe mutar `data.Amount` en el hook `OnDamageDealt` en vez de usar
+    `EnqueueExtraDamage`.
+
+**Guards comunes (todos los métodos `Grant*` y `EnqueueExtraDamage`):**
+early return si `_phase == Victory || _phase == Defeat`. La API es defensiva:
+si un Retazo intenta otorgar algo después de que el combate terminó (caso
+borde de un hook que se dispara tarde), no rompe — simplemente no hace nada.
+`GrantHeal`/`GrantBlock`/etc también validan que `actor != null`.
+
+---
+
+## Orden de ejecución y casos borde
+
+1. **Múltiples Retazos en mismo hook:** ejecución secuencial por
+   `AcquisitionOrder` ascendente. El primer Retazo adquirido corre primero.
+2. **Mutación de daño con varios Retazos:** se encadena. Si Retazo A es
+   "+5 daño" y Retazo B es "x2 daño", el resultado depende del orden de
+   adquisición. Esto es **intencional** (el jugador construye su build) y debe
+   ser observable en tooltip ("este Retazo modifica el daño después de los
+   anteriores").
+3. **Sin Retazos:** `Dispatch` filtra y obtiene 0 suscriptores. Cero overhead
+   funcional. Comportamiento idéntico al pre-3A.
+4. **Reentrada:** un efecto que dispara otro hook (ej: `OnCardPlayed` que
+   provoca un `OnDamageDealt`). El dispatcher debe permitirlo (no lockear).
+   Opción más simple: no proteger contra reentrada — los hooks no son recursivos
+   de naturaleza (cada uno se invoca desde un punto único de TurnManager).
+5. **Retazo adquirido a mitad de combate (drop de Elite no aplica en M3
+   porque drops son post-combate, pero por tienda en M3 podrían):** se agrega
+   a `RunState.Relics` con el siguiente `AcquisitionOrder` libre. Se activa
+   inmediatamente para hooks futuros.
+
+---
+
+## Reuso
+
+- Patrón `IGameAction` + `ActionQueue` se mantiene inalterado. Los Retazos no
+  son acciones de combate, son "modificadores" que viven una capa arriba.
+- Patrón de eventos de `TurnManager` (eventos UI) se mantiene. El dispatcher
+  es paralelo a los eventos UI, no los reemplaza.
+- ScriptableObject pattern (igual que `CardDefinition`, `EnemyDefinition`).
+- `RunSession` como dueño del dispatcher (mismo patrón que el ownership de
+  `RunState`).
+
+---
+
+## Casos de prueba (EditMode)
+
+Archivo: `RelicHookDispatcherTests.cs`. Mínimo:
+
+1. **Sin Retazos, dispatch no rompe:** `Dispatch(OnPlayerTurnStart, data)` con
+   `RunState.Relics` vacío → no excepción, no efectos.
+2. **Suscripción única:** Retazo con hook `OnCombatStart` → al disparar, su
+   `OnHook` se invoca exactamente 1 vez con el hook correcto.
+3. **Múltiples Retazos en orden de adquisición:** 3 Retazos con `OnPlayerTurnStart`,
+   adquiridos en orden A → B → C. Al disparar, llamadas registradas en ese orden.
+4. **Hook no relevante no dispara:** Retazo con `OnDamageDealt` no se llama al
+   disparar `OnPlayerTurnStart`.
+5. **Mutación de payload encadenada:** 2 Retazos en `OnDamageDealt`, ambos
+   suman +1 al `Amount`. Damage base 10 — final 12.
+6. **Retazo con múltiples hooks declarados:** un Retazo declara
+   `[OnCombatStart, OnCombatEnd]` y se llama en ambos eventos.
+7. **Counter persistente entre invocaciones:** una instance de `RelicInstance`
+   incrementa un counter (ej: `Counters["x"]++`) en una llamada a `OnHook`,
+   y en una segunda llamada al mismo instance el valor sigue siendo el
+   incrementado. Verifica que el dispatcher NO toca/resetea counters entre
+   invocaciones — el ciclo de vida queda en manos del Retazo.
+8. **`GetSubscribers` filtra correctamente:** con 5 Retazos mixtos, devuelve
+   solo los que escuchan el hook pedido.
+
+Tests de integración con `TurnManager` se cubren en Sub-PR 3B (donde hay Retazos
+reales).
+
+---
+
+## Validación manual (BattleScene)
+
+1. Abrir `BattleScene` con `RunState.Relics` vacío (default).
+2. Jugar un combate completo (atacar, recibir daño, cambiar mundo, ganar).
+3. **Resultado esperado:** combate idéntico a pre-3A. Zero console errors.
+   Logs de dispatch silenciosos por default (`LogDispatches = false`, ver
+   [CERRADO 5]).
+
+**[CERRADO 5] Logging implementado, default OFF.** El `RelicHookDispatcher`
+incluye un `bool LogDispatches = false` configurable. Cuando se prende, cada
+dispatch loggea:
+```
+[Relics] OnPlayerTurnStart → 2 subscribers (StrikeBoost, DrawExtra)
+[Relics] OnDamageDealt — Amount mutado 10 → 12 por StrikeBoost
+[Relics] GrantBlock(player, 4) por OpeningRelic
+```
+Cuando está apagado el dispatcher no llama a `Debug.Log` en absoluto (zero
+overhead, zero ruido). Los logs son parte de la implementación de 3A — no
+detrás de `#if UNITY_EDITOR` — para que también funcionen en builds de
+desarrollo si Sebastián quiere debuggear más tarde.
+
+---
+
+## Decisiones cerradas
+
+**Bases (cerradas al iniciar diseño):**
+
+- 9 hooks definidos en `RelicHook` enum (lista cerrada para 3A).
+- Dispatcher vive en `RunSession` (cruza escenas con la run).
+- Hooks se invocan **fuera** de `ActionQueue.ProcessAll`.
+- Orden de ejecución = `AcquisitionOrder` ascendente.
+- Sin Retazos = cero cambio de comportamiento.
+- Sin contenido de Retazos en 3A (eso es 3B).
+- `RelicCategory` enum alineado con GOLDEN_RULES §10 (Neutral, Switch, World).
+- `OnCampfireOptionsBuilt` y `OnShopStockBuilt` son hooks fuera de combate, los
+  invocan los controllers de nodos en sub-PRs 3C/3D (en 3A solo se declara la
+  signature, no el call site).
+
+**Cerradas en sesión de diseño (2026-05-07):**
+
+- **[CERRADO 1]** `[SerializeReference]` sobre `IRelicEffect` directo en el SO
+  (Opción C). Type-safe, sin reflexión.
+- **[CERRADO 2]** `OnCardPlayed` se dispara **antes** de `CheckCombatEndConditions()`.
+- **[CERRADO 3]** `OnCombatEnd` muta `RunState` directamente (no encola
+  acciones).
+- **[CERRADO 4]** API limitada en `RelicHookContext` con 7 métodos:
+  `GrantBlock`, `GrantHeal`, `GrantDrawCards`, `GrantEnergy`, `GrantStyleCharge`,
+  `GrantBonusWorldSwitch`, `EnqueueExtraDamage`. Lista cerrada para 3A;
+  ampliarla requiere nueva sub-PR.
+- **[CERRADO 5]** Logging implementado en el dispatcher con flag
+  `LogDispatches` (default `false`). Logs son parte de la implementación, no
+  detrás de `#if UNITY_EDITOR`.
+
+## Decisiones abiertas
+
+Ninguna. Spec listo para `modo:implementacion` tras aprobación explícita de
+Sebastián a los 7 puntos de inserción en `TurnManager.cs` (ver §Cambios en
+`TurnManager.cs`).
+
+---
+
+## Decisiones tomadas durante implementación (2026-05-08)
+
+Durante la implementación de Sub-PR 3A, el agente tomó 5 decisiones que no
+estaban explícitas en el spec original. Quedan registradas acá para
+trazabilidad y porque varias tienen impacto en sub-PRs futuras.
+
+**[IMPL 1] `OnDamageDealt` se dispara solo en el path tipado, no en el path
+de cartas neutras (`ElementType.None`).** En `ApplyPlayerToEnemyEffectiveness`
+(líneas 588-630), el branch de cartas None retorna temprano sin pasar por el
+hook. Razón: agregar el dispatch ahí hubiera sido un 8º punto en TurnManager
+fuera de los 7 aprobados. Consecuencia: Retazos de modificador de daño NO
+afectan cartas neutras hoy. **Reabrir en Sub-PR 3B** cuando se diseñen
+Retazos de esa categoría — ver Insight 5 para las dos opciones (extender el
+hook al path None con aprobación, o restringir Retazos a cartas tipadas).
+
+**[IMPL 2] Try/catch alrededor de `effect.OnHook(hook, data)` en el
+dispatcher.** No estaba en el spec; el agente lo agregó como defensa: un
+Retazo defectuoso (asset SO mal serializado, NullRef en su efecto, etc.) no
+debe abortar la cadena de Retazos restantes ni el flujo de combate. Excepción
+queda como `Debug.LogError`. **Trade-off:** enmascara errores — si un Retazo
+deja de funcionar, solo se entera por consola. Cubrir con un test "un Retazo
+que tira excepción no rompe a los demás" en 3B.
+
+**[IMPL 3] El parámetro `type` en `EnqueueExtraDamage(target, amount, type)`
+no se usa en el cálculo de 3A.** Se acepta y se ignora. Razón: aplicarlo
+implicaría duplicar la efectividad orgánica (el daño raw quedaría con
+multiplicador, lo cual contradice [CERRADO 3] de la doc de
+`EnqueueExtraDamage`). El parámetro se conserva en la signature como metadata
+para futuros usos (animaciones diferenciadas por tipo en UI de 3B, posibles
+Retazos en M5/M6 que sí lo lean). Comentario explícito en
+[TurnManager.cs:1018-1041](Assets/Scripts/Gameplay/Combat/TurnManager.cs#L1018).
+
+**[IMPL 4] `RelicGrantEnergy` es no-op silencioso para non-player actors.**
+Razón: la energía es concepto del jugador (`PlayerCombatActor.GainEnergy`);
+`ICombatActor` no expone `GainEnergy` y el enemigo no tiene pool de energía.
+Si un Retazo intenta `GrantEnergy(enemy, 1)`, el método valida y retorna sin
+loggear. Documentado en
+[TurnManager.cs:992-1000](Assets/Scripts/Gameplay/Combat/TurnManager.cs#L992).
+
+**[IMPL 5] Logger del dispatcher no spammea cuando hay 0 subscribers.**
+Aún con `LogDispatches = true`, si el filtrado del hook devuelve 0
+subscribers, el dispatcher hace early-return sin loggear nada. Razón:
+evitar inundar consola en combates sin Retazos (el caso default en M3 hasta
+que 3B aterrice contenido). Si en debug querés ver "el dispatch se invocó
+aunque no hubo subscribers", sumar un flag `LogEmptyDispatches` aparte —
+no es prioridad ahora.
+
+Ninguna de estas decisiones rompe el spec ni reabre las 5 [CERRADO]s. Todas
+son refinamientos de implementación dentro del alcance acordado.
+
+## Alternativas consideradas
+
+- **[ALTERNATIVA] Eventos `Action<>` en TurnManager por cada hook (como
+  `PlayerHitEffectiveness`):** descartada porque obligaría a cada Retazo a
+  suscribirse/desuscribirse manualmente y la lógica de filtrado por hook
+  declarado en SO se duplicaría. El dispatcher centraliza esto.
+
+- **[ALTERNATIVA] Sistema de aspectos / componentes ECS:** descartada por
+  overkill. El proyecto no usa ECS y meterlo solo para Retazos no se justifica.
+
+- **[ALTERNATIVA] Hooks como métodos virtuales en `RelicDefinition` (sin enum,
+  sin dispatcher):** descartada porque cada Retazo tendría que filtrar "soy
+  para este evento o no" en runtime y el dispatcher no podría optimizar el
+  filtrado.
+
+- **[ALTERNATIVA] Invocar hooks desde dentro de `ActionQueue.ProcessAll`:**
+  descartada — riesgo de reentrada y rompe la garantía de "FIFO determinista
+  sin side effects externos" de `ActionQueue`.
+
+---
+
+## Estimación
+
+- **Complejidad:** alta (toca archivo protegido, infraestructura nueva, payloads
+  mutables, decide la forma del API que las sub-PRs 3B/3C/3D consumen).
+- **Riesgo:** alto si las decisiones abiertas no se cierran antes de codear —
+  rehacer el contrato después de 3B implica refactor de cada Retazo.
+- **Sub-tareas (post-cierre de abiertos):**
+  1. Crear estructura de archivos (`Relics/` + `Hooks/`).
+  2. Definir enums y SO.
+  3. Implementar `RelicHookDispatcher` + `RelicHookContext`.
+  4. Modificar `RunState` + `RunSession`.
+  5. **[REQUIERE APROBACIÓN]** Modificar `TurnManager` con 7 invocaciones.
+  6. Tests EditMode (8 casos arriba).
+  7. Validación manual sin Retazos (zero diff de comportamiento).
+  8. Actualizar `_tech_snapshot.md` (nuevo subsistema `Gameplay/Relics/`).
+  9. Marcar checkbox de Sub-PR 3A en `_roadmap.md`.
+
+- **Bloqueo principal:** aprobación de Sebastián para modificar `TurnManager.cs`
+  (los 7 puntos descritos en §Cambios en TurnManager).
+
+---
+
+## Próximo paso
+
+Aprobar los 7 puntos de inserción en `TurnManager.cs` (archivo protegido).
+Con eso, el spec pasa a `modo:implementacion` como input directo.
+
+


### PR DESCRIPTION
## Resumen

Primera sub-PR de M3. Instala el subsistema completo de Retazos: enums,
interfaces, SO, dispatcher, contexto y payloads. **Sin contenido todavía** —
las sub-PRs 3B/3C/3D/3E/3F consumen esta infraestructura.

## Nuevo subsistema: `Assets/Scripts/Gameplay/Relics/`

- `RelicHook` enum con 9 hooks (7 de combate con payload, 2 de nodos solo declarados para 3C/3D)
- `RelicCategory`, `IRelicEffect`, `RelicDefinition` SO con `[SerializeReference]` sobre el efecto inline
- `RelicInstance` runtime wrapper con `AcquisitionOrder` + `Counters` (lifecycle del Retazo, dispatcher no toca)
- `RelicHookDispatcher` con filtrado por hook, orden por adquisición y flag `LogDispatches` default OFF
- 7 payloads heredando de `RelicHookContext`: `CombatStart`, `PlayerTurnStart`, `DamageDealt`, `DamageTaken`, `WorldSwitch`, `CombatEnd`, `CardPlayed`
- API limitada en `RelicHookContext`: 7 métodos `Grant*`/`EnqueueExtraDamage` con guards `Victory`/`Defeat`

## Cambios en archivos protegidos / existentes

- **`TurnManager`** (PROTEGIDO, aprobado explícitamente): 7 dispatches en los puntos exactos del spec; 7 métodos `internal Relic*`; helper `TryGetRelicContext`; extracción de `IncrementStyleCharges` (golden rule §4 con una sola fuente de verdad — refactor sin cambio de comportamiento).
- **`RunState`**: `List<RelicInstance> Relics` + `Relics.Clear()` en `Reset(map)`.
- **`RunSession`**: instancia `RelicDispatcher` en `Awake` post-`State.EnsureInitialized`.

## Tests

- 8 casos nuevos en `RelicHookDispatcherTests.cs` (los 8 del spec).
- **Total proyecto: 78 tests EditMode verdes** (70 previos + 8 nuevos).

## Documentación

- Spec final en [Docs/dev/specs/m3_hooks_spec.md](Docs/dev/specs/m3_hooks_spec.md) (3 rondas de revisión: 8 + 3 + 4 hallazgos cerrados).
- Sección [IMPL 1-5] al final del spec con 5 decisiones tomadas durante implementación.
- **Insight 4**: 5 campos de payload diferidos por falta de cableado (`TurnNumber`, `TurnsTaken`, `WasFreeSwitch`, `IsBoss`, `IsElite`).
- **Insight 5**: scope estricto puede dejar comportamiento no obvio en paths secundarios. Decisión Opción A confirmada — extender hook a path None en 3B para que Retazos de daño afecten cartas neutras.
- Roadmap: Sub-PR 3A todos los checkboxes en `[x]`.
- DD-017 cerrada en `DESIGN_DECISIONS.md` (opción C, 2-3 Retazos de cambio).

## Aprobaciones explícitas registradas

- 7 puntos de inserción en TurnManager (archivo PROTEGIDO).
- API limitada de `RelicHookContext` con guards.
- Semántica de `EnqueueExtraDamage`: daño raw, no re-dispara, no aplica efectividad ni cargas.
- Extracción de `IncrementStyleCharges` (refactor interno DRY).

## Plomería

Se incluyen los `.meta` huérfanos de `HealAction.cs` y `HealActionTests.cs` (Sub-PR D) que quedaron sin trackear post-merge — necesarios para que los GUIDs de Unity queden consistentes entre máquinas.

## Test plan

- [x] Tests EditMode al 100% (78/78 verdes).
- [x] Compilación Unity sin errores ni warnings nuevos.
- [x] BattleScene: combate completo jugable, cargas de Estilo siguen funcionando (regresión de la extracción `IncrementStyleCharges`), cambio de mundo respeta cap dinámico.
- [x] Run completo hasta el Boss sin errores en consola.

## Pendiente para Sub-PR 3B

- Diseño formal de ~23 Retazos placeholder por las 6 categorías (Insight 3).
- 8º punto de dispatch en path `None` de `ApplyPlayerToEnemyEffectiveness` (Insight 5, opción A confirmada).
- UI de inventario estilo StS (fila de iconos en HUD de combate y mapa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)