### PR TITLE
feat(ui): tinte por tipo elemental (auditoría de arte C8, sin IA)

### DIFF
--- a/Assets/Scripts/Gameplay/Combat/CardHandView.cs
+++ b/Assets/Scripts/Gameplay/Combat/CardHandView.cs
@@ -293,7 +293,15 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 prefix = _turnManager.CurrentWorld == TurnManager.WorldSide.A ? "[A] " : "[B] ";
             }
 
-            string typePrefix = activeCard.ElementType != ElementType.None ? $"[{activeCard.ElementType}] " : string.Empty;
+            // Tinte por tipo (C8): el prefijo [Tipo] toma el color del tipo vía rich
+            // text. ReadableOnDark mantiene legible el Negro sobre el fondo oscuro de
+            // la carta. Color desde la fuente única de verdad (ElementTypeColors).
+            string typePrefix = string.Empty;
+            if (activeCard.ElementType != ElementType.None)
+            {
+                string typeHex = ColorUtility.ToHtmlStringRGB(ElementTypeColors.ReadableOnDark(activeCard.ElementType));
+                typePrefix = $"<color=#{typeHex}>[{activeCard.ElementType}]</color> ";
+            }
             string title = string.IsNullOrEmpty(prefix)
                 ? $"{typePrefix}{activeCard.CardName}"
                 : $"{prefix}{typePrefix}{activeCard.CardName}";

--- a/Assets/Scripts/Gameplay/Combat/CombatHudView.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatHudView.cs
@@ -167,6 +167,10 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             _playerHpLabel.text = $"{_turnManager.PlayerHP}/{_turnManager.PlayerMaxHP}";
             _enemyHpLabel.text = $"{_turnManager.EnemyHP}/{_turnManager.EnemyMaxHP}";
             _enemyTypeLabel.text = BuildEnemyTypeLabel();
+            ElementType enemyType = _turnManager.EnemyElementType;
+            _enemyTypeLabel.color = enemyType == ElementType.None
+                ? Color.white
+                : ElementTypeColors.ReadableOnDark(enemyType);
             _drawPileText.text = $"Draw: {_turnManager.PlayerDrawPileCount}";
             _discardPileText.text = $"Discard: {_turnManager.PlayerDiscardPileCount}";
             _enemyIntentText.text = BuildEnemyIntentLabel();
@@ -185,6 +189,10 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             {
                 ElementType activeType = _turnManager.PlayerActiveType;
                 _playerTypeText.text = activeType == ElementType.None ? "Tipo: —" : $"Tipo: {activeType}";
+                // Tinte por tipo (C8): el label del tipo activo del jugador toma su color.
+                _playerTypeText.color = activeType == ElementType.None
+                    ? Color.white
+                    : ElementTypeColors.ReadableOnDark(activeType);
             }
 
             bool playerTurn = _turnManager.IsPlayerTurn();

