### PR TITLE
feat(map): Mapa horizontal M3 Sub-PR 3F — scroll lateral + Retazos en HUD (cierra M3)

### DIFF
--- a/Assets/Scripts/Run/Map/UI/RunMapEdgeView.cs
+++ b/Assets/Scripts/Run/Map/UI/RunMapEdgeView.cs
@@ -36,8 +36,11 @@ namespace RoguelikeCardBattler.Run
             go.transform.SetParent(parent, false);
 
             Rect = go.GetComponent<RectTransform>();
-            Rect.anchorMin = new Vector2(0.5f, 1f);
-            Rect.anchorMax = new Vector2(0.5f, 1f);
+            // Anchor centro-izquierda: alinea con el pivot (0, 0.5) del content
+            // horizontal (Sub-PR 3F). La matemática de la arista (atan2/magnitud) es
+            // agnóstica al eje y no cambia.
+            Rect.anchorMin = new Vector2(0f, 0.5f);
+            Rect.anchorMax = new Vector2(0f, 0.5f);
             Rect.pivot = new Vector2(0.5f, 0.5f);
             Rect.anchoredPosition = (from + to) / 2f;
             Rect.sizeDelta = new Vector2(distance, thickness);

--- a/Assets/Scripts/Run/Map/UI/RunMapNodeView.cs
+++ b/Assets/Scripts/Run/Map/UI/RunMapNodeView.cs
@@ -43,8 +43,10 @@ namespace RoguelikeCardBattler.Run
             go.transform.SetParent(parent, false);
 
             Rect = go.GetComponent<RectTransform>();
-            Rect.anchorMin = new Vector2(0.5f, 1f);
-            Rect.anchorMax = new Vector2(0.5f, 1f);
+            // Anchor centro-izquierda: alinea con el pivot (0, 0.5) del content
+            // horizontal (Sub-PR 3F). El pivot del nodo se mantiene centrado.
+            Rect.anchorMin = new Vector2(0f, 0.5f);
+            Rect.anchorMax = new Vector2(0f, 0.5f);
             Rect.pivot = new Vector2(0.5f, 0.5f);
             Rect.anchoredPosition = position;
             Rect.sizeDelta = size;

--- a/Assets/Scripts/Run/Map/UI/RunMapView.cs
+++ b/Assets/Scripts/Run/Map/UI/RunMapView.cs
@@ -15,10 +15,14 @@ namespace RoguelikeCardBattler.Run
     /// </summary>
     public class RunMapView
     {
-        private const float RowSpacing = 130f;
-        private const float HorizontalSpacing = 200f;
-        private const float TopPadding = 50f;
-        private const float BottomPadding = 50f;
+        // Eje horizontal (DD-005): depth avanza en X hacia la derecha, los nodos del
+        // mismo depth se apilan en Y. ColumnSpacing gobierna el avance (antes
+        // HorizontalSpacing); NodeRowSpacing el apilado (antes RowSpacing=130, se baja
+        // a 120 porque ahora compite con el alto de pantalla, no con scroll infinito).
+        private const float ColumnSpacing = 200f;
+        private const float NodeRowSpacing = 120f;
+        private const float LeftPadding = 80f;
+        private const float RightPadding = 80f;
         private const float NodeWidth = 130f;
         private const float NodeHeight = 50f;
         private const float EdgeThickness = 3f;
@@ -62,8 +66,8 @@ namespace RoguelikeCardBattler.Run
                 depthBuckets[kvp.Value].Add(kvp.Key);
             }
 
-            float contentHeight = TopPadding + (maxDepth + 1) * RowSpacing + BottomPadding;
-            content.sizeDelta = new Vector2(0f, contentHeight);
+            float contentWidth = LeftPadding + maxDepth * ColumnSpacing + RightPadding;
+            content.sizeDelta = new Vector2(contentWidth, 0f);
 
             foreach (MapNode node in map.Nodes)
             {
@@ -196,7 +200,7 @@ namespace RoguelikeCardBattler.Run
 
         /// <summary>
         /// BFS desde startNode para calcular la profundidad de cada nodo.
-        /// Se usa para posicionar nodos en filas (Y) por profundidad.
+        /// Se usa para posicionar nodos en columnas (X) por profundidad.
         /// </summary>
         private static Dictionary<int, int> ComputeDepths(ActMap map)
         {
@@ -230,9 +234,10 @@ namespace RoguelikeCardBattler.Run
         }
 
         /// <summary>
-        /// Calcula la posición de un nodo en coordenadas del content (anchor 0.5, 1).
-        /// X=0 es el centro horizontal; Y negativo va hacia abajo.
-        /// Nodos del mismo depth se distribuyen simétricamente alrededor del centro.
+        /// Calcula la posición de un nodo en coordenadas del content (pivot 0, 0.5).
+        /// X avanza hacia la derecha por profundidad (start a la izquierda, boss a la
+        /// derecha); Y=0 es el centro vertical del content. Nodos del mismo depth se
+        /// apilan simétricamente arriba/abajo del centro (una columna de 1 nodo → y=0).
         /// </summary>
         private static Vector2 GetNodePosition(int nodeId,
             Dictionary<int, int> depthMap, Dictionary<int, List<int>> depthBuckets)
@@ -242,8 +247,8 @@ namespace RoguelikeCardBattler.Run
             int index = bucket.IndexOf(nodeId);
             int count = bucket.Count;
 
-            float x = (index - (count - 1) / 2f) * HorizontalSpacing;
-            float y = -(TopPadding + depth * RowSpacing);
+            float x = LeftPadding + depth * ColumnSpacing;
+            float y = -(index - (count - 1) / 2f) * NodeRowSpacing;
 
             return new Vector2(x, y);
         }
@@ -257,7 +262,9 @@ namespace RoguelikeCardBattler.Run
 
             RectTransform scrollRect = scrollGO.GetComponent<RectTransform>();
             scrollRect.anchorMin = new Vector2(0.02f, 0.02f);
-            scrollRect.anchorMax = new Vector2(0.98f, 0.78f);
+            // Techo bajado a 0.72 (antes 0.78) para liberar la franja superior del
+            // mapa para el HUD de Retazos (RunFlowController lo monta en 0.72–0.79).
+            scrollRect.anchorMax = new Vector2(0.98f, 0.72f);
             scrollRect.offsetMin = Vector2.zero;
             scrollRect.offsetMax = Vector2.zero;
 
@@ -267,8 +274,8 @@ namespace RoguelikeCardBattler.Run
             bg.color = new Color(0.03f, 0.04f, 0.07f, 0.35f);
 
             ScrollRect scroll = scrollGO.GetComponent<ScrollRect>();
-            scroll.horizontal = false;
-            scroll.vertical = true;
+            scroll.horizontal = true;
+            scroll.vertical = false;
             scroll.movementType = ScrollRect.MovementType.Clamped;
 
             GameObject viewportGO = new GameObject("Viewport",
@@ -287,11 +294,14 @@ namespace RoguelikeCardBattler.Run
             GameObject contentGO = new GameObject("Content", typeof(RectTransform));
             contentGO.transform.SetParent(viewportGO.transform, false);
             RectTransform contentRect = contentGO.GetComponent<RectTransform>();
-            contentRect.anchorMin = new Vector2(0f, 1f);
-            contentRect.anchorMax = new Vector2(1f, 1f);
-            contentRect.pivot = new Vector2(0.5f, 1f);
+            // Stretch vertical anclado a la izquierda, pivot en centro-izquierda:
+            // el content crece hacia la derecha por ANCHO (lo pisa el dimensionado
+            // por contentWidth en el constructor); y=0 es el centro vertical.
+            contentRect.anchorMin = new Vector2(0f, 0f);
+            contentRect.anchorMax = new Vector2(0f, 1f);
+            contentRect.pivot = new Vector2(0f, 0.5f);
             contentRect.anchoredPosition = Vector2.zero;
-            contentRect.sizeDelta = new Vector2(0f, 800f);
+            contentRect.sizeDelta = new Vector2(800f, 0f);
 
             scroll.viewport = viewportRect;
             scroll.content = contentRect;

--- a/Assets/Scripts/Run/RunFlowController.cs
+++ b/Assets/Scripts/Run/RunFlowController.cs
@@ -7,6 +7,7 @@ using RoguelikeCardBattler.Core;
 using RoguelikeCardBattler.Gameplay.Cards;
 using RoguelikeCardBattler.Gameplay.Combat;
 using RoguelikeCardBattler.Gameplay.Relics;
+using RoguelikeCardBattler.Gameplay.Relics.UI;
 using RoguelikeCardBattler.Run.Campfire;
 using RoguelikeCardBattler.Run.Shop;
 
@@ -38,6 +39,7 @@ namespace RoguelikeCardBattler.Run
         private Text _statusText;
         private Text _titleText;
         private RunMapView _mapView;
+        private RelicInventoryView _relicView;
         private Text _resolveTitleText;
         private Text _resolveBodyText;
         private Button _resolveCompleteButton;
@@ -134,6 +136,17 @@ namespace RoguelikeCardBattler.Run
 
             _mapView = new RunMapView(_mapPanel, _map, _state, uiFont, GetWhiteSprite());
             _mapView.OnNodeClicked += EnterNode;
+
+            // Fila de Retazos en el HUD del mapa (espejo del HUD de combate, Sub-PR 3F):
+            // banda dedicada 0.72–0.79, arriba del scroll (techo 0.72) y bajo el status
+            // (0.80) → no colisiona con el área scrolleable ni con los raycasts de nodos.
+            RectTransform relicBar = CreatePanel("RelicBar", _mapPanel, new Color(0f, 0f, 0f, 0f), false);
+            relicBar.anchorMin = new Vector2(0.02f, 0.72f);
+            relicBar.anchorMax = new Vector2(0.98f, 0.79f);
+            relicBar.offsetMin = Vector2.zero;
+            relicBar.offsetMax = Vector2.zero;
+            _relicView = new RelicInventoryView(relicBar, uiFont);
+
             BuildResolvePanel();
             BuildDefeatPanel();
             BuildRewardPanel();
@@ -240,6 +253,9 @@ namespace RoguelikeCardBattler.Run
 
             _statusText.text = $"Gold: {_state.Gold} | Completados: {completed}/{_map.Nodes.Count}";
             _mapView?.Refresh(_state);
+            // Suficiente refrescar acá: los Retazos sólo cambian fuera del mapa
+            // (combate/elite/boss/tienda) y todo retorno al mapa pasa por ShowMap.
+            _relicView?.Refresh(_state.Relics);
         }
 
         private void EnterNode(int index)
