### PR TITLE
docs(roadmap): backlog — legibilidad de tipo/color de carta en selectores

### DIFF
--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -463,6 +463,16 @@ categoría de hook) registrados en `_insights.md`.
 Ideas que pueden volverse milestones cuando el GDD las priorice o cuando se
 cierren los milestones actuales:
 
+- **Legibilidad de tipo/color de carta en selectores (Hoguera + Tienda)**
+  `[CANDIDATO PRE-M4 — pulido]`: los selectores de "mejorar carta" (Hoguera) y
+  "eliminar carta" (Tienda) listan las cartas como texto plano ("Strike / Strike
+  (B)", "Defend / Defend (B)") sin indicar el **tipo elemental / color** de la
+  carta — justo en un juego donde el tipo es central. Mejora: tintar el label /
+  agregar un chip de color reusando el helper `ElementTypeColors` (de C8) +
+  posiblemente el prefijo `[Tipo]` como en combate/NewRun. Barato (helper ya
+  existe, sólo cambia presentación en `CampfireNodeController` y `ShopNodeController`).
+  Detectado en playtest 2026-06-05. Candidato a hacer **antes de arrancar M4**,
+  como parte del pulido de identidad de carta (junto con C7 cara de carta).
 - **Refactor cross-cutting de los `Initialize()` de las views**: introducir un
   struct `ViewRefs` compartido en lugar de 25+ parámetros. Tiene sentido HACER
   después de Fase 4 cerrada (cuando las 3 views estén estables). ~30 min.


### PR DESCRIPTION
## Backlog: tipo/color de carta en selectores de Hoguera y Tienda

Anota una mejora detectada en playtest (2026-06-05) en el backlog del roadmap. **Solo es una nota — no se implementa ahora.**

**Observación:** los selectores de "mejorar carta" (Hoguera) y "eliminar carta" (Tienda) listan las cartas como texto plano (`Strike / Strike (B)`, `Defend / Defend (B)`) sin indicar el **tipo elemental / color** — justo en un juego donde el tipo es central.

**Propuesta (cuando se haga):** tintar el label / chip de color reusando el helper `ElementTypeColors` (de C8), posiblemente con el prefijo `[Tipo]` como en combate/NewRun. Barato: el helper ya existe; solo cambia presentación en `CampfireNodeController` y `ShopNodeController`.

**Cuándo:** candidato a pulido **antes de arrancar M4**, junto con C7 (cara de carta), como parte del pulido de identidad de carta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