--- a/Assets/Scripts/Gameplay/Combat/ElementTypeColors.cs
+++ b/Assets/Scripts/Gameplay/Combat/ElementTypeColors.cs
@@ -1,0 +1,87 @@
+using UnityEngine;
+
+namespace RoguelikeCardBattler.Gameplay.Combat
+{
+    /// <summary>
+    /// Fuente única de verdad del color de cada tipo elemental (slot C8 de la
+    /// auditoría de arte). Los 6 tipos son placeholders POR color
+    /// (Rojo/Amarillo/Azul/Morado/Negro/Blanco), así que la UI puede pintar
+    /// botones y labels de tipo sin necesidad de arte/IA. Cualquier sitio que
+    /// muestre un <see cref="ElementType"/> debe tomar su color de acá para que el
+    /// día que se renombren a tipos finales haya un solo lugar que tocar.
+    /// </summary>
+    public static class ElementTypeColors
+    {
+        // Paleta crayón: saturada pero no neón, coherente con la estética handmade.
+        // Negro/Blanco son los extremos reales del tipo (se corrigen por contraste
+        // en ReadableOnDark / ReadableTextOn según dónde se usen).
+        private static readonly Color Rojo = new Color(0.82f, 0.22f, 0.18f, 1f);
+        private static readonly Color Amarillo = new Color(0.95f, 0.80f, 0.25f, 1f);
+        private static readonly Color Azul = new Color(0.27f, 0.50f, 0.85f, 1f);
+        private static readonly Color Morado = new Color(0.60f, 0.35f, 0.72f, 1f);
+        private static readonly Color Negro = new Color(0.18f, 0.18f, 0.20f, 1f);
+        private static readonly Color Blanco = new Color(0.92f, 0.92f, 0.88f, 1f);
+        private static readonly Color Neutro = new Color(0.55f, 0.55f, 0.55f, 1f);
+
+        // Tintas de texto para máximo contraste sobre un fondo coloreado.
+        private static readonly Color DarkInk = new Color(0.12f, 0.10f, 0.10f, 1f);
+        private static readonly Color LightInk = Color.white;
+
+        // Piso de luminancia para texto coloreado sobre fondos oscuros (HUD/cartas):
+        // por debajo, el color se levanta hacia blanco para no perderse (ej. Negro).
+        private const float MinLuminanceOnDark = 0.45f;
+        // Umbral para decidir tinta oscura vs clara sobre un fondo dado.
+        private const float DarkTextThreshold = 0.55f;
+
+        /// <summary>Color canónico del tipo. None devuelve un gris neutro.</summary>
+        public static Color For(ElementType type) => type switch
+        {
+            ElementType.Rojo => Rojo,
+            ElementType.Amarillo => Amarillo,
+            ElementType.Azul => Azul,
+            ElementType.Morado => Morado,
+            ElementType.Negro => Negro,
+            ElementType.Blanco => Blanco,
+            _ => Neutro
+        };
+
+        /// <summary>
+        /// Variante del color del tipo pensada para TEXTO coloreado sobre fondos
+        /// oscuros (labels del HUD, prefijo de tipo en las cartas). Levanta los
+        /// colores oscuros hacia blanco hasta superar un piso de luminancia para
+        /// que Negro (y rojos profundos) sigan siendo legibles.
+        /// </summary>
+        public static Color ReadableOnDark(ElementType type)
+        {
+            Color c = For(type);
+            float lum = Luminance(c);
+            if (lum < MinLuminanceOnDark)
+            {
+                // t crece cuanto más oscuro es el color; clamp evita división por ~0.
+                float t = (MinLuminanceOnDark - lum) / Mathf.Max(0.01f, 1f - lum);
+                c = Color.Lerp(c, Color.white, Mathf.Clamp01(t));
+            }
+            return c;
+        }
+
+        /// <summary>
+        /// Tinta de texto (oscura o blanca) que mejor contrasta sobre el fondo dado.
+        /// Para labels dentro de botones tintados con <see cref="For"/>.
+        /// </summary>
+        public static Color ReadableTextOn(Color background) =>
+            Luminance(background) > DarkTextThreshold ? DarkInk : LightInk;
+
+        /// <summary>
+        /// Atenúa un color preservando su alpha (para estados deshabilitados que
+        /// igual deben dejar leer de qué tipo se trata).
+        /// </summary>
+        public static Color Dim(Color color, float factor)
+        {
+            factor = Mathf.Clamp01(factor);
+            return new Color(color.r * factor, color.g * factor, color.b * factor, color.a);
+        }
+
+        // Luminancia perceptual (Rec. 601) — suficiente para decisiones de contraste.
+        private static float Luminance(Color c) => 0.299f * c.r + 0.587f * c.g + 0.114f * c.b;
+    }
+}

--- a/Assets/Scripts/Gameplay/Combat/ElementTypeColors.cs.meta
+++ b/Assets/Scripts/Gameplay/Combat/ElementTypeColors.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: de9d6483d4c7d4649a836b356f12c909

