### PR TITLE
docs(art): auditoría de arte post-M3 (ART_NEEDS + ART_PROMPTS)

### DIFF
--- a/Docs/design/ART_NEEDS.md
+++ b/Docs/design/ART_NEEDS.md
@@ -1,0 +1,195 @@
+# ART_NEEDS.md — Auditoría de arte (placeholders IA)
+
+> **Qué es este archivo:** doc vivo que recoge TODO lugar del juego que consume o
+> debería consumir un sprite, su estado actual, y si el código ya lo soporta. Es el
+> checklist de integración de arte para ambos devs. Generado en la auditoría de
+> arte post-M3 (2026-06-05, `modo:diseno`).
+>
+> **No es arte final.** Todo lo marcado `placeholder-IA` se cubre con imágenes
+> generadas por IA como puente. El arte definitivo llegará después; estos son
+> stand-ins para ver las pantallas vestidas.
+>
+> **Flujo del plan:** Fase 1 (esta auditoría) → Fase 2 (estilo madre, abajo) →
+> Fase 3 (prompts por asset, sesión siguiente) → Fase 4 (import + asignar a SOs).
+
+---
+
+## Cómo leer la tabla
+
+- **Estado actual** — qué se ve hoy en pantalla sin arte nuevo.
+- **¿Código ya lo soporta?** — la distinción clave del plan:
+  - ✅ **Drop-in**: el gancho (campo de sprite en el SO o lista en el componente)
+    ya existe. Generar el arte → asignar → listo. Sin tocar código.
+  - 🔶 **Mixto**: falta código ANTES de poder usar el arte (campo nuevo en un SO,
+    render nuevo en una vista). El arte por sí solo no entra.
+  - 🎨 **Solo arte / solo código**: casos especiales anotados en la fila.
+- **Prioridad** — P1 (impacto visual alto, barato) · P2 (medio) · P3 (pulido / post).
+- **Marca** — `placeholder-IA` = se genera con IA en Fase 3.
+
+---
+
+## Hallazgo de la auditoría (leer primero)
+
+El barrido reveló que **el patrón placeholder-first de 3C/3D ya dejó mucho arte
+asignado**. El panorama real es más chico de lo que asumía el plan:
+
+**Ya tiene placeholder asignado en su SO (✅ no requiere acción, salvo pulido):**
+
+| Slot | Dónde | Confirmado |
+|------|-------|------------|
+| Fondo de combate parallax (5 capas × Mundo A/B = 10 sprites) | `CombatBackgroundTheme_Act1.asset` | sprites asignados en las 5 `LayerSprites` |
+| Hoguera parallax (cielo / medio / fuego) | `CampfireConfig.asset` | `skySprite` / `midSprite` / `fireSprite` asignados |
+| Tienda parallax (pared / estantería / mostrador) | `ShopConfig.asset` | `wallSprite` / `shelfSprite` / `counterSprite` asignados |
+| Íconos de Retazos (23) | `RelicDefinition.Icon` | 23 PNG en `Assets/Art/Relics/Icons/` |
+| Animación del héroe (Mundo A: idle + 14 frames de ataque) | `CombatUIController.heroIdleFrames` / `heroAttackFrames` | PNGs en `Assets/Art/Sprites/Hero/A/` |
+| Avatar del Slime (Mundo A idle) | `EnemyDefinition.Avatar` (WeakSlime) | `Assets/Art/Sprites/Enemies/Slime/A/Idle/` |
+
+> Lo de arriba **no se vuelve a generar** en Fase 3 a menos que Sebastián quiera
+> subir la calidad. Lo que sigue es lo que **falta** o **requiere código**.
+
+---
+
+## Tabla de assets faltantes / pendientes
+
+### Combate
+
+| # | Asset | Dónde se usa (archivo/SO) | Estado actual | Proporción / formato | ¿Código lo soporta? | Prioridad | Marca |
+|---|-------|---------------------------|---------------|----------------------|---------------------|-----------|-------|
+| C1 | Avatar enemigo — Goblin | `EnemyDefinition.Avatar` (Goblin.asset) | sin sprite → no se ve avatar | ~512×512, PNG transparente | ✅ Drop-in (campo `avatar`) | P1 | `placeholder-IA` |
+| C2 | Avatar enemigo — SkeletonWarrior | `EnemyDefinition.Avatar` (SkeletonWarrior.asset) | sin sprite | ~512×512, PNG transparente | ✅ Drop-in | P1 | `placeholder-IA` |
+| C3 | Avatar enemigo — DarkMage | `EnemyDefinition.Avatar` (DarkMage.asset) | sin sprite | ~512×512, PNG transparente | ✅ Drop-in | P1 | `placeholder-IA` |
+| C4 | Avatar boss — BossAct1 (UNIT-RB7 / Costura maldita) | `EnemyDefinition.Avatar` (BossAct1.asset) | sin sprite | ~768×768, PNG transparente | ✅ Drop-in **pero** campo es 1 sprite → el boss es dual-mundo (GDD §boss) y hoy NO puede tener avatar A + B distintos sin código. Generar **una** versión por ahora; marcar como deuda. | P1 | `placeholder-IA` |
+| C5 | Animación del héroe — Mundo B (idle + ataque) | `CombatUIController` (listas de frames) | **arte ya existe** en `Hero/B/`, pero el código usa una sola lista de frames (no conmuta héroe por mundo) | frames PNG transparentes, mismo tamaño que A | 🔶 Mixto: arte listo; falta código para swap de frames del héroe en world switch | P2 | (arte existe) |
+| C6 | Frames de "hit" del enemigo (flash de golpe) | `CombatUIController.enemyHitFrames` | lista vacía; sin animación de impacto | frames PNG transparentes | ✅ Drop-in (lista opcional) | P3 | `placeholder-IA` |
+| C7 | Cara de carta (ilustración) | `CardDefinition` + `CardHandView` | **cartas son botones de TEXTO**; sin campo de sprite | ventana de arte vertical, ~512×768 o región interna; PNG | 🔶 **Mixto (tarea grande)**: agregar campo sprite a `CardDefinition` + render en `CardHandView`; recién después entra el arte de cada carta | P1 | `placeholder-IA` |
+| C8 | Tinte por tipo elemental | `CardHandView` (prefijo `[Tipo]`) + HUD (labels de tipo) + NewRunScene (botones de tipo) | ✔ **HECHO** (branch `feat/element-type-color-tint`): helper `ElementTypeColors` (fuente única de verdad) tinta los botones de tipo de NewRunScene, los labels de tipo del HUD (jugador/enemigo) y el prefijo `[Tipo]` de las cartas | — (no es arte) | ✅ **Cerrado** — solo código, sin IA | P1 | (sin arte) |
+
+### Mapa del run
+
+| # | Asset | Dónde se usa | Estado actual | Proporción / formato | ¿Código lo soporta? | Prioridad | Marca |
+|---|-------|--------------|---------------|----------------------|---------------------|-----------|-------|
+| M1 | Íconos de nodo por tipo (Combate / Élite / Tienda / Hoguera / Boss) | `RunMapNodeView` | nodos = recuadro de color + texto; `_bgImage` usa whiteSprite | íconos cuadrados ~128×128, PNG transparente | 🔶 Mixto: agregar sprite-por-tipo en `RunMapNodeView` (hoy sólo tinta color) | P2 | `placeholder-IA` |
+| M2 | Fondo del mapa (horizontal) | `RunFlowController._mapPanel` | panel transparente (color 0,0,0,0); fondo vacío | banda ancha horizontal (scroll izq→der), p.ej. 3000×1080, tileable horizontal | 🔶 Mixto: agregar Image de fondo al `_mapPanel` (+ posible campo de config) | P2 | `placeholder-IA` |
+
+### Tienda
+
+| # | Asset | Dónde se usa | Estado actual | Proporción / formato | ¿Código lo soporta? | Prioridad | Marca |
+|---|-------|--------------|---------------|----------------------|---------------------|-----------|-------|
+| S1 | Vendedor / personaje de la tienda | `ShopConfig` (no existe campo) | sin vendedor; sólo parallax de fondo | personaje, ~512×768, PNG transparente | 🔶 Mixto: agregar `vendorSprite` a `ShopConfig` + render en `ShopNodeController` | P2 | `placeholder-IA` |
+
+### NewRunScene (arranque de run)
+
+| # | Asset | Dónde se usa | Estado actual | Proporción / formato | ¿Código lo soporta? | Prioridad | Marca |
+|---|-------|--------------|---------------|----------------------|---------------------|-----------|-------|
+| N1 | Fondo de la pantalla de arranque | `NewRunConfig` (no existe campo) / `NewRunController` | UI runtime sobre fondo liso | 16:9, 1920×1080, PNG/JPG | 🔶 Mixto: agregar campo bg a `NewRunConfig` + render (o reusar un fondo genérico) | P2 | `placeholder-IA` |
+| N2 | Caras de carta del draft | `NewRunController` (usa `CardDefinition` de `draftFaces`) | botones de texto (igual que combate) | depende de C7 | 🔶 Mixto: **bloqueado por C7** (sprite en `CardDefinition`) | P2 | `placeholder-IA` |
+
+### HUD (combate y mapa)
+
+| # | Asset | Dónde se usa | Estado actual | Proporción / formato | ¿Código lo soporta? | Prioridad | Marca |
+|---|-------|--------------|---------------|----------------------|---------------------|-----------|-------|
+| H1 | Íconos de HUD (energía / oro / bloqueo / intent) | `CombatHudView` / `CardHandView` / `RunFlowController` (status) | todo texto | ~64×64, PNG transparente | 🔶 Mixto: render de Image junto a cada label | P3 | `placeholder-IA` |
+
+---
+
+## Resumen: drop-in vs dependiente de código
+
+**Total de slots pendientes catalogados: 13** (C1–C8, M1–M2, S1, N1–N2, H1).
+
+- ✅ **Drop-in puro (genera → asigna, sin código): 4**
+  → C1, C2, C3 (avatares Goblin/Skeleton/DarkMage), C6 (hit frames enemigo).
+  → C4 (avatar boss) es drop-in técnicamente pero con la deuda de "1 solo sprite
+    para un boss dual-mundo".
+- 🔶 **Mixto (requiere código antes del arte): 8**
+  → C5 (héroe Mundo B — arte ya existe, falta swap), C7 (cara de carta — la grande),
+    M1 (íconos de nodo), M2 (fondo de mapa), S1 (vendedor), N1 (fondo NewRun),
+    N2 (caras de draft, bloqueado por C7), H1 (íconos de HUD).
+- 🔶 **Solo código, sin arte: 1**
+  → C8 (tinte por tipo elemental) — ganancia barata, no necesita IA.
+
+**Dependencia crítica (la que ordena todo):** **C7** (sprite en `CardDefinition` +
+render en `CardHandView`). Desbloquea las cartas de combate Y las caras de draft de
+NewRun (N2). Es la pieza de código más grande de toda la integración de arte.
+
+---
+
+## Propuesta de prioridad para la sesión de prompts (Fase 3)
+
+Ordenada por **impacto visual / costo**:
+
+1. **Avatares de enemigos (C1–C4)** — drop-in puro, 4 prompts, llenan el combate
+   de golpe. Empezar acá: máximo retorno, cero código.
+2. **Tinte por tipo (C8)** — no necesita prompt; es un mini-tarea de código que
+   puede ir en el primer PR de arte. Anotar para `modo:implementacion`.
+3. **Cara de carta (C7)** — definir el PR de código primero (campo + render); el
+   prompt de "ilustración de carta" se diseña en paralelo pero no se asigna hasta
+   tener el campo.
+4. **Mapa (M1 íconos de nodo, M2 fondo)** y **Tienda (S1 vendedor)** — prompts +
+   PRs de código chicos.
+5. **NewRun (N1 fondo, N2 caras)** — N1 independiente; N2 espera a C7.
+6. **Pulido (C5 héroe Mundo B, C6 hit frames, H1 íconos HUD)** — P3, al final.
+
+> Nota: lo ya asignado (fondos de combate, Hoguera, Tienda parallax, Retazos, héroe
+> A, Slime) se puede re-generar en Fase 3 SÓLO si se quiere subir calidad — no es
+> bloqueante para vestir las pantallas que hoy están desnudas.
+
+---
+
+## Fase 2 — Estilo madre (bloque reutilizable para todos los prompts)
+
+> Este bloque se **pega al inicio de cada prompt** de Fase 3 para garantizar
+> coherencia visual entre todos los assets. Define la estética base (handmade de los
+> dos hermanos) y las dos variantes de mundo. Abajo, en inglés (los generadores de
+> imágenes responden mejor), con notas en español.
+
+### Bloque base (pegar siempre)
+
+```
+STYLE: Childlike handmade arts-and-crafts aesthetic — as if drawn and built by two
+kids from cardboard, wax crayons, cut-out paper, magazine clippings, school glue and
+sticky tape. Visible crayon strokes, uneven hand-cut paper edges, cardboard texture,
+slightly wonky proportions, warm imperfect lines. Flat 2D, storybook/diorama feel.
+Everything looks like a physical scrap pinned into a kids' imaginary world.
+NOT digital-clean, NOT vector-smooth, NOT photorealistic, NO gradients-heavy 3D.
+```
+
+### Variante Mundo A — Medieval Oscuro (pegar para assets de Mundo A)
+
+```
+WORLD A — DARK MEDIEVAL: gloomy fairy-tale medieval theme rendered in the same
+crayon-and-cardboard craft style. Muted earthy palette — deep browns, charcoal,
+dried-blood reds, candle-amber highlights. Castles, torn banners, rusty armor,
+stitched cloth monsters, torchlight. Spooky but still handmade and toy-like, never
+gory-realistic.
+```
+
+### Variante Mundo B — Cyberpunk / Futurista (pegar para assets de Mundo B)
+
+```
+WORLD B — CYBERPUNK: neon-soaked futuristic theme rendered in the SAME crayon-and-
+cardboard craft style. Palette — electric cyan, magenta, violet, acid green over
+dark base; "neon" drawn as glowing crayon scribbles, circuits as taped foil and
+marker lines, robots built from cardboard boxes and bottle caps. High-tech subjects
+made of craft materials, never sleek digital chrome.
+```
+
+### Restricciones técnicas (anexar según el slot en Fase 3)
+
+- **Transparencia:** avatares, vendedor, íconos, caras de personaje → fondo
+  transparente (PNG con alpha). Fondos de escena → sin alpha.
+- **Aspect ratio del slot:** respetar la columna "Proporción / formato" de la tabla.
+- **Parallax / fondos de mapa:** tileable en horizontal cuando aplica (mapa, capas).
+- **Íconos:** legibles a tamaño chico, silueta clara, un solo sujeto centrado.
+- **Cartas (C7):** ilustración pensada para una ventana vertical dentro del marco de
+  la carta, no una escena de página completa.
+
+---
+
+## Mantenimiento
+
+- Cuando un slot se cubre (arte generado + asignado al SO), marcarlo aquí (✔) o
+  moverlo a la tabla de "ya tiene placeholder".
+- Cuando se cierra una tarea de código mixta (ej. C7), actualizar la columna
+  "¿Código lo soporta?" a ✅ Drop-in.
+- Las decisiones de diseño cerradas que afecten arte (paleta, estilo) viven acá;
+  cambios de fondo se discuten con Sebastián.