@@ -354,6 +370,7 @@ namespace RoguelikeCardBattler.Run
                 return;
             }
             _mapView?.Cleanup();
+            _relicView?.Cleanup();
             SceneTransitionManager.LoadScene(BattleSceneName);
         }
 
@@ -636,6 +653,7 @@ namespace RoguelikeCardBattler.Run
                 _state.PendingReturnFromBattle = false;
                 _state.LastNodeOutcome = RunState.NodeOutcome.None;
                 _mapView?.Cleanup();
+                _relicView?.Cleanup();
                 SceneTransitionManager.LoadScene("BattleScene");
             });
 

--- a/Assets/Tests/EditMode/RunMapGeneratorTests.cs
+++ b/Assets/Tests/EditMode/RunMapGeneratorTests.cs
@@ -1,0 +1,212 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using NUnit.Framework;
+using UnityEngine;
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Gameplay.Enemies;
+using RoguelikeCardBattler.Run;
+
+namespace RoguelikeCardBattler.Tests.EditMode
+{
+    /// <summary>
+    /// Tests EditMode de <see cref="RunMapGenerator"/> (Sub-PR 3F). El refactor del
+    /// mapa a scroll horizontal es puramente visual y vive entero en RunMapView; estos
+    /// tests blindan que la GENERACIÓN (lógica pura, agnóstica al eje) no cambió:
+    /// "misma seed = mismo mapa" + invariantes del DAG. Es la red de seguridad del
+    /// refactor (antes de 3F no había ningún test del sistema de mapa).
+    ///
+    /// Patrón: se construye un <see cref="Act1MapConfig"/> con defaults vía
+    /// <c>ScriptableObject.CreateInstance</c> (mismo patrón que <c>GenerateAct1</c>);
+    /// el <see cref="EnemyPoolConfig"/> se puebla por reflexión sobre sus campos
+    /// privados serializados (no expone setter de debug) para no salir del scope del
+    /// spec (sólo se crea este archivo de test).
+    /// </summary>
+    public class RunMapGeneratorTests
+    {
+        // ────────────────────────────────────────
+        // Helpers
+        // ────────────────────────────────────────
+
+        private static Act1MapConfig MakeConfig()
+        {
+            // Defaults: 8 nodos, start=Combat, end=Boss, pesos por tipo predefinidos.
+            return ScriptableObject.CreateInstance<Act1MapConfig>();
+        }
+
+        private static EnemyDefinition MakeEnemy(string id)
+        {
+            EnemyDefinition enemy = ScriptableObject.CreateInstance<EnemyDefinition>();
+            enemy.SetDebugData(
+                id, id, 30, 0, EnemyAIPattern.RandomWeighted,
+                new List<string>(), new List<EnemyMove>(), 1f, null, ElementType.None);
+            return enemy;
+        }
+
+        // EnemyPoolConfig no tiene SetDebugData; poblamos su campo privado por reflexión.
+        // Un único pool de rango amplio con varias entradas de peso distinto basta para
+        // que la asignación varíe entre nodos (y por ende sea un test de determinismo real).
+        private static EnemyPoolConfig MakePool(params EnemyDefinition[] enemies)
+        {
+            EnemyPoolConfig pool = ScriptableObject.CreateInstance<EnemyPoolConfig>();
+            DepthPool dp = new DepthPool { label = "all", minDepth = 0, maxDepth = 99 };
+            float w = 1f;
+            foreach (EnemyDefinition e in enemies)
+            {
+                dp.entries.Add(new EnemyWeightEntry { enemy = e, weight = w });
+                w += 1f;
+            }
+
+            FieldInfo field = typeof(EnemyPoolConfig).GetField(
+                "depthPools", BindingFlags.NonPublic | BindingFlags.Instance);
+            field.SetValue(pool, new List<DepthPool> { dp });
+            return pool;
+        }
+
+        // Firma estable de la topología + tipos de un mapa, para comparaciones profundas.
+        private static string Signature(ActMap map)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append("start=").Append(map.StartNodeId).Append(';');
+            foreach (MapNode node in map.Nodes)
+            {
+                sb.Append(node.Id).Append(':').Append(node.Type).Append("->[");
+                sb.Append(string.Join(",", node.Connections));
+                sb.Append("];");
+            }
+
+            return sb.ToString();
+        }
+
+        // ────────────────────────────────────────
+        // 1. Determinismo de topología — "misma seed = mismo mapa"
+        // ────────────────────────────────────────
+
+        [Test]
+        public void Generate_SameSeed_ProducesIdenticalMap()
+        {
+            Act1MapConfig config = MakeConfig();
+
+            ActMap a = RunMapGenerator.Generate(config, 12345);
+            ActMap b = RunMapGenerator.Generate(config, 12345);
+
+            Assert.AreEqual(a.StartNodeId, b.StartNodeId, "Mismo StartNodeId.");
+            Assert.AreEqual(a.Nodes.Count, b.Nodes.Count, "Misma cantidad de nodos.");
+
+            for (int i = 0; i < a.Nodes.Count; i++)
+            {
+                MapNode na = a.GetNode(i);
+                MapNode nb = b.GetNode(i);
+                Assert.IsNotNull(nb, $"El nodo {i} debe existir en ambos mapas.");
+                Assert.AreEqual(na.Type, nb.Type, $"Mismo Type en el nodo {i}.");
+                CollectionAssert.AreEqual(na.Connections, nb.Connections,
+                    $"Mismas Connections en el nodo {i}.");
+            }
+        }
+
+        // ────────────────────────────────────────
+        // 2. Determinismo de enemigos — "misma seed = mismos enemigos"
+        // ────────────────────────────────────────
+
+        [Test]
+        public void AssignEnemies_SameSeed_ProducesIdenticalAssignment()
+        {
+            Act1MapConfig config = MakeConfig();
+            EnemyPoolConfig pool = MakePool(MakeEnemy("e1"), MakeEnemy("e2"), MakeEnemy("e3"));
+
+            ActMap a = RunMapGenerator.Generate(config, 12345);
+            ActMap b = RunMapGenerator.Generate(config, 12345);
+
+            RunMapGenerator.AssignEnemies(a, pool, 12345);
+            RunMapGenerator.AssignEnemies(b, pool, 12345);
+
+            int checkedCombat = 0;
+            for (int i = 0; i < a.Nodes.Count; i++)
+            {
+                MapNode na = a.GetNode(i);
+                MapNode nb = b.GetNode(i);
+                if (na.Type != NodeType.Combat && na.Type != NodeType.Elite)
+                {
+                    continue;
+                }
+
+                Assert.AreSame(na.SpecificEnemy, nb.SpecificEnemy,
+                    $"Mismo enemigo asignado en el nodo {i} (misma seed).");
+                checkedCombat++;
+            }
+
+            Assert.Greater(checkedCombat, 0, "Debe haber al menos un nodo Combat/Elite para validar.");
+        }
+
+        // ────────────────────────────────────────
+        // 3. Seeds distintas pueden divergir
+        // ────────────────────────────────────────
+
+        [Test]
+        public void Generate_DifferentSeeds_ProduceDivergentMaps()
+        {
+            // Guard suave anti-fragilidad: en vez de comparar dos seeds puntuales
+            // (que por azar podrían coincidir), barremos un rango y exigimos que
+            // existan al menos 2 firmas distintas — confirma que la seed afecta el mapa.
+            Act1MapConfig config = MakeConfig();
+            HashSet<string> signatures = new HashSet<string>();
+            for (int seed = 1; seed <= 10; seed++)
+            {
+                signatures.Add(Signature(RunMapGenerator.Generate(config, seed)));
+            }
+
+            Assert.Greater(signatures.Count, 1,
+                "Seeds distintas deben poder producir mapas distintos (topología o tipos).");
+        }
+
+        // ────────────────────────────────────────
+        // 4. DAG válido invariante (independiente del eje)
+        // ────────────────────────────────────────
+
+        [Test]
+        public void Generate_ProducesValidDag()
+        {
+            Act1MapConfig config = MakeConfig();
+            ActMap map = RunMapGenerator.Generate(config, 777);
+            int total = map.Nodes.Count;
+
+            // Nodo 0 = start: no debe tener aristas entrantes.
+            foreach (MapNode node in map.Nodes)
+            {
+                CollectionAssert.DoesNotContain(node.Connections, 0,
+                    $"El nodo start (0) no puede tener entrantes (desde {node.Id}).");
+            }
+
+            // Nodo total-1 = end: no debe tener salientes.
+            MapNode end = map.GetNode(total - 1);
+            Assert.AreEqual(0, end.Connections.Count, "El nodo end no debe tener salientes.");
+
+            // Todas las conexiones dentro de rango [0, total).
+            foreach (MapNode node in map.Nodes)
+            {
+                foreach (int conn in node.Connections)
+                {
+                    Assert.GreaterOrEqual(conn, 0, $"connId fuera de rango en nodo {node.Id}.");
+                    Assert.Less(conn, total, $"connId fuera de rango en nodo {node.Id}.");
+                }
+            }
+        }
+
+        // ────────────────────────────────────────
+        // 5. Start/end forzados (pin defensivo, no se ve afectado por el refactor visual)
+        // ────────────────────────────────────────
+
+        [Test]
+        public void Generate_ForcesStartAndEndTypes()
+        {
+            Act1MapConfig config = MakeConfig();
+            ActMap map = RunMapGenerator.Generate(config, 999);
+            int total = map.Nodes.Count;
+
+            Assert.AreEqual(config.ForcedStartType, map.GetNode(0).Type,
+                "El nodo 0 debe tener el tipo forzado de inicio.");
+            Assert.AreEqual(config.ForcedEndType, map.GetNode(total - 1).Type,
+                "El último nodo debe tener el tipo forzado de fin (Boss).");
+        }
+    }
+}