--- a/Assets/Scripts/Run/NewRun/NewRunController.cs
+++ b/Assets/Scripts/Run/NewRun/NewRunController.cs
@@ -225,9 +225,29 @@ namespace RoguelikeCardBattler.Run.NewRun
 
                 Button btn = CreateButtonAnchored(_typesPanel, $"{name}_{type}", type.ToString(),
                     xMin, yMin, xMax, yMax, !disabledByOther);
+
+                // Tinte por tipo (C8): cada tipo elemental ES un color → el botón lo
+                // refleja. El dorado se reserva para "elegido" (afordancia ya usada en
+                // el draft); deshabilitado = color del tipo atenuado pero aún legible.
                 if (isSelected)
                 {
                     btn.image.color = SelectedTint;
+                }
+                else if (disabledByOther)
+                {
+                    btn.image.color = ElementTypeColors.Dim(ElementTypeColors.For(type), 0.4f);
+                }
+                else
+                {
+                    btn.image.color = ElementTypeColors.For(type);
+                }
+
+                // El texto se adapta para contrastar sobre el fondo tintado
+                // (negro sobre amarillo/blanco, blanco sobre azul/rojo/etc.).
+                Text btnLabel = btn.GetComponentInChildren<Text>();
+                if (btnLabel != null)
+                {
+                    btnLabel.color = ElementTypeColors.ReadableTextOn(btn.image.color);
                 }
 
                 if (!disabledByOther)

--- a/Assets/Tests/EditMode/ElementTypeColorsTests.cs
+++ b/Assets/Tests/EditMode/ElementTypeColorsTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using RoguelikeCardBattler.Gameplay.Combat;
+
+namespace RoguelikeCardBattler.Tests.EditMode
+{
+    /// <summary>
+    /// Blinda el helper de tinte por tipo (C8): fuente única de verdad
+    /// ElementType→Color. Verifica que cada tipo tiene color distinto, que None es
+    /// neutro, que el texto contrasta sobre el fondo, y que ReadableOnDark levanta
+    /// los colores oscuros (Negro) para que sigan siendo legibles.
+    /// </summary>
+    public class ElementTypeColorsTests
+    {
+        private static readonly ElementType[] ColoredTypes =
+        {
+            ElementType.Rojo, ElementType.Amarillo, ElementType.Azul,
+            ElementType.Morado, ElementType.Negro, ElementType.Blanco
+        };
+
+        private static float Luminance(Color c) => 0.299f * c.r + 0.587f * c.g + 0.114f * c.b;
+
+        [Test]
+        public void For_EveryEnumValue_ReturnsOpaqueColor()
+        {
+            foreach (ElementType type in Enum.GetValues(typeof(ElementType)))
+            {
+                Color c = ElementTypeColors.For(type);
+                Assert.AreEqual(1f, c.a, 1e-4f, $"{type} debe ser opaco");
+            }
+        }
+
+        [Test]
+        public void For_SixTypes_AreAllDistinct()
+        {
+            var seen = new HashSet<Color>();
+            foreach (ElementType type in ColoredTypes)
+            {
+                Assert.IsTrue(seen.Add(ElementTypeColors.For(type)),
+                    $"El color de {type} está duplicado con otro tipo");
+            }
+        }
+
+        [Test]
+        public void ReadableTextOn_LightBackground_IsDark_And_DarkBackground_IsLight()
+        {
+            // Amarillo y Blanco son fondos claros → texto oscuro.
+            Assert.Less(Luminance(ElementTypeColors.ReadableTextOn(ElementTypeColors.For(ElementType.Amarillo))), 0.5f);
+            Assert.Less(Luminance(ElementTypeColors.ReadableTextOn(ElementTypeColors.For(ElementType.Blanco))), 0.5f);
+            // Azul y Negro son fondos oscuros → texto claro.
+            Assert.Greater(Luminance(ElementTypeColors.ReadableTextOn(ElementTypeColors.For(ElementType.Azul))), 0.5f);
+            Assert.Greater(Luminance(ElementTypeColors.ReadableTextOn(ElementTypeColors.For(ElementType.Negro))), 0.5f);
+        }
+
+        [Test]
+        public void ReadableOnDark_LiftsDarkTypes_AboveVisibilityFloor()
+        {
+            // Negro de fondo se pierde sobre un HUD oscuro; ReadableOnDark lo levanta.
+            float negroRaw = Luminance(ElementTypeColors.For(ElementType.Negro));
+            float negroOnDark = Luminance(ElementTypeColors.ReadableOnDark(ElementType.Negro));
+            Assert.Greater(negroOnDark, negroRaw, "Negro debería levantarse para ser legible sobre oscuro");
+            Assert.GreaterOrEqual(negroOnDark, 0.44f);
+        }
+
+        [Test]
+        public void ReadableOnDark_KeepsBrightTypesEssentiallyUnchanged()
+        {
+            // Amarillo ya es brillante: no debe alterarse (sigue por encima del piso).
+            Color raw = ElementTypeColors.For(ElementType.Amarillo);
+            Color onDark = ElementTypeColors.ReadableOnDark(ElementType.Amarillo);
+            Assert.AreEqual(raw.r, onDark.r, 1e-4f);
+            Assert.AreEqual(raw.g, onDark.g, 1e-4f);
+            Assert.AreEqual(raw.b, onDark.b, 1e-4f);
+        }
+
+        [Test]
+        public void Dim_PreservesAlpha_AndDarkens()
+        {
+            Color dimmed = ElementTypeColors.Dim(ElementTypeColors.For(ElementType.Rojo), 0.4f);
+            Color raw = ElementTypeColors.For(ElementType.Rojo);
+            Assert.AreEqual(raw.a, dimmed.a, 1e-4f, "Dim debe preservar el alpha");
+            Assert.Less(Luminance(dimmed), Luminance(raw), "Dim debe oscurecer");
+        }
+    }
+}

