### PR TITLE
chore(perms): limpieza de permisos en settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,11 +75,11 @@
       "mcp__ai-game-developer__profiler-get-script-stats",
       "Bash(git check-ignore *)",
       "Bash(node .claude/hooks/protect-files.js)",
-      "Bash(printf '%s' '{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"c:\\\\\\\\Users\\\\\\\\Asus\\\\\\\\RoguelikeCardBattler\\\\\\\\Assets\\\\\\\\Scripts\\\\\\\\Gameplay\\\\\\\\Combat\\\\\\\\TurnManager.cs\"}}')",
       "Read(//tmp/**)",
-      "Bash(node -e 'const j=JSON.stringify\\({tool_name:\"Edit\",tool_input:{file_path:\"c:\\\\\\\\Users\\\\\\\\Asus\\\\\\\\RoguelikeCardBattler\\\\\\\\Assets\\\\\\\\Scripts\\\\\\\\Gameplay\\\\\\\\Combat\\\\\\\\TurnManager.cs\"}}\\); require\\(\"fs\"\\).writeFileSync\\(\"/tmp/h2.json\", j\\); console.log\\(\"JSON valido:\", j\\)')"
+      "Bash(npx unity-mcp-cli *)"
     ],
     "deny": [
+      "Bash(rm:*)",
       "Bash(rm -rf:*)",
       "Bash(git push --force:*)",
       "Bash(git push -f:*)",


### PR DESCRIPTION
## Limpieza de permisos (revisión de seguridad)

Higiene de `.claude/settings.json` tras una revisión de seguridad pedida por Sebastián. Cambio chico y trazable, en branch `chore/*` (no colado en un PR de feature).

### Qué cambia
- **Quita 2 entradas basura** de una sesión vieja que probaba el hook `protect-files` (los `Bash(printf ...)` y `Bash(node -e ...writeFileSync /tmp/h2.json...)`). Eran inofensivas pero ruido.
- **Agrega `Bash(npx unity-mcp-cli *)`** deliberadamente — es el CLI del flujo de validación con Unity-MCP. Va acá, en commit de tooling, no auto-agregado en un PR de feature.
- **Agrega `Bash(rm:*)` a `deny`** — cinturón extra sobre el `Bash(rm -rf:*)` que ya estaba: ningún borrado de archivos sin pasar por confirmación.

### Qué NO cambia (por decisión)
- **No se auto-aprueba `gh pr merge`/`close`** — quedan sólo las granulares `gh pr create/view/list/diff/checks`, así los merges piden confirmación.
- `git commit`/`git push` siguen auto-aprobados (decisión explícita de Sebastián).
- Se mantiene `Read(//tmp/**)`.

### Por qué
Refuerza el aprendizaje de proceso (settings.json se auto-modifica durante sesiones → las entradas útiles van en un commit de tooling deliberado, las basura se limpian, y los permisos sensibles no se cuelan). El setup queda con muro `deny` sólido + hook de archivos protegidos + sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