--- a/Assets/Tests/EditMode/RunMapGeneratorTests.cs.meta
+++ b/Assets/Tests/EditMode/RunMapGeneratorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9a68c556fa6f4194e9e24c568cde2f23

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -7,10 +7,10 @@
 > En `modo:implementacion` se lee al inicio para saber qué milestone está activo
 > y qué sub-tareas quedan.
 >
-> **Fase actual:** M2 cerrado completo (motor v2 estable). Diseño de M3 cerrado.
-> **Milestone activo:** M3 — Personalización del run (Retazos, Tienda, Hoguera, NewRunScene, mapa horizontal)
-> **Próximo bloque:** M4 — Resto del Acto 1 (mejora cartas con UI, eventos, transdimensionales, ancla)
-> **Última actualización:** 2026-06-04 (Sub-PR 3E NewRunScene **implementado y validado en Unity**: EditMode 126/126, NewRunScene en Build Settings con NewRunController + NewRunConfig asignado, draft "Componer" funcionando con pool placeholder de 18 caras. Branch `feat/m3-sub-e-newrun`. Falta sólo 3F para cerrar M3.)
+> **Fase actual:** M3 cerrado completo (personalización del run + mapa horizontal). M4 activo.
+> **Milestone activo:** M4 — Resto del Acto 1 (mejora cartas con UI, eventos, transdimensionales, ancla)
+> **Próximo bloque:** M5 — Bosses con fases + Boss Acto 1 según GDD v2
+> **Última actualización:** 2026-06-05 (Sub-PR 3F mapa horizontal **implementado y validado en Unity**: refactor de RunMapView a scroll lateral izq→der, RelicInventoryView en HUD del mapa, `RunMapGeneratorTests` nuevo (5 casos). EditMode 131/131. Branch `feat/m3-sub-f-horizontal-map`. **M3 cerrado** → M4 activo. Siguiente paso del proyecto: plan de auditoría de arte.)
 
 ---
 
@@ -44,17 +44,102 @@
 
 ## Activo
 
+### M4 — Resto del Acto 1 según GDD v2
+
+**Estado:** milestone activo desde 2026-06-05 (al cerrar M3 con el mapa horizontal).
+
+**Objetivo:** cerrar el contenido del Acto 1: mejora de cartas, eventos básicos
+y multidimensionales, enemigos transdimensionales y enemigos ancla.
+
+**Sub-tareas (desagregar al activar):**
+- Mejora de cartas (DD-013): toggle `IsUpgraded` en `CardDeckEntry`, campos
+  upgraded en `CardDefinition`, mejora ambos lados de cartas duales, UI
+- Eventos (DD-005): `EventDefinition` SO, controller, choice UI, sistema de
+  decisiones, eventos multidimensionales (elegir mundo)
+- Quests con MCguffin (DD-021 se cierra aquí): tracking en RunState, marca de
+  nodo destino en mapa, eventos de aceptar/robar
+- Enemigos transdimensionales (DD-014): campo `TypeWorldB` en `EnemyDefinition`,
+  resolución de tipo activo según `RunState.CurrentWorld`
+- Enemigos ancla (DD-014): flag `IsAnchor` en `EnemyDefinition`, bypass del
+  cambio de mundo en lógica
+
+**Toca archivos protegidos:** sí (TurnManager para tipo activo de transdim y
+ancla).
+
+**Dependencias:** M3 cerrado ✅ 2026-06-05 (eventos pueden otorgar Retazos /
+mejoras y necesitan el sistema funcionando).
+
+**Complejidad:** alta. El sistema de eventos con quests es trabajo significativo.
+
+> **Nota de proceso:** antes de arrancar M4 está agendado el plan de auditoría
+> de arte (barrido de slots de arte → `Docs/design/ART_NEEDS.md` → estilo madre
+> → prompts para IA de placeholders). Ver memoria `project-art-audit-plan`.
+
+---
+
+## Pendientes
+
+### M5 — Bosses con fases + Boss Acto 1 según GDD v2
+
+**Objetivo:** rediseñar el Boss del Acto 1 (Costura Maldita / UNIT-RB7) según
+DD-004 con fases, debuffs únicos y mecánica "Desfase Dimensional". Establecer
+el patrón para futuros bosses.
+
+**Sub-tareas (desagregar al activar):**
+- Sistema de fases en bosses (Fase 2 obligatoria al 50% HP)
+- Mecánica "Desfase Dimensional": contador de cartas jugadas en turno, cambio
+  automático cada 3 cartas (2 en Fase 2)
+- Debuff Sangrado (DD-019, exclusivo del boss medieval): pérdida de HP al jugar
+  ataque
+- Debuff Virus (DD-019, exclusivo del boss cyberpunk): bloqueo al 80%
+  efectividad
+- 2 tipos por boss (1 SuperEficaz contra el jugador, 1 debilidad)
+- Retazo único de boss vinculado narrativamente
+
+**Toca archivos protegidos:** sí (TurnManager + ActionQueue para hook
+post-ProcessAll y mutación de mundo desde IA).
+
+**Dependencias:** M2 cerrado (cambio de mundo robusto), M4 cerrado (transdim/
+ancla establecen el patrón de tipos múltiples).
+
+**Complejidad:** alta.
+
+---
+
+### M6 — Acto 2, Acto 3, Meta-progresión
+
+**Objetivo:** llevar el juego a su shape final: 3 actos, dificultad escalada
+según DD-011, XP entre runs, desbloqueos según DD-016.
+
+**Probable subdivisión:**
+- M6a — Acto 2 (HP enemigo, 2 tipos simultáneos, fases simples por umbral,
+  primer transdimensional, elites con 2 mecánicas)
+- M6b — Acto 3 (multifase, ancla, bosses que bloquean/fuerzan cambio,
+  restricciones de cambio)
+- M6c — Meta-progresión (XP, persistencia, desbloqueos, viñetas narrativas
+  iniciales — DD-015 entra aquí si está listo)
+
+**Toca archivos protegidos:** parcial (Acto 3 con bosses que bloquean cambio
+toca TurnManager).
+
+**Dependencias:** M5 cerrado (Boss Acto 1 funcional como plantilla).
+
+**Complejidad:** muy alta.
+
+---
+
+## Completados
+
 ### M3 — Personalización del run