--- a/Assets/Tests/EditMode/ElementTypeColorsTests.cs.meta
+++ b/Assets/Tests/EditMode/ElementTypeColorsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3c87aa10c1f31604ba19ea7e3f526e07

--- a/Docs/dev/_tech_snapshot.md
+++ b/Docs/dev/_tech_snapshot.md
@@ -7,7 +7,23 @@
 > En `modo:implementacion` se lee OBLIGATORIAMENTE antes de cualquier cambio que
 > afecte arquitectura o componentes críticos.
 >
-> **Última actualización:** 2026-06-05 — M3 Sub-PR 3F (Mapa horizontal) **implementado
+> **Última actualización:** 2026-06-05 — **Auditoría de arte, slot C8 (tinte por tipo
+> elemental, solo código, sin IA)** en branch `feat/element-type-color-tint`. Nuevo
+> `Assets/Scripts/Gameplay/Combat/ElementTypeColors.cs`: fuente única de verdad
+> `ElementType→Color` (los 6 tipos son placeholders por color). API: `For(type)`
+> (color canónico), `ReadableOnDark(type)` (levanta colores oscuros como Negro para
+> texto legible sobre fondos oscuros), `ReadableTextOn(bg)` (tinta negra/blanca por
+> luminancia), `Dim(color,factor)` (atenúa preservando alpha). Aplicado en 3 sitios
+> de presentación (sin tocar lógica): `NewRunController.BuildTypeColumn` (fondo de los
+> botones de tipo tintado por color + texto contrastado; dorado se reserva para
+> "elegido", deshabilitado = color atenuado), `CombatHudView.Sync` (labels de tipo del
+> jugador y del enemigo tintados), `CardHandView.BuildCardLabel` (prefijo `[Tipo]` de
+> la carta coloreado vía rich text). Nuevo `Assets/Tests/EditMode/ElementTypeColorsTests.cs`
+> (6 casos: opacidad, colores distintos por tipo, contraste de texto, levante de Negro
+> sobre oscuro, brillantes intactos, Dim preserva alpha). **Validado:** compilación
+> limpia, EditMode **137/137** (131 previos + 6 nuevos). Cubre C8 de `ART_NEEDS.md`.
+>
+> **Última actualización previa:** 2026-06-05 — M3 Sub-PR 3F (Mapa horizontal) **implementado
 > y validado en Unity** en branch `feat/m3-sub-f-horizontal-map`. **Cierra M3.**
 > Refactor de UX puro del mapa del run: scroll vertical → **scroll horizontal
 > izquierda→derecha** (DD-005, start a la izquierda / boss a la derecha). El eje vive