--- a/Docs/design/ART_PROMPTS.md
+++ b/Docs/design/ART_PROMPTS.md
@@ -22,7 +22,12 @@
 2. Pegalo tal cual en la IA generadora. Cada bloque ya trae: estilo madre + variante
    de mundo correcta + sujeto + restricciones técnicas (tamaño, transparencia).
 3. Generá; elegí la mejor variante; exportá PNG con alpha.
-4. Importá a Unity y asigná según la **nota de asignación (Fase 4)** de cada slot.
+4. Guardá el archivo con el **nombre y la ruta exactos** que indica el campo
+   **`📁 Guardar el PNG como:`** de cada slot. **Las carpetas destino ya están
+   creadas en el proyecto** (`Assets/Art/Sprites/Enemies/<Enemigo>/A/Idle/` y
+   `.../Common/Hit/`) → solo tenés que copiar el PNG ahí.
+5. En Unity: refrescá (el asset se importa), confirmá import como **Sprite (2D and UI
+   / Single)**, y asigná según la **nota de asignación (Fase 4)** de cada slot.
 
 **Contexto técnico común (verificado contra código):**
 - `[INTERPRETACIÓN]` El avatar de enemigo se renderiza con `preserveAspect = true`
@@ -72,8 +77,11 @@ the screen). TRANSPARENT background (PNG with alpha, no scene, no ground). Squar
 composition, target 512x512 px. Clean silhouette readable at small size.
 ```
 
+**📁 Guardar el PNG como:** `Assets/Art/Sprites/Enemies/Goblin/A/Idle/personaje_goblin.png`
+— la carpeta **ya está creada** en el proyecto.
+
 **Nota de asignación (Fase 4):** importar como Sprite (2D and UI / Single, alpha
-transparente) en `Assets/Art/Sprites/Enemies/Goblin/A/Idle/`. Asignar al campo
+transparente). Asignar al campo
 `avatar` de `Assets/ScriptableObjects/Enemies/Goblin.asset`
 (`EnemyDefinition.Avatar`). Hoy `avatar: {fileID: 0}` (vacío). `avatarScale` actual =
 1, `avatarOffset` = (0,0) — ajustar a ojo tras asignar si hace falta.
@@ -110,8 +118,10 @@ the screen). TRANSPARENT background (PNG with alpha, no scene, no ground). Squar
 composition, target 512x512 px. Clean silhouette readable at small size.
 ```
 
-**Nota de asignación (Fase 4):** importar como Sprite en
-`Assets/Art/Sprites/Enemies/SkeletonWarrior/A/Idle/`. Asignar al campo `avatar` de
+**📁 Guardar el PNG como:** `Assets/Art/Sprites/Enemies/SkeletonWarrior/A/Idle/personaje_skeletonwarrior.png`
+— la carpeta **ya está creada** en el proyecto.
+
+**Nota de asignación (Fase 4):** importar como Sprite. Asignar al campo `avatar` de
 `Assets/ScriptableObjects/Enemies/SkeletonWarrior.asset`. Hoy vacío.
 
 ---
@@ -146,8 +156,10 @@ the screen). TRANSPARENT background (PNG with alpha, no scene, no ground). Squar
 composition, target 512x512 px. Clean silhouette readable at small size.
 ```
 
-**Nota de asignación (Fase 4):** importar como Sprite en
-`Assets/Art/Sprites/Enemies/DarkMage/A/Idle/`. Asignar al campo `avatar` de
+**📁 Guardar el PNG como:** `Assets/Art/Sprites/Enemies/DarkMage/A/Idle/personaje_darkmage.png`
+— la carpeta **ya está creada** en el proyecto.
+
+**Nota de asignación (Fase 4):** importar como Sprite. Asignar al campo `avatar` de
 `Assets/ScriptableObjects/Enemies/DarkMage.asset`. Hoy vacío.
 
 ---
@@ -199,8 +211,10 @@ composition, target 768x768 px (larger than regular enemies — it is a boss). C
 silhouette readable at small size.
 ```
 