-
-**Objetivo:** entregar el ecosistema completo que convierte una secuencia de combates
-en un run con identidad: Retazos como sistema base de pasivos, Tienda y Hoguera
-funcionales como nodos del mapa, NewRunScene como flujo inicial (elección de tipos +
-draft de carta especial dual), y mapa con scroll horizontal según GDD.
-
-**Por qué bundle:** los 4 sistemas comparten una capa de infraestructura nueva
-(sistema de hooks/dispatcher de Retazos). Hacer cada sistema en milestones separados
-implicaría diseñar la infra varias veces o duplicar código. M3 instala la base + 4
-features que la usan + 1 refactor de UX (mapa horizontal).
+**Fecha cierre:** 2026-06-05 (mapa horizontal 3F como último sub-PR cierra el milestone)
+**Resumen:** ecosistema completo que convierte una secuencia de combates en un
+run con identidad. 6 sub-PRs mergeados: 3A foundations (hooks + dispatcher de
+Retazos, toca TurnManager con aprobación), 3B Retazos (23 SOs + UI inventario),
+3C Hoguera, 3D Tienda (PR #96), 3E NewRunScene (PR #97), 3F mapa horizontal
+(scroll lateral + RelicInventoryView en HUD del mapa + `RunMapGeneratorTests`).
+Run jugable de inicio a fin: NewRunScene → mapa horizontal → combates con Retazos
+visibles y activos → Tienda/Hoguera funcionales → Boss con drop de Retazo único.
+Detalle de sub-PRs abajo (histórico de implementación).
 
 **Decisiones cerradas durante diseño (2026-05-07):**
 - DD-017 → opción C: 2-3 Retazos de cambio en contenido base como demo de la categoría.
@@ -201,7 +286,7 @@ disparan", no de "qué efecto se nos ocurre".
       ShelfSprite/CounterSprite) importados como Sprite Single, asignados al
       `ShopConfig.asset` y encuadrados en 3 capas (pared full + estanterías arriba
       + mostrador abajo, preserveAspect). Probado en una run: panel se ve bien,
-      comprar/eliminar/Salir funcionan. Falta solo `modo:revision` + PR.
+      comprar/eliminar/Salir funcionan. PR #96 mergeado.
 
 #### Sub-PR 3E — NewRunScene
 - [x] Escena dedicada `Assets/Scenes/NewRunScene.unity` con `NewRunController.cs`
@@ -232,125 +317,42 @@ disparan", no de "qué efecto se nos ocurre".
       vía el menú (18 caras, [3,3,3,3,3,3] por tipo), `newRunConfig` asignado al
       `NewRunController` en NewRunScene (persistido), NewRunScene en Build Settings.
       E2E por código: tipos elegidos → mazo = starter+1 drafteada, filtro Tienda
-      respeta los tipos (Morado sí / Azul no)
+      respeta los tipos (Morado sí / Azul no). PR #97 mergeado (squash, 6d171a5).
 
 #### Sub-PR 3F — Mapa horizontal (refactor scroll)
-- [ ] Refactor `RunMapView` para scroll lateral (izquierda → derecha) por DD-005
-- [ ] Adaptar generación de `RunMapGenerator` a layout horizontal
-- [ ] Adaptar UI de nodos y aristas (`RunMapNodeView`, `RunMapEdgeView`) al
-      nuevo eje
-- [ ] `RelicInventoryView` integrado en HUD del mapa (consistencia con HUD de
-      combate)
-- [ ] Tests: misma seed = mismo mapa (no romper determinismo en el refactor)
+- [x] Refactor `RunMapView` para scroll lateral (izquierda → derecha) por DD-005
+      (depth→X / índice→Y, ScrollRect horizontal, content pivot (0,0.5) anclado
+      izquierda, dimensionado por ancho, techo del scroll a 0.72)
+- [x] `RunMapGenerator` **NO se tocó** (decisión cerrada #1 del spec: es agnóstico
+      al eje — sólo asigna tipos/aristas, nunca calcula posiciones). El eje vive
+      enteramente en `RunMapView`. Blindado con tests en vez de adaptado.
+- [x] Adaptar UI de nodos y aristas (`RunMapNodeView`, `RunMapEdgeView`) al
+      nuevo eje (anchor (0.5,1) → (0,0.5); animaciones/matemática de aristas
+      agnósticas al eje, sin cambios)
+- [x] `RelicInventoryView` integrado en HUD del mapa (banda 0.72–0.79 en `_mapPanel`,
+      Refresh en `ShowMap`, Cleanup en transición de escena; consistencia con HUD
+      de combate)
+- [x] Tests: misma seed = mismo mapa (`RunMapGeneratorTests.cs`, 5 casos:
+      determinismo topología, determinismo enemigos, divergencia por seed, DAG
+      válido, start/end forzados)
+- [x] **Validación Unity (2026-06-05):** compilación limpia (zero errors), suite
+      EditMode **131/131** verde (126 previos + 5 nuevos `RunMapGeneratorTests`),
+      Play en RunScene sin errores/excepciones de consola. Verificado por
+      diagnóstico de código: ScrollRect h=true/v=false/Clamped, content
+      pivot (0,0.5) sizeDelta (1160,0), start en x=80 / boss en x=1080,
+      ramas del mismo depth apiladas y centradas (±60), RelicBar en su banda.
 
 **Sistemas afectados:** TurnManager (hooks), RunState (Relics), RunFlowController
-(NewRunScene flow + Tienda/Hoguera nodes), RunMapView/Generator (horizontal),
-CombatUIController (RelicInventoryView). Nuevos: RelicHookDispatcher,
-RelicDefinition, IRelicEffect, NewRunController, CampfireNodeController,
-ShopNodeController, RelicInventoryView.
+(NewRunScene flow + Tienda/Hoguera nodes + RelicInventoryView en HUD del mapa),
+RunMapView (refactor horizontal), CombatUIController (RelicInventoryView). Nuevos:
+RelicHookDispatcher, RelicDefinition, IRelicEffect, NewRunController,
+CampfireNodeController, ShopNodeController, RelicInventoryView, RunMapGeneratorTests.
 