@@ -295,6 +311,7 @@ Gameplay/
     EnemyCombatActor.cs
     ICombatActor.cs, IGameAction.cs, ActionContext.cs
     ElementTypes.cs              ← 7 tipos + matriz de efectividad
+    ElementTypeColors.cs         ← C8: fuente única de verdad ElementType→Color (tinte UI)
     SpriteFrameAnimatorUI.cs
     CombatUIController.cs        ← 710 loc (era 1473)
     CombatFeedbackView.cs        ← 357 loc (extraído en Fase 1)
@@ -355,7 +372,7 @@ RelicSoGenerator.cs                   ← MenuItem "Roguelike/Generate Relic Ass
                                         (idempotente — saltea archivos existentes)
 ```
 
-### Tests (`Assets/Tests/EditMode/`) — 15 archivos (suite EditMode 131/131)
+### Tests (`Assets/Tests/EditMode/`) — 16 archivos (suite EditMode 137/137)
 
 ```
 CombatTestBase.cs                ← helper compartido
@@ -377,6 +394,9 @@ NewRunTests.cs                   ← M3 Sub-PR 3E (8 casos: draft/dual/tipos)
 RunMapGeneratorTests.cs          ← M3 Sub-PR 3F (5 casos: determinismo topología/
                                    enemigos, divergencia por seed, DAG válido,
                                    start/end forzados — blinda el refactor horizontal)
+ElementTypeColorsTests.cs        ← Auditoría de arte C8 (6 casos: tinte por tipo —
+                                   colores distintos, contraste de texto, levante de
+                                   Negro sobre oscuro, Dim preserva alpha)
 ```
 
 ### ScriptableObjects (`Assets/ScriptableObjects/`)


### PR DESCRIPTION
## Qué

Slot **C8** de la auditoría de arte (`Docs/design/ART_NEEDS.md`): **tinte por tipo elemental, solo código, sin arte/IA**. Los 6 tipos son placeholders por color (Rojo/Amarillo/Azul/Morado/Negro/Blanco), así que la UI puede pintarlos sin esperar arte.

## Cambios

- **Nuevo `ElementTypeColors`** — fuente única de verdad `ElementType→Color`:
  - `For(type)` color canónico · `ReadableOnDark(type)` levanta colores oscuros (Negro) para texto legible sobre fondos oscuros · `ReadableTextOn(bg)` tinta negra/blanca por luminancia · `Dim(color,factor)` atenúa preservando alpha.
- **`NewRunController.BuildTypeColumn`** — fondo de los botones de tipo tintado por color + texto contrastado. El dorado se reserva para "elegido"; deshabilitado = color del tipo atenuado pero legible.
- **`CombatHudView.Sync`** — labels de tipo del jugador y del enemigo tintados.
- **`CardHandView.BuildCardLabel`** — prefijo `[Tipo]` de la carta coloreado vía rich text.

Solo presentación: no toca lógica de combate ni archivos protegidos.

## Validación

- Compilación limpia (zero console errors).
- EditMode **137/137** (131 previos + 6 nuevos en `ElementTypeColorsTests`).
- Diff acotado: sin `.claude/settings.json` ni `.slnx` (de-scopeados). Docs de la auditoría de arte (`ART_NEEDS.md`/`ART_PROMPTS.md`) quedan fuera de este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)