### PR TITLE
fix(combat): el flash de impacto borraba el sprite del enemigo

### DIFF
--- a/Assets/Scripts/Gameplay/Combat/SpriteFrameAnimatorUI.cs
+++ b/Assets/Scripts/Gameplay/Combat/SpriteFrameAnimatorUI.cs
@@ -19,6 +19,10 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         [SerializeField] private float fps = 16f;
 
         private Coroutine _currentRoutine;
+        // Sprite "en reposo": el que está puesto al configurar (p.ej. el avatar del
+        // enemigo). Se restaura tras un ataque cuando NO hay idle loop, para que el
+        // flash de impacto no quede pegado al último frame y borre el sprite base.
+        private Sprite _restingSprite;
 
         public void Configure(Image target, List<Sprite> idle, List<Sprite> attack, float framesPerSecond)
         {
@@ -26,6 +30,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             idleFrames = idle ?? new List<Sprite>();
             attackFrames = attack ?? new List<Sprite>();
             fps = framesPerSecond > 0 ? framesPerSecond : 16f;
+            _restingSprite = targetImage != null ? targetImage.sprite : null;
         }
 
         public void PlayIdleLoop()
@@ -94,7 +99,17 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             }
 
             onComplete?.Invoke();
-            PlayIdleLoop();
+            if (idleFrames != null && idleFrames.Count > 0)
+            {
+                PlayIdleLoop();
+            }
+            else if (targetImage != null)
+            {
+                // Sin idle frames (caso del enemigo: attackFrames se usa como flash de
+                // impacto sobre su propio avatar). Restaurar el sprite en reposo en vez
+                // de dejar el último frame del flash → el enemigo reaparece tras el golpe.
+                targetImage.sprite = _restingSprite;
+            }
         }
     }
 }


### PR DESCRIPTION
## Bug: el flash de impacto del enemigo se quedaba pegado y borraba al enemigo

**Síntoma:** al golpear a un enemigo, los frames del flash (`enemyHitFrames`, C6) se ven bien pero **se quedan fijos en el último frame y el sprite del enemigo desaparece**. Pasa con todos (slime, goblin, esqueleto, boss).

**Causa raíz:** el flash se reproduce con `SpriteFrameAnimatorUI.PlayAttackOnce` sobre la **misma `Image`** del avatar del enemigo (`EnemyAvatar_Sprite`). Al terminar, `AttackRoutine` llamaba `PlayIdleLoop()`, pero el enemigo **no tiene idle frames** (`Configure(..., new List<Sprite>(), enemyHitFrames, ...)`), así que `PlayIdleLoop` retorna sin tocar la imagen → queda pegada en el último frame del flash. (Se hizo visible recién ahora porque, sin avatar asignado, no se creaba la `Image` hija y el animador nunca corría.)

**Fix** en `SpriteFrameAnimatorUI` — cumple su contrato documentado (*"ataque una vez, luego vuelve a idle"*) también cuando idle está vacío:
- Nuevo `_restingSprite`, capturado en `Configure` (el sprite ya presente = el avatar del enemigo).
- `AttackRoutine`: si hay idle frames → `PlayIdleLoop()` (sin cambios, **hero intacto**); si no hay → **restaura `_restingSprite`** en vez de dejar el último frame del flash → el enemigo reaparece tras el golpe.

### Validación
- ✅ Compilación limpia, **EditMode 137/137**.
- 🟡 Confirmación visual (enemigo reaparece tras el flash) queda para Play — el game view no repinta sin foco vía CLI.

### Nota
El flash sigue reemplazando brevemente al enemigo durante los 4 frames (~0.25s) y luego lo restaura — es un efecto de impacto aceptable para placeholder. Si más adelante se quiere el enemigo visible *debajo* del flash, eso sería un overlay separado (enhancement, no este fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