-**Toca archivos protegidos:** **SÍ** — TurnManager (hooks en eventos clave).
-**REQUIERE APROBACIÓN EXPLÍCITA** antes de empezar implementación de Sub-PR 3A.
-
-**Dependencias:** M2 cerrado ✅ (motor de combate v2 estable; hooks pueden
-colgarse en eventos confiables como Contador de Estilo, daño bidireccional,
-HealAction, PhaseBased AI).
-
-**Validación obligatoria por sub-PR:**
-- Compilación de Unity sin errores antes de marcar como mergeable.
-- Tests EditMode en verde.
-- Validación visual en la escena correspondiente (combate / hoguera / tienda /
-  new run / mapa).
-
-**Complejidad:** alta. Sub-PR 3A es la más crítica arquitectónicamente; el resto
-depende de que su contrato esté bien definido (lección reforzada por Insight 3).
-
-**Criterios de cierre M3:** todos los sub-PRs mergeados + run completo jugable
-de inicio a fin (NewRunScene → mapa horizontal → combates con Retazos visibles
-y activos → Tienda y Hoguera funcionales → Boss con drop de Retazo único +
-zero console errors + tests EditMode al 100%.
-
----
-
-## Pendientes
-
-### M4 — Resto del Acto 1 según GDD v2
-
-**Objetivo:** cerrar el contenido del Acto 1: mejora de cartas, eventos básicos
-y multidimensionales, enemigos transdimensionales y enemigos ancla.
-
-**Sub-tareas (desagregar al activar):**
-- Mejora de cartas (DD-013): toggle `IsUpgraded` en `CardDeckEntry`, campos
-  upgraded en `CardDefinition`, mejora ambos lados de cartas duales, UI
-- Eventos (DD-005): `EventDefinition` SO, controller, choice UI, sistema de
-  decisiones, eventos multidimensionales (elegir mundo)
-- Quests con MCguffin (DD-021 se cierra aquí): tracking en RunState, marca de
-  nodo destino en mapa, eventos de aceptar/robar
-- Enemigos transdimensionales (DD-014): campo `TypeWorldB` en `EnemyDefinition`,
-  resolución de tipo activo según `RunState.CurrentWorld`
-- Enemigos ancla (DD-014): flag `IsAnchor` en `EnemyDefinition`, bypass del
-  cambio de mundo en lógica
-
-**Toca archivos protegidos:** sí (TurnManager para tipo activo de transdim y
-ancla).
-
-**Dependencias:** M3 cerrado (eventos pueden otorgar Retazos / mejoras y
-necesitan el sistema funcionando).
-
-**Complejidad:** alta. El sistema de eventos con quests es trabajo significativo.
-
----
-
-### M5 — Bosses con fases + Boss Acto 1 según GDD v2
-
-**Objetivo:** rediseñar el Boss del Acto 1 (Costura Maldita / UNIT-RB7) según
-DD-004 con fases, debuffs únicos y mecánica "Desfase Dimensional". Establecer
-el patrón para futuros bosses.
-
-**Sub-tareas (desagregar al activar):**
-- Sistema de fases en bosses (Fase 2 obligatoria al 50% HP)
-- Mecánica "Desfase Dimensional": contador de cartas jugadas en turno, cambio
-  automático cada 3 cartas (2 en Fase 2)
-- Debuff Sangrado (DD-019, exclusivo del boss medieval): pérdida de HP al jugar
-  ataque
-- Debuff Virus (DD-019, exclusivo del boss cyberpunk): bloqueo al 80%
-  efectividad
-- 2 tipos por boss (1 SuperEficaz contra el jugador, 1 debilidad)
-- Retazo único de boss vinculado narrativamente
-
-**Toca archivos protegidos:** sí (TurnManager + ActionQueue para hook
-post-ProcessAll y mutación de mundo desde IA).
-
-**Dependencias:** M2 cerrado (cambio de mundo robusto), M4 cerrado (transdim/
-ancla establecen el patrón de tipos múltiples).
-
-**Complejidad:** alta.
-
----
-
-### M6 — Acto 2, Acto 3, Meta-progresión
-
-**Objetivo:** llevar el juego a su shape final: 3 actos, dificultad escalada
-según DD-011, XP entre runs, desbloqueos según DD-016.
-
-**Probable subdivisión:**
-- M6a — Acto 2 (HP enemigo, 2 tipos simultáneos, fases simples por umbral,
-  primer transdimensional, elites con 2 mecánicas)
-- M6b — Acto 3 (multifase, ancla, bosses que bloquean/fuerzan cambio,
-  restricciones de cambio)
-- M6c — Meta-progresión (XP, persistencia, desbloqueos, viñetas narrativas
-  iniciales — DD-015 entra aquí si está listo)
-
-**Toca archivos protegidos:** parcial (Acto 3 con bosses que bloquean cambio
-toca TurnManager).
-
-**Dependencias:** M5 cerrado (Boss Acto 1 funcional como plantilla).
-
-**Complejidad:** muy alta.
-
----
-
-## Completados
+**Insights / aprendizajes de M3:** Insight 3 (Retazos por categoría de hook),
+Insight 4 (payloads diferidos), Insight 7 (sinergia mazo↔stock diferida). Proceso:
+`.claude/settings.json` se auto-modifica durante sesiones → se de-scopea del PR de
+feature (confirmado de nuevo en 3E y 3F); `modo:diseno` genera prompt de handoff al
+cerrar specs.
 
 ### M2 — TurnManager v2: mecánica core nueva + deuda técnica
 **Fecha cierre:** 2026-05-07

--- a/Docs/dev/_tech_snapshot.md
+++ b/Docs/dev/_tech_snapshot.md
@@ -7,7 +7,34 @@
 > En `modo:implementacion` se lee OBLIGATORIAMENTE antes de cualquier cambio que
 > afecte arquitectura o componentes críticos.
 >
-> **Última actualización:** 2026-06-04 — M3 Sub-PR 3E (NewRunScene) **implementado
+> **Última actualización:** 2026-06-05 — M3 Sub-PR 3F (Mapa horizontal) **implementado
+> y validado en Unity** en branch `feat/m3-sub-f-horizontal-map`. **Cierra M3.**
+> Refactor de UX puro del mapa del run: scroll vertical → **scroll horizontal
+> izquierda→derecha** (DD-005, start a la izquierda / boss a la derecha). El eje vive
+> ENTERAMENTE en `RunMapView`: `GetNodePosition` ahora mapea `depth→X`
+> (`x = LeftPadding + depth*ColumnSpacing`) e `índice→Y`
+> (`y = -(index-(count-1)/2)*NodeRowSpacing`, apilado vertical centrado); el content
+> se dimensiona por ANCHO (`contentWidth`, `sizeDelta=(W,0)`); `CreateScrollView`
+> setea `ScrollRect.horizontal=true/vertical=false`, content pivot `(0,0.5)` anclado
+> a la izquierda, y baja el techo del scroll a `anchorMax.y=0.72`. Constantes
+> renombradas: `HorizontalSpacing→ColumnSpacing(200)`, `RowSpacing→NodeRowSpacing(120)`,
+> `TopPadding→LeftPadding(80)`, `BottomPadding→RightPadding(80)`. `RunMapNodeView` y
+> `RunMapEdgeView` sólo cambian su anchor `(0.5,1)→(0,0.5)` (1 línea c/u; animaciones
+> y matemática de aristas son agnósticas al eje). **`RunMapGenerator` NO se tocó**
+> (es agnóstico al eje — sólo asigna tipos/aristas; decisión cerrada del spec).
+> `RunFlowController` ahora instancia un `RelicInventoryView` en una banda dedicada
+> del `_mapPanel` (anchors 0.72–0.79, arriba del scroll y bajo el status) → fila de
+> Retazos en el HUD del mapa, consistente con el HUD de combate; `Refresh` en
+> `ShowMap()` y `Cleanup()` junto al de `_mapView` en las transiciones de escena.
+> Nuevo `Assets/Tests/EditMode/RunMapGeneratorTests.cs` (5 casos: determinismo de
+> topología, determinismo de enemigos, divergencia por seed, DAG válido, start/end
+> forzados) — blinda "misma seed = mismo mapa" (no existía test del sistema de mapa).
+> **Validado:** compilación limpia, EditMode **131/131** (126 previos + 5 nuevos),
+> Play en RunScene sin errores/excepciones; diagnóstico de código confirma ScrollRect
+> horizontal, content `pivot(0,0.5) sizeDelta(1160,0)`, start en x=80 / boss en x=1080,
+> ramas del mismo depth apiladas y centradas (±60), RelicBar en su banda.
+>
+> **Última actualización previa:** 2026-06-04 — M3 Sub-PR 3E (NewRunScene) **implementado
 > y validado en Unity** en branch `feat/m3-sub-e-newrun`. Nuevos:
 > `Assets/Scripts/Run/NewRun/{NewRunController, NewRunConfig, StarterDraft}.cs`,
 > `Assets/Editor/NewRunConfigSetup.cs` (menú `Roguelike > Setup New Run Config`),
@@ -250,7 +277,9 @@ Run/
     RunMapGenerator.cs
     Act1MapConfig.cs, EnemyPoolConfig.cs
     UI/
-      RunMapView.cs, RunMapNodeView.cs, RunMapEdgeView.cs
+      RunMapView.cs                ← 3F: scroll HORIZONTAL (depth→X, índice→Y); el eje
+                                     vive entero acá (GetNodePosition + CreateScrollView)
+      RunMapNodeView.cs, RunMapEdgeView.cs  ← 3F: anchor (0,0.5)
 
 Gameplay/
   Cards/
@@ -306,7 +335,8 @@ Gameplay/
       RelicElitePuristEffect.cs, RelicEliteChargeBoostEffect.cs
       RelicBossLastStitchEffect.cs
     UI/
-      RelicInventoryView.cs      ← fila de iconos en HUD combate (3F: RunMapView)
+      RelicInventoryView.cs      ← fila de iconos en HUD combate Y mapa (3F: instanciada
+                                   también por RunFlowController en banda del _mapPanel)
 
 Save/
   ISaveService.cs
@@ -325,7 +355,7 @@ RelicSoGenerator.cs                   ← MenuItem "Roguelike/Generate Relic Ass
                                         (idempotente — saltea archivos existentes)
 ```
 
-### Tests (`Assets/Tests/EditMode/`) — 11 archivos
+### Tests (`Assets/Tests/EditMode/`) — 15 archivos (suite EditMode 131/131)
 
 ```
 CombatTestBase.cs                ← helper compartido
@@ -341,6 +371,12 @@ RelicHookDispatcherTests.cs      ← M3 Sub-PR 3A (8 casos de plomería)
 RelicEffectsTests.cs             ← M3 Sub-PR 3B (efectos concretos: mutación,
                                    counters, RunState directo, hook filtering,
                                    guards con TurnManager null)
+CampfireTests.cs                 ← M3 Sub-PR 3C (8 casos: heal/upgrade/hook)
+ShopTests.cs                     ← M3 Sub-PR 3D (13 casos: oro/stock/filtro/hook)
+NewRunTests.cs                   ← M3 Sub-PR 3E (8 casos: draft/dual/tipos)
+RunMapGeneratorTests.cs          ← M3 Sub-PR 3F (5 casos: determinismo topología/
+                                   enemigos, divergencia por seed, DAG válido,
+                                   start/end forzados — blinda el refactor horizontal)
 ```
 
 ### ScriptableObjects (`Assets/ScriptableObjects/`)

--- a/Docs/dev/specs/m3_3f_horizontal_map_spec.md
+++ b/Docs/dev/specs/m3_3f_horizontal_map_spec.md
@@ -1,0 +1,394 @@
+# Spec — Sub-PR 3F: Mapa horizontal (refactor scroll lateral)
+
+> Estado: **CERRADO** (sin decisiones abiertas). Último sub-PR de M3 — su cierre
+> cierra el milestone. Diseñado 2026-06-05 en `modo:diseno`.
+
+## Origen
+
+- `[GDD]` §"DD-005 / Sistema de nodos": *"El jugador atravesará un mapa de
+  **scroll lateral (izquierda a derecha)** que se creará a través de un sistema
+  de semillas"*.
+- `GOLDEN_RULES.md` §7 → "Estructura del mapa: **Scroll lateral (izquierda a
+  derecha)**".
+- `_roadmap.md` → M3 Sub-PR 3F (checklist de 5 puntos).
+- Es un **refactor de UX puro**, no una feature nueva: el mapa hoy scrollea
+  vertical (filas por profundidad). Hay que invertirlo a horizontal.
+
+## Objetivo
+
+Que el mapa del run se presente como un scroll horizontal izquierda→derecha
+(start a la izquierda, boss a la derecha), coherente con el GDD y la estética de
+roguelike de progresión lateral. El refactor es **puramente visual**: no puede
+alterar la topología generada, los tipos de nodo ni la asignación de enemigos
+(determinismo por seed intacto). Además integra el inventario de Retazos al HUD
+del mapa (consistencia con el HUD de combate, pendiente declarado desde 3B).
+
+## Comportamiento esperado
+
+Desde la perspectiva del jugador:
+
+- Entra a RunScene y ve el mapa con el **nodo inicial a la izquierda** y el
+  **boss a la derecha**. Las columnas avanzan por profundidad hacia la derecha.
+- Los nodos del mismo depth (las ramas paralelas de una bifurcación) se apilan
+  **verticalmente, centrados** en su columna.
+- El mapa **scrollea horizontalmente** (drag / rueda) cuando no entra completo
+  en pantalla. No scrollea en vertical.
+- La animación de entrada sigue siendo escalonada por profundidad: aparece
+  primero el start (izquierda), por último el boss (derecha).
+- Una **fila de íconos de Retazos** es visible siempre en la parte superior del
+  HUD del mapa (igual que en combate), reflejando la build actual.
+- Todo el resto del flujo (click en nodo disponible → entra; nodos
+  completados/bloqueados; highlight de aristas al desbloquear) se comporta
+  idéntico a hoy.
+
+## Sistemas afectados
+
+- **UI (Run/Map/UI):** `RunMapView` (refactor de ejes + ScrollRect),
+  `RunMapNodeView` y `RunMapEdgeView` (ajuste de anchor), `RunFlowController`
+  (instancia el `RelicInventoryView` en el HUD del mapa).
+- **Generación (Run/Map):** `[CÓDIGO ACTUAL]` `RunMapGenerator` es **agnóstico
+  al eje** → **NO se toca** (ver Decisiones cerradas #1).
+- **RunState / ScriptableObjects:** sin cambios.
+- **Archivos protegidos (TurnManager/ActionQueue/PlayerCombatActor):** **NINGUNO**.
+
+## Archivos a crear
+
+- `Assets/Tests/EditMode/RunMapGeneratorTests.cs` — tests de determinismo que
+  blindan la generación (ver "Casos de prueba"). **No existe hoy ningún test del
+  sistema de mapa** → este archivo es la red de seguridad del refactor.
+
+## Archivos a modificar
+
+- `Assets/Scripts/Run/Map/UI/RunMapView.cs` — el grueso del refactor: invertir
+  el mapeo de ejes, el `ScrollRect` y el dimensionado del content.
+- `Assets/Scripts/Run/Map/UI/RunMapNodeView.cs` — cambiar el anchor del nodo de
+  `(0.5, 1)` a `(0, 0.5)` para alinear con el nuevo pivot del content.
+- `Assets/Scripts/Run/Map/UI/RunMapEdgeView.cs` — mismo cambio de anchor
+  `(0.5, 1)` → `(0, 0.5)`. La matemática de la arista (atan2/distancia) es
+  agnóstica al eje y **no cambia**.
+- `Assets/Scripts/Run/RunFlowController.cs` — instanciar `RelicInventoryView` en
+  el HUD del mapa y refrescarlo en `ShowMap()`.
+
+## Archivos protegidos involucrados
+
+- [x] **Ninguno.** Todo vive en `Run/Map/UI/`, `Run/RunFlowController.cs` y
+  `Tests/EditMode/`. `RunMapGenerator` (no protegido) tampoco se toca.
+
+---
+
+## Contratos
+
+### 1. Refactor de ejes en `RunMapView.cs`
+
+`[PROPUESTA]` Reemplazar las constantes y el mapeo. Hoy (vertical):
+
+```
+depth  → Y  (filas, hacia abajo)   via  y = -(TopPadding + depth * RowSpacing)
+índice → X  (columnas, centrado)   via  x = (index - (count-1)/2) * HorizontalSpacing
+```
+
+Nuevo (horizontal):
+
+```
+depth  → X  (columnas, hacia la derecha)   x = LeftPadding + depth * ColumnSpacing
+índice → Y  (apilado vertical, centrado)   y = -(index - (count-1)/2) * NodeRowSpacing
+```
+
+**Constantes nuevas del eje** (renombrar las actuales, no agregar duplicados):
+
+| Constante | Valor `[PROPUESTA]` | Rol |
+|-----------|---------------------|-----|
+| `ColumnSpacing` | `200f` | separación horizontal entre columnas de depth (hoy el valor vivía en `HorizontalSpacing`, ahora gobierna el eje de avance) |
+| `NodeRowSpacing` | `120f` | separación vertical entre nodos del mismo depth (hoy era `RowSpacing=130`; se baja un poco porque ahora compite con alto de pantalla, no de scroll infinito) |
+| `LeftPadding` | `80f` | padding antes de la primera columna (reemplaza `TopPadding`) |
+| `RightPadding` | `80f` | padding tras la última columna (reemplaza `BottomPadding`) |
+| `NodeWidth` | `130f` | sin cambio |
+| `NodeHeight` | `50f` | sin cambio |
+| `EdgeThickness` | `3f` | sin cambio |
+| `EntranceDelayPerDepth` | `0.08f` | sin cambio (sigue escalonando por depth, ahora izq→der) |
+
+**Centrado vertical de cada columna:** el signo del término de índice se mantiene
+negativo (`-(index - (count-1)/2) * NodeRowSpacing`) para que el orden de apilado
+sea estable respecto al actual; con el content pivoteado en el centro vertical
+(ver abajo) `y=0` es el centro de la pantalla y la columna se reparte simétrica
+arriba/abajo. Una columna de 1 nodo queda en `y=0` (centrada).
+
+**`GetNodePosition` nuevo** (firma idéntica, sólo cambia el cuerpo):
+
+```
+int depth = depthMap[nodeId];
+List<int> bucket = depthBuckets[depth];
+int index = bucket.IndexOf(nodeId);
+int count = bucket.Count;
+
+float x = LeftPadding + depth * ColumnSpacing;
+float y = -(index - (count - 1) / 2f) * NodeRowSpacing;
+return new Vector2(x, y);
+```
+
+**Dimensionado del content (por ANCHO):**
+
+```
+float contentWidth = LeftPadding + maxDepth * ColumnSpacing + RightPadding;
+content.sizeDelta = new Vector2(contentWidth, 0f);
+```
+
+(hoy es `contentHeight` sobre el eje Y con `sizeDelta = (0, contentHeight)`).
+
+### 2. `CreateScrollView` — invertir ScrollRect y pivot del content
+
+`[PROPUESTA]` Cambios dentro de `CreateScrollView`:
+
+- `scroll.horizontal = true;` / `scroll.vertical = false;` (hoy es al revés).
+- `movementType = Clamped` se mantiene.
+- **Content anchoring/pivot** — hoy stretch horizontal anclado arriba:
+  ```
+  contentRect.anchorMin = new Vector2(0f, 1f);
+  contentRect.anchorMax = new Vector2(1f, 1f);
+  contentRect.pivot     = new Vector2(0.5f, 1f);
+  ```
+  Nuevo: stretch vertical anclado a la izquierda, pivot en centro-izquierda:
+  ```
+  contentRect.anchorMin = new Vector2(0f, 0f);
+  contentRect.anchorMax = new Vector2(0f, 1f);
+  contentRect.pivot     = new Vector2(0f, 0.5f);
+  contentRect.anchoredPosition = Vector2.zero;
+  contentRect.sizeDelta = new Vector2(800f, 0f);  // placeholder, lo pisa el dimensionado por ancho
+  ```
+- El rect del ScrollView (`scrollRect.anchorMin/Max`) **baja su techo** para dejar
+  una franja superior limpia para el HUD de Retazos (ver #4): cambiar el
+  `anchorMax` de `(0.98, 0.78)` a `(0.98, 0.72)`. El `anchorMin` `(0.02, 0.02)`
+  se mantiene.
+
+### 3. `RunMapNodeView` y `RunMapEdgeView` — anchor
+
+`[PROPUESTA]` Ambos hardcodean hoy `anchorMin/Max = (0.5, 1)` y `pivot` para
+alinear con el content pivot anterior. Con el content pivoteado en `(0, 0.5)`,
+ambos deben usar:
+
+```
+Rect.anchorMin = new Vector2(0f, 0.5f);
+Rect.anchorMax = new Vector2(0f, 0.5f);
+// pivot del nodo se mantiene (0.5, 0.5); pivot de la arista se mantiene (0.5, 0.5)
+```
+
+`[CÓDIGO ACTUAL]` Confirmado: ningún otro cambio. La animación de entrada
+(`PlayEntrance`, scale+fade), el pulse de nodos disponibles, el punch al
+completar y el `AnimateHighlight` de aristas son **agnósticos al eje** — sólo
+operan sobre `localScale`/`alpha`/`color`, nunca sobre posición. Reciben las
+posiciones ya calculadas por `RunMapView`. La matemática de la arista
+(`Atan2(diff.y, diff.x)`, magnitud) funciona con cualquier par de posiciones.
+
+### 4. `RelicInventoryView` en el HUD del mapa (`RunFlowController`)
+
+`[CÓDIGO ACTUAL]` `RunFlowController.BuildUI()` ya tiene `uiFont`,
+`GetWhiteSprite()`, `_state` y `_root` (RectTransform del RunCanvas). El estado
+expone `_state.Relics` (la misma lista que lee el dispatcher). Todos los caminos
+de retorno al mapa (combate, tienda, hoguera, evento, derrota cancelada) pasan
+por `ShowMap()`.
+
+`[PROPUESTA]` Espejo del patrón de combate (`CombatUIController` crea un panel
+`RelicBar` y mete dentro un `RelicInventoryView`):
+
+- Nuevo campo `private RelicInventoryView _relicView;`.
+- En `BuildUI()`, tras crear `_mapPanel` y antes/después de `_mapView`, crear una
+  franja horizontal **dentro de `_mapPanel`** que no pise el scroll:
+  ```
+  // Franja de Retazos: arriba del scroll del mapa (techo del scroll = 0.72),
+  // debajo del status (0.80). Banda dedicada → no colisiona con el área scrolleable.
+  RectTransform relicBar = CreatePanel("RelicBar", _mapPanel,
+      <anchorMin (0.02, 0.72)>, <anchorMax (0.98, 0.79)>, new Color(0,0,0,0));
+  _relicView = new RelicInventoryView(relicBar, uiFont);
+  ```
+  (usar el helper `CreatePanel` existente; los valores exactos de anchor son
+  `[PROPUESTA]` — la banda 0.72–0.79 queda libre tras bajar el techo del scroll a
+  0.72 en #2, y bajo el status 0.80–0.88).
+- En `ShowMap()`, tras `_mapView?.Refresh(_state)`, agregar
+  `_relicView?.Refresh(_state.Relics);`. Refrescar en `ShowMap` es suficiente:
+  los Retazos sólo cambian fuera del mapa (combate/elite/boss/tienda) y todo
+  retorno al mapa pasa por `ShowMap`.
+- `RelicInventoryView` ya es presentación pura no-MonoBehaviour, ya construye su
+  propio tooltip colgado del Canvas raíz y ya tiene `Cleanup()`. **Llamar
+  `_relicView?.Cleanup()`** donde hoy se hace `_mapView?.Cleanup()` (transición
+  de escena) para no dejar el tooltip huérfano.
+
+`[INTERPRETACIÓN]` No se necesita `AddRelic` (pulse-on-acquire) en el mapa: la
+adquisición de Retazos ocurre en combate/tienda con su propio feedback; en el
+mapa basta con que el ícono esté presente. `Refresh` crea los íconos faltantes.
+
+---
+
+## Reuso
+
+- `RelicInventoryView` (3B) — se reusa tal cual, sin tocar su código.
+- `CreatePanel` / `GetWhiteSprite` / `uiFont` de `RunFlowController` — helpers
+  existentes.
+- `UIAnimationHelper`, DOTween — ya usados por los node/edge views; sin cambios.
+- `RunMapGenerator.Generate` / `AssignEnemies` — se reusan intactos; los tests
+  nuevos los ejercitan.
+
+## Casos de prueba (EditMode) — `RunMapGeneratorTests.cs`
+
+El refactor es visual; el blindaje prueba que la **generación** (lógica pura) no
+cambió. `RunMapGenerator` es `static` y no necesita Unity runtime → testeable en
+EditMode. Se construye un `Act1MapConfig` vía `ScriptableObject.CreateInstance`
+(mismo patrón que `GenerateAct1`).
+
+1. **Determinismo de topología:** `Generate(config, seed=12345)` dos veces →
+   mismo `StartNodeId`, misma cantidad de nodos, mismos `Type` por Id y mismas
+   `Connections` por Id (comparación profunda). Es el corazón del blindaje:
+   "misma seed = mismo mapa".
+2. **Determinismo de enemigos:** `AssignEnemies(map, pool, seed=12345)` sobre dos
+   mapas idénticos → mismo `SpecificEnemy` por nodo Combat/Elite. "misma seed =
+   mismos enemigos".
+3. **Seeds distintas pueden divergir:** `Generate(config, seed=1)` vs `seed=2`
+   producen al menos una diferencia (topología o tipos). Guard suave: si por
+   azar coincidieran, el test no debe ser frágil → afirmar sobre el log de
+   template index o sobre el arreglo de tipos con dos seeds elegidas que se sabe
+   difieren (elegir seeds tras una corrida exploratoria; documentar en comentario).
+4. **DAG válido invariante:** el mapa generado mantiene nodo 0 sin entrantes,
+   nodo `TotalNodes-1` sin salientes, y todos los `connId` ∈ rango válido
+   (sanity del contrato de `Topologies`, independiente del eje).
+5. **Boss/end forzado:** `types[total-1] == ForcedEndType` y
+   `types[0] == ForcedStartType` (la asignación de tipos no se ve afectada por el
+   refactor visual — pin defensivo).
+
+`[INTERPRETACIÓN]` No se testea `RunMapView.GetNodePosition` directamente: es
+`private static` sobre UI y exponerlo (InternalsVisibleTo) agrega acoplamiento de
+test por un cálculo trivial. El contrato que importa blindar es el de generación;
+el layout se valida en la pasada visual en escena.
+
+## Validación manual (RunScene)
+
+1. Abrir RunScene en Play (o entrar vía MainMenu → NewRunScene → RunScene).
+2. **Resultado esperado:** el mapa se ve con el start a la **izquierda**, el boss
+   a la **derecha**, columnas avanzando hacia la derecha; nodos del mismo depth
+   apilados verticalmente y centrados. Scroll horizontal funciona (drag/rueda);
+   no hay scroll vertical.
+3. La animación de entrada aparece izq→der (start primero, boss último).
+4. La **fila de íconos de Retazos** está visible arriba del mapa y no se solapa
+   con el área scrolleable ni con title/status. Tooltip al hover funciona.
+5. Completar un nodo → highlight dorado de aristas hacia los nodos desbloqueados;
+   los nuevos nodos disponibles pulsan. Avanzar hasta el boss.
+6. Volver de tienda/elite con un Retazo nuevo → al re-mostrar el mapa el ícono
+   aparece en la fila.
+7. **Zero console errors** durante todo el recorrido. Sin warnings de
+   "destroyed RectTransform" al cambiar de escena (Cleanup correcto).
+
+## Decisiones cerradas
+
+1. **`RunMapGenerator` NO se toca.** `[CÓDIGO ACTUAL]` confirmado leyendo el
+   archivo: sólo asigna tipos (peso) y aristas (templates DAG); nunca calcula
+   posiciones ni asume eje. `AssignEnemies` usa BFS depth, agnóstico al layout.
+   El eje vive **enteramente** en `RunMapView.GetNodePosition` +
+   `CreateScrollView`. Declarado para no inventar trabajo (punto 2 del checklist).
+2. **`RunMapNodeView`/`RunMapEdgeView` sólo cambian el anchor** (1 línea cada
+   uno). Su lógica de animación y la matemática de aristas son agnósticas al eje
+   y reciben posiciones ya calculadas (punto 3 del checklist).
+3. **HUD de Retazos en banda dedicada superior** (0.72–0.79), bajando el techo
+   del scroll a 0.72. No se reusa un layout flotante sobre el scroll para evitar
+   solapamiento de raycasts con los nodos.
+4. **Refresh en `ShowMap`, sin pulse-on-acquire.** Suficiente porque los Retazos
+   sólo cambian fuera del mapa y todo retorno pasa por `ShowMap`.
+5. **El blindaje de determinismo apunta a `RunMapGenerator`** (lógica pura), no a
+   `RunMapView` (UI). Es donde vive el contrato "misma seed = mismo mapa".
+6. **Estética handmade:** sin cambios de paleta ni sprites en este sub-PR; el
+   mapa usa los mismos colores/whiteSprite actuales. El arte del mapa entra en el
+   plan de auditoría de arte post-M3, no aquí.
+
+## Alternativas consideradas
+
+- **`[ALTERNATIVA]` Usar `HorizontalLayoutGroup` para las columnas** — descartada:
+  el layout es un DAG con ramas de ancho variable y aristas diagonales; un layout
+  group no modela posiciones absolutas con bifurcaciones. El posicionamiento
+  manual actual (anchoredPosition) ya resuelve esto y sólo hay que invertir ejes.
+- **`[ALTERNATIVA]` Parametrizar el eje (enum Vertical/Horizontal) en `RunMapView`**
+  — descartada: nadie necesita el modo vertical nunca más (el GDD pide horizontal
+  definitivo). Mantener ambos modos agrega ramas muertas. Se hace el flip directo.
+- **`[ALTERNATIVA]` Reutilizar el `relicBar` de combate moviéndolo a un helper
+  compartido** — descartada por ahora: el panel de combate vive en
+  `CombatUIController` (otra escena/controller) y extraer un helper compartido es
+  scope creep. Cada HUD instancia su propio `RelicInventoryView` (la view ya es
+  reutilizable; sólo cambia el parent). Posible cleanup futuro si aparece un 3er
+  consumidor.
+
+## Estimación
+
+- **Complejidad: baja-media.** El refactor de ejes es mecánico y acotado a 1
+  archivo grande (`RunMapView`) + 2 cambios de 1 línea + integración del HUD +
+  tests nuevos.
+- **Sub-tareas:**
+  1. Flip de ejes + ScrollRect + dimensionado en `RunMapView`.
+  2. Anchor en `RunMapNodeView` y `RunMapEdgeView`.
+  3. `RelicInventoryView` en `RunFlowController` (build + Refresh + Cleanup).
+  4. `RunMapGeneratorTests.cs` (5 casos).
+  5. Validación visual en escena + suite EditMode.
+- **Riesgo:** bajo. El único riesgo real es que el flip de pivot/anchor descoloque
+  visualmente nodos o aristas → se mitiga con la pasada visual obligatoria. El
+  determinismo está cubierto por código intacto + tests nuevos. Sin tocar
+  protegidos.
+
+---
+
+## Prompt de handoff para `modo:implementacion`
+
+```text
+modo:implementacion
+
+Implementá el Sub-PR 3F — Mapa horizontal (refactor scroll lateral), el último
+sub-PR de M3 (su cierre). El spec cerrado está en
+`Docs/dev/specs/m3_3f_horizontal_map_spec.md` — leelo completo antes de tocar
+código; todas las decisiones de diseño ya están cerradas, no abras ninguna.
+
+Setup de branch (dependencia previa: PR #97 / 3E ya MERGED a main, 6d171a5):
+  git fetch --all --prune
+  git checkout -b feat/m3-sub-f-horizontal-map origin/main
+
+Qué construir (el detalle y los contratos están en el spec):
+Modificar:
+- `Assets/Scripts/Run/Map/UI/RunMapView.cs` — invertir ejes (depth→X / índice→Y),
+  ScrollRect horizontal=true/vertical=false, content pivot (0,0.5) anclado
+  izquierda, dimensionar por ANCHO (contentWidth), nuevas constantes
+  (ColumnSpacing/NodeRowSpacing/LeftPadding/RightPadding), bajar techo del scroll
+  a anchorMax.y=0.72.
+- `Assets/Scripts/Run/Map/UI/RunMapNodeView.cs` — anchor (0.5,1) → (0,0.5).
+- `Assets/Scripts/Run/Map/UI/RunMapEdgeView.cs` — anchor (0.5,1) → (0,0.5).
+- `Assets/Scripts/Run/RunFlowController.cs` — instanciar RelicInventoryView en
+  banda superior del _mapPanel (0.72–0.79), Refresh en ShowMap, Cleanup en la
+  transición de escena.
+Crear:
+- `Assets/Tests/EditMode/RunMapGeneratorTests.cs` — 5 casos de determinismo
+  (topología, enemigos, divergencia por seed, DAG válido, start/end forzados).
+
+Reglas no negociables:
+- NO tocar archivos protegidos (TurnManager, ActionQueue, PlayerCombatActor) —
+  este PR no los necesita.
+- NO tocar `RunMapGenerator.cs`: es agnóstico al eje (decisión cerrada #1). Si
+  durante la implementación parece que hace falta tocarlo, PARAR — algo se
+  entendió mal respecto al spec.
+- No manual editor setup: el mapa se construye en runtime por RunFlowController;
+  nada nuevo que asignar en inspector.
+- Reusar RelicInventoryView tal cual (no editar su código); sólo cambia el parent.
+- Estética handmade: sin cambios de paleta/sprites en este PR.
+
+Validación obligatoria antes de cerrar:
+- Compilación limpia (zero console errors).
+- `RunMapGeneratorTests` 5/5 verde + suite EditMode completa sin regresiones
+  (vía `tests-run` EditMode o Test Runner).
+- Flujo end-to-end en escena (Unity-MCP / Play): mapa horizontal start-izq /
+  boss-der, scroll lateral, entrada izq→der, fila de Retazos visible sin pisar el
+  scroll, recorrido completo hasta el boss sin errores ni warnings de
+  RectTransform destruido.
+- OJO (Insight de 3E): no dejar que `.claude/settings.json` viaje en el PR de
+  feature con permisos auto-agregados — revisar el diff antes de commitear.
+
+Al cerrar (cierra M3):
+- `_roadmap.md`: marcar los 5 checkboxes de Sub-PR 3F `[x]`; mover M3 completo de
+  "Activo" a "Completados" con fecha y resumen; activar M4 como milestone activo;
+  registrar aprendizajes en `_insights.md` si los hubo.
+- `_tech_snapshot.md`: nota del refactor horizontal de RunMapView + RelicInventory
+  en HUD del mapa + nuevo RunMapGeneratorTests.cs (subir conteo de tests).
+- Commit + push + PR a main (Closes #<issue de 3F si existe>).
+- Tras el merge: arranca el plan de auditoría de arte (memoria
+  project-art-audit-plan).
+```


### PR DESCRIPTION
## Sub-PR 3F — Mapa horizontal (refactor scroll lateral) · **cierra M3**

Refactor de UX puro: el mapa del run pasa de scroll vertical a **scroll horizontal izquierda→derecha** (DD-005, GOLDEN_RULES §7). Start a la izquierda, boss a la derecha; las ramas paralelas del mismo depth se apilan verticalmente y centradas. No altera la topología, los tipos de nodo ni la asignación de enemigos (determinismo por seed intacto).

Spec cerrado: `Docs/dev/specs/m3_3f_horizontal_map_spec.md`.

### Cambios
- **`RunMapView`** — invierte ejes (`depth→X` / `índice→Y`), `ScrollRect` horizontal, content pivot `(0,0.5)` anclado a la izquierda, dimensionado por **ancho** (`contentWidth`), techo del scroll bajado a `anchorMax.y=0.72`. Constantes renombradas (`ColumnSpacing/NodeRowSpacing/LeftPadding/RightPadding`).
- **`RunMapNodeView` / `RunMapEdgeView`** — anchor `(0.5,1)→(0,0.5)` (1 línea c/u). Animaciones y matemática de aristas son agnósticas al eje → sin cambios.
- **`RunFlowController`** — instancia un `RelicInventoryView` en banda dedicada del `_mapPanel` (0.72–0.79), `Refresh` en `ShowMap`, `Cleanup` en transiciones de escena. Fila de Retazos en el HUD del mapa, consistente con combate.
- **`RunMapGeneratorTests.cs`** (nuevo, 5 casos) — determinismo de topología y de enemigos, divergencia por seed, DAG válido, start/end forzados. Blinda "misma seed = mismo mapa".

### Decisión clave
**`RunMapGenerator` NO se tocó** — es agnóstico al eje (sólo asigna tipos/aristas, nunca posiciones). El eje vive enteramente en `RunMapView`. Se blinda con tests en vez de adaptarlo.

### Validación (Unity, 2026-06-05)
- ✅ Compilación limpia (zero console errors).
- ✅ Suite EditMode **131/131** verde (126 previos + 5 nuevos).
- ✅ Play en RunScene sin errores/excepciones de consola. Diagnóstico de código confirma: `ScrollRect h=true/v=false/Clamped`, content `pivot(0,0.5) sizeDelta(1160,0)`, start en x=80 / boss en x=1080, ramas del mismo depth apiladas y centradas (±60), `RelicBar` en su banda.

### Cierre de M3
Último sub-PR de M3 (Personalización del run). Con esto los 6 sub-PRs quedan mergeados (3A foundations, 3B Retazos, 3C Hoguera, 3D Tienda #96, 3E NewRunScene #97, 3F mapa horizontal). Docs actualizados: `_roadmap.md` (M3→Completados, M4 activo) y `_tech_snapshot.md`.

> Sin issue específico de 3F en el tracker → sin `Closes #`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