-**Nota de asignación (Fase 4):** importar como Sprite en
-`Assets/Art/Sprites/Enemies/BossAct1/A/Idle/`. Asignar al campo `avatar` de
+**📁 Guardar el PNG como:** `Assets/Art/Sprites/Enemies/BossAct1/A/Idle/personaje_bossact1.png`
+— la carpeta **ya está creada** en el proyecto.
+
+**Nota de asignación (Fase 4):** importar como Sprite. Asignar al campo `avatar` de
 `Assets/ScriptableObjects/Enemies/BossAct1.asset`. Hoy vacío. `avatarScale` actual =
 1.2, `avatarOffset` = (0,-30).
 
@@ -256,8 +270,11 @@ margin. Square 1:1 composition, target 512x512 px per frame (matches the enemy a
 frame so it overlays correctly). Deliver as 4 separate transparent PNGs.
 ```
 
-**Nota de asignación (Fase 4):** importar los 4 PNGs como Sprites en
-`Assets/Art/Sprites/Enemies/Common/Hit/` (carpeta nueva compartida). Asignarlos **en
+**📁 Guardar los 4 PNGs como:** en `Assets/Art/Sprites/Enemies/Common/Hit/`
+(carpeta **ya creada**), nombrados **en orden**: `hit_1.png`, `hit_2.png`,
+`hit_3.png`, `hit_4.png` (frame 1 = chispa → frame 4 = remanente).
+
+**Nota de asignación (Fase 4):** importar los 4 PNGs como Sprites. Asignarlos **en
 orden** a la lista `enemyHitFrames` del componente `CombatUIController` (lista
 `[SerializeField]`, misma forma en que hoy se asignan los frames del héroe — no es
 setup nuevo, es el patrón de frames existente). `enemyHitFps` actual = 16.

--- a/Docs/design/ART_PROMPTS.md
+++ b/Docs/design/ART_PROMPTS.md
@@ -1,0 +1,288 @@
+# ART_PROMPTS.md — Prompts de IA para placeholders (Fase 3)
+
+> **Qué es este archivo:** prompts paste-ready (en inglés) para generar los
+> placeholders de arte con una IA generadora de imágenes. Doc dedicado y separado de
+> [ART_NEEDS.md](ART_NEEDS.md) porque estos prompts se copian/pegan repetido — el
+> catálogo de slots y el estilo madre viven allá; acá vive el texto final listo para
+> pegar.
+>
+> **Generado:** Fase 3 del plan de auditoría de arte, `modo:diseno` (2026-06-05).
+> **Alcance de esta sesión:** SOLO el lote **drop-in** (cero código): C1, C2, C3, C6
+> y C4 (con deuda anotada). Los slots mixtos (C5, C7, C8, M1, M2, S1, N1, N2, H1) NO
+> se prompean acá todavía — necesitan código antes.
+>
+> **No es arte final.** Todo lo generado acá es placeholder-IA: stand-in para vestir
+> las pantallas hasta que llegue el arte definitivo.
+
+---
+
+## Cómo usar este doc
+
+1. Copiá el bloque ` ``` ` completo de la sección del slot que vas a generar.
+2. Pegalo tal cual en la IA generadora. Cada bloque ya trae: estilo madre + variante
+   de mundo correcta + sujeto + restricciones técnicas (tamaño, transparencia).
+3. Generá; elegí la mejor variante; exportá PNG con alpha.
+4. Importá a Unity y asigná según la **nota de asignación (Fase 4)** de cada slot.
+
+**Contexto técnico común (verificado contra código):**
+- `[INTERPRETACIÓN]` El avatar de enemigo se renderiza con `preserveAspect = true`
+  dentro de un box cuadrado del HUD ([CombatUIController.cs:563-595](../../Assets/Scripts/Gameplay/Combat/CombatUIController.cs#L563-L595)).
+  Por eso el formato correcto es **cuadrado 1:1** con el sujeto centrado y aire
+  alrededor — un PNG cuadrado encaja sin deformarse. El Slime de referencia
+  (`Enemies/Slime/A/Idle/personaje_slime.png`, escala 0.85) confirma que esto
+  funciona.
+- `[GDD]` (línea 57): Mundo A = **Medieval Oscuro**, Mundo B = **Cyberpunk/Futurista**.
+  Goblin, SkeletonWarrior y DarkMage son sujetos de fantasía medieval y su único
+  sprite vive en la convención `.../A/Idle/` igual que el Slime → **todos son Mundo A
+  (Medieval Oscuro)** en su placeholder actual.
+- `[INTERPRETACIÓN]` Los 4 enemigos tienen `elementType: 3` (= **Azul**, ver
+  [ElementTypes.cs](../../Assets/Scripts/Gameplay/Combat/ElementTypes.cs)). Es un
+  acento opcional: un detalle azul/cian de crayón puede tejerse en cada criatura sin
+  romper la paleta medieval. No es obligatorio para el placeholder.
+
+---
+
+## C1 — Avatar enemigo: Goblin (Mundo A)
+
+**Prompt paste-ready:**
+
+```
+STYLE: Childlike handmade arts-and-crafts aesthetic — as if drawn and built by two
+kids from cardboard, wax crayons, cut-out paper, magazine clippings, school glue and
+sticky tape. Visible crayon strokes, uneven hand-cut paper edges, cardboard texture,
+slightly wonky proportions, warm imperfect lines. Flat 2D, storybook/diorama feel.
+Everything looks like a physical scrap pinned into a kids' imaginary world.
+NOT digital-clean, NOT vector-smooth, NOT photorealistic, NO gradients-heavy 3D.
+
+WORLD A — DARK MEDIEVAL: gloomy fairy-tale medieval theme rendered in the same
+crayon-and-cardboard craft style. Muted earthy palette — deep browns, charcoal,
+dried-blood reds, candle-amber highlights. Castles, torn banners, rusty armor,
+stitched cloth monsters, torchlight. Spooky but still handmade and toy-like, never
+gory-realistic.
+
+SUBJECT: a small mischievous GOBLIN — scrawny green creature with big pointy ears, a
+crooked toothy grin, holding a tiny rusty dagger or jagged knife. Hunched, wiry,
+cheeky-menacing but toy-like. A weak, common dungeon minion. Optional subtle
+blue/cyan crayon accent woven into the goblin (it is an "Azul"-type enemy) without
+overriding the medieval palette.
+
+TECHNICAL: single character, full body head-to-toe, centered with generous empty
+margin all around. Facing slightly LEFT (it faces the hero, who stands on the left of
+the screen). TRANSPARENT background (PNG with alpha, no scene, no ground). Square 1:1
+composition, target 512x512 px. Clean silhouette readable at small size.
+```
+
+**Nota de asignación (Fase 4):** importar como Sprite (2D and UI / Single, alpha
+transparente) en `Assets/Art/Sprites/Enemies/Goblin/A/Idle/`. Asignar al campo
+`avatar` de `Assets/ScriptableObjects/Enemies/Goblin.asset`
+(`EnemyDefinition.Avatar`). Hoy `avatar: {fileID: 0}` (vacío). `avatarScale` actual =
+1, `avatarOffset` = (0,0) — ajustar a ojo tras asignar si hace falta.
+
+---
+
+## C2 — Avatar enemigo: SkeletonWarrior (Mundo A)
+
+**Prompt paste-ready:**
+
+```
+STYLE: Childlike handmade arts-and-crafts aesthetic — as if drawn and built by two
+kids from cardboard, wax crayons, cut-out paper, magazine clippings, school glue and
+sticky tape. Visible crayon strokes, uneven hand-cut paper edges, cardboard texture,
+slightly wonky proportions, warm imperfect lines. Flat 2D, storybook/diorama feel.
+Everything looks like a physical scrap pinned into a kids' imaginary world.
+NOT digital-clean, NOT vector-smooth, NOT photorealistic, NO gradients-heavy 3D.
+
+WORLD A — DARK MEDIEVAL: gloomy fairy-tale medieval theme rendered in the same
+crayon-and-cardboard craft style. Muted earthy palette — deep browns, charcoal,
+dried-blood reds, candle-amber highlights. Castles, torn banners, rusty armor,
+stitched cloth monsters, torchlight. Spooky but still handmade and toy-like, never
+gory-realistic.
+
+SUBJECT: a SKELETON WARRIOR — a standing skeleton soldier made of cut-out white/bone
+paper, wearing a dented rusty helmet and holding a chipped sword and a small battered
+shield. Bones drawn as crayon-outlined paper strips, hollow eye sockets, a grim but
+goofy toy-soldier vibe. Optional subtle blue/cyan crayon accent (it is an "Azul"-type
+enemy) without overriding the medieval palette.
+
+TECHNICAL: single character, full body head-to-toe, centered with generous empty
+margin all around. Facing slightly LEFT (it faces the hero, who stands on the left of
+the screen). TRANSPARENT background (PNG with alpha, no scene, no ground). Square 1:1
+composition, target 512x512 px. Clean silhouette readable at small size.
+```
+
+**Nota de asignación (Fase 4):** importar como Sprite en
+`Assets/Art/Sprites/Enemies/SkeletonWarrior/A/Idle/`. Asignar al campo `avatar` de
+`Assets/ScriptableObjects/Enemies/SkeletonWarrior.asset`. Hoy vacío.
+
+---
+
+## C3 — Avatar enemigo: DarkMage (Mundo A)
+
+**Prompt paste-ready:**
+
+```
+STYLE: Childlike handmade arts-and-crafts aesthetic — as if drawn and built by two
+kids from cardboard, wax crayons, cut-out paper, magazine clippings, school glue and
+sticky tape. Visible crayon strokes, uneven hand-cut paper edges, cardboard texture,
+slightly wonky proportions, warm imperfect lines. Flat 2D, storybook/diorama feel.
+Everything looks like a physical scrap pinned into a kids' imaginary world.
+NOT digital-clean, NOT vector-smooth, NOT photorealistic, NO gradients-heavy 3D.
+
+WORLD A — DARK MEDIEVAL: gloomy fairy-tale medieval theme rendered in the same
+crayon-and-cardboard craft style. Muted earthy palette — deep browns, charcoal,
+dried-blood reds, candle-amber highlights. Castles, torn banners, rusty armor,
+stitched cloth monsters, torchlight. Spooky but still handmade and toy-like, never
+gory-realistic.
+
+SUBJECT: a DARK MAGE — a hooded robed sorcerer cut from dark purple and charcoal
+paper, face hidden in shadow under the hood, raising one hand that conjures a small
+crayon-scribbled magic spark. Long tattered robe, crooked wooden staff optional.
+Sinister but storybook, toy-like. The conjured magic spark should read as a
+blue/cyan crayon glow (it is an "Azul"-type enemy) — that accent is welcome here.
+
+TECHNICAL: single character, full body head-to-toe, centered with generous empty
+margin all around. Facing slightly LEFT (it faces the hero, who stands on the left of
+the screen). TRANSPARENT background (PNG with alpha, no scene, no ground). Square 1:1
+composition, target 512x512 px. Clean silhouette readable at small size.
+```
+
+**Nota de asignación (Fase 4):** importar como Sprite en
+`Assets/Art/Sprites/Enemies/DarkMage/A/Idle/`. Asignar al campo `avatar` de
+`Assets/ScriptableObjects/Enemies/DarkMage.asset`. Hoy vacío.
+
+---
+
+## C4 — Avatar boss: BossAct1 (Costura maldita — Mundo A) · ⚠ con deuda conocida
+
+`[GDD]` (línea 57) — el boss es **dual-mundo**:
+- **Mundo A (Medieval): "Costura maldita"** — peluche de paja en forma de conejo,
+  poseído por una maldición; de su pecho sale una mano oscura con la que ataca
+  (inspiración Mimikyu).
+- **Mundo B (Futurista): "UNIT-RB7"** — robot de juguete infectado por un virus de
+  una IA mutada.
+
+`[INTERPRETACIÓN]` `EnemyDefinition.Avatar` es **un solo `Sprite`** — no hay forma de
+guardar A + B distintos sin código. **Decisión ya tomada (no es decisión abierta):**
+generamos **una** versión placeholder ahora — la de **Mundo A (Costura maldita)**,
+para mantener coherencia con el roster del Acto 1 (todos Mundo A) — y dejamos la
+variante B (UNIT-RB7) como **deuda de código** (ver abajo).
+
+**Prompt paste-ready (Mundo A — Costura maldita):**
+
+```
+STYLE: Childlike handmade arts-and-crafts aesthetic — as if drawn and built by two
+kids from cardboard, wax crayons, cut-out paper, magazine clippings, school glue and
+sticky tape. Visible crayon strokes, uneven hand-cut paper edges, cardboard texture,
+slightly wonky proportions, warm imperfect lines. Flat 2D, storybook/diorama feel.
+Everything looks like a physical scrap pinned into a kids' imaginary world.
+NOT digital-clean, NOT vector-smooth, NOT photorealistic, NO gradients-heavy 3D.
+
+WORLD A — DARK MEDIEVAL: gloomy fairy-tale medieval theme rendered in the same
+crayon-and-cardboard craft style. Muted earthy palette — deep browns, charcoal,
+dried-blood reds, candle-amber highlights. Castles, torn banners, rusty armor,
+stitched cloth monsters, torchlight. Spooky but still handmade and toy-like, never
+gory-realistic.
+
+SUBJECT — ACT 1 BOSS "CURSED STITCH" ("Costura maldita"): a cursed handmade
+straw-stuffed RABBIT PLUSHIE, sewn from patchwork burlap and frayed cloth with big
+uneven stitches and loose straw poking out. It looks like a child's toy gone wrong —
+button eyes, a crooked stitched mouth. From a torn seam in its CHEST emerges a
+shadowy dark spectral HAND reaching out to attack (Mimikyu-like menace). Imposing,
+boss-scale, eerie but still toy/craft-made, never gory-realistic. Subtle blue/cyan
+crayon accent allowed (it can roll an "Azul" type) without overriding the medieval
+palette.
+
+TECHNICAL: single character, full body head-to-toe, centered with generous empty
+margin all around. Facing slightly LEFT (it faces the hero, who stands on the left of
+the screen). TRANSPARENT background (PNG with alpha, no scene, no ground). Square 1:1
+composition, target 768x768 px (larger than regular enemies — it is a boss). Clean
+silhouette readable at small size.
+```
+
+**Nota de asignación (Fase 4):** importar como Sprite en
+`Assets/Art/Sprites/Enemies/BossAct1/A/Idle/`. Asignar al campo `avatar` de
+`Assets/ScriptableObjects/Enemies/BossAct1.asset`. Hoy vacío. `avatarScale` actual =
+1.2, `avatarOffset` = (0,-30).
+
+**🔧 Deuda de código registrada (NO es decisión abierta):** para que el boss muestre
+**A (Costura maldita) y B (UNIT-RB7)** distintos según el mundo activo, hace falta un
+PR de código: agregar un segundo campo de avatar (p. ej. `avatarWorldB`) a
+`EnemyDefinition` y conmutarlo en el world-switch (análogo a C5 héroe Mundo B). El
+prompt del UNIT-RB7 (Mundo B / Cyberpunk) se genera **recién después** de ese campo,
+para no producir un PNG sin gancho donde asignarlo. Por ahora: solo el placeholder A.
+
+---
+
+## C6 — Frames de impacto del ENEMIGO (flash de golpe) · genérico, compartido
+
+⚠ **Corrección de slot (verificado en código):** el pedido original decía "hit-frames
+del héroe", pero el único slot de hit vacío es `CombatUIController.enemyHitFrames`
+([CombatUIController.cs:730](../../Assets/Scripts/Gameplay/Combat/CombatUIController.cs#L730)):
+son los frames de impacto del **enemigo**. El héroe ya tiene sus frames
+(`heroIdleFrames`/`heroAttackFrames`, Mundo A asignado) y **no existe** un campo
+`heroHitFrames`. → Este slot se genera para el enemigo.
+
+`[INTERPRETACIÓN]` `enemyHitFrames` es una **lista única en el componente**, NO por
+`EnemyDefinition`. El animador la reproduce sobre el sprite del avatar enemigo al
+recibir un golpe. Como es compartida entre TODOS los enemigos, **debe ser
+agnóstica**: no puede ser una pose de retroceso de un enemigo concreto (reemplazaría
+al Goblin/Skeleton/etc.). Por eso se diseña como un **efecto de impacto que se
+superpone**: un destello/estrellido de crayón tipo cómic, transparente, mismo
+encuadre cuadrado y mismo pivote/escala en todos los frames — solo cambia la fase del
+estallido. Estética handmade, sin variante de mundo (es un efecto, no un personaje).
+
+**Prompt paste-ready (secuencia de 4 frames):**
+
+```
+STYLE: Childlike handmade arts-and-crafts aesthetic — wax crayons, cut-out paper,
+cardboard texture, visible crayon strokes, uneven hand-cut edges, warm imperfect
+lines. Flat 2D, storybook feel. NOT digital-clean, NOT vector-smooth, NOT
+photorealistic.
+
+SUBJECT: a generic comic-book "HIT" / impact effect — a hand-drawn crayon IMPACT
+BURST: a spiky star-burst / "POW" splash of jagged crayon lines and torn-paper shards
+radiating from the center, in bright white with red and yellow crayon edges. Reads as
+the moment a character gets struck. No creature, no letters/text, just the impact
+flash.
+
+SEQUENCE: 4 separate frames of the SAME burst animating: frame 1 = small bright core
+sparking; frame 2 = burst fully expanded and brightest; frame 3 = burst breaking into
+scattered shards; frame 4 = faint fading remnants. Identical center pivot, identical
+canvas scale and framing across all 4 frames — ONLY the burst pose/size changes, so
+they overlay cleanly on the same spot.
+
+TECHNICAL: TRANSPARENT background (PNG with alpha) on every frame. Centered burst with
+margin. Square 1:1 composition, target 512x512 px per frame (matches the enemy avatar
+frame so it overlays correctly). Deliver as 4 separate transparent PNGs.
+```
+
+**Nota de asignación (Fase 4):** importar los 4 PNGs como Sprites en
+`Assets/Art/Sprites/Enemies/Common/Hit/` (carpeta nueva compartida). Asignarlos **en
+orden** a la lista `enemyHitFrames` del componente `CombatUIController` (lista
+`[SerializeField]`, misma forma en que hoy se asignan los frames del héroe — no es
+setup nuevo, es el patrón de frames existente). `enemyHitFps` actual = 16.
+
+---
+
+## Cierre — orden sugerido de las próximas fases
+
+`[PROPUESTA]` Después de generar e importar este lote drop-in (C1–C4, C6), el orden
+que ordena el resto de la integración de arte es:
+
+1. **C8 — Tinte por tipo elemental (quick win de CÓDIGO, sin IA).** Es la ganancia
+   más barata: los 6 tipos SON colores (Rojo/Amarillo/Azul/Morado/Negro/Blanco).
+   Helper `ElementType → Color` + tintar borde/fondo del botón de carta en
+   `CardHandView` (hoy solo prefijo de texto `[Rojo]`). No necesita prompt; va a
+   `modo:implementacion`. Buen candidato para el primer PR de arte/código.
+2. **C7 — Cara de carta (la pieza grande, requiere spec de código ANTES del prompt).**
+   Hay que diseñar primero el PR que agrega un campo `Sprite` a `CardDefinition` y el
+   render en `CardHandView`. **Recién con ese campo cerrado se diseña el prompt** de
+   "ilustración de carta". C7 también desbloquea N2 (caras del draft de NewRun).
+3. Luego: M1/M2 (mapa), S1 (vendedor), N1 (fondo NewRun) — prompts + PRs de código
+   chicos. Pulido al final: C5 (héroe Mundo B), H1 (íconos HUD), y la **variante B del
+   boss (UNIT-RB7)** una vez exista el segundo campo de avatar.
+
+> **Próxima sesión recomendada:** `modo:diseno` para el **spec de código de C7**
+> (campo sprite en `CardDefinition` + render en `CardHandView`), o bien
+> `modo:implementacion` para el quick win de **C8**. C7 es la dependencia crítica que
+> destraba más arte.


### PR DESCRIPTION
## Auditoría de arte post-M3 — Fases 1-3

Rescata en git los entregables del plan de auditoría de arte (`project-art-audit-plan`) que hasta ahora vivían **sin commitear** en el working tree. Doc puro, sin código.

### Qué incluye
- **`Docs/design/ART_NEEDS.md`** (Fase 1 + 2): catálogo de los **13 slots de arte que faltan**, clasificados en drop-in / mixto / solo-código, con estado actual, si el código ya lo soporta, prioridad y marca `placeholder-IA`. Incluye el **estilo madre** (cartón/crayón/papel; variantes Mundo A Medieval Oscuro / Mundo B Cyberpunk).
  - Hallazgo clave: el patrón placeholder-first de 3C/3D ya dejó mucho arte asignado (parallax de combate 10 sprites, Hoguera/Tienda, 23 íconos de Retazos, héroe Mundo A, Slime).
- **`Docs/design/ART_PROMPTS.md`** (Fase 3, lote drop-in): 5 prompts paste-ready en inglés:
  - C1 Goblin · C2 SkeletonWarrior · C3 DarkMage (avatares, Mundo A, 512²)
  - C4 boss "Costura maldita" (Mundo A, 768²; variante B UNIT-RB7 = deuda de código)
  - C6 flash de impacto del **enemigo** (4 frames, genérico/agnóstico — corrige el pedido original que decía "héroe": el slot real vacío es `enemyHitFrames`)

### Estado del plan
- ✅ Fase 1+2 (auditoría + estilo madre) · ✅ Fase 3 drop-in (prompts) · ✅ C8 tinte (PR #100, mergeado)
- ⏭️ Siguiente: generar/importar el arte drop-in (manual), y **C7 — cara de carta** (dependencia crítica: necesita spec de código `CardDefinition.sprite` + render en `CardHandView` ANTES de su prompt; desbloquea cartas de combate y caras de draft N2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
