### PR TITLE
docs: sistema de subagentes en el workflow + CI parqueado

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,65 @@
+name: EditMode Tests
+
+# ⚠️ PARQUEADO (2026-06-09) — workflow desactivado a propósito.
+# Bloqueante: Unity 6 usa licencias "Entitlement" y Unity eliminó la activación
+# manual de Personal; el flujo .alf/.ulf de GameCI quedó deprecado, así que no
+# hay aún forma limpia de proveer el secret UNITY_LICENSE. Ver _roadmap.md
+# (Future work → "CI con GitHub Actions").
+#
+# Para REACTIVAR cuando la licencia esté resuelta: reemplazar el trigger
+# `workflow_dispatch` de abajo por:
+#   on:
+#     push:
+#       branches: [main]
+#     pull_request:
+#       branches: [main]
+# y configurar los secrets UNITY_LICENSE / UNITY_EMAIL / UNITY_PASSWORD.
+#
+# La versión de Unity la detecta unity-test-runner desde
+# ProjectSettings/ProjectVersion.txt (6000.2.14f1). La imagen
+# unityci/editor para esa versión ya existe (verificado).
+
+on:
+  workflow_dispatch: {}
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  editmode-tests:
+    name: EditMode
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      # Cachea la carpeta Library para acelerar corridas siguientes.
+      - name: Cache Library
+        uses: actions/cache@v4
+        with:
+          path: Library
+          key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          restore-keys: |
+            Library-
+
+      - name: Run EditMode tests
+        uses: game-ci/unity-test-runner@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          testMode: editmode
+          projectPath: .
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          artifactsPath: editmode-artifacts
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: EditMode results
+          path: editmode-artifacts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,32 @@ activa un modo, el primer paso del ritual es leer el archivo correspondiente.**
 - Comentarios en código: español o inglés según consistencia local del archivo.
 - Sé directo. Sebastián prefiere respuestas concretas sobre vaguedades.
 
+### Sobre subagentes y delegación
+- Tenés subagentes vía el Agent tool (`Explore` read-only, `Plan` para diseño,
+  `general-purpose` para todo). Cada uno corre en SU propia ventana de contexto
+  y devuelve solo su conclusión → sirven para AISLAR contexto (no inflar el hilo
+  principal, caro en Opus) y para PARALELIZAR.
+- **Desplegá un subagente cuando se cumpla al menos uno:**
+  - Fan-out de lectura: hay que rastrear ≥3-4 archivos para una conclusión y el
+    detalle intermedio no necesita vivir en el hilo principal.
+  - Paralelismo: ≥2 sub-tareas independientes que pueden correr a la vez.
+  - Verificación independiente: querés una segunda mirada adversarial.
+- **NO despliegues (hacelo directo) cuando:** es un lookup de un dato en archivo
+  conocido; una edición puntual de 1-3 ubicaciones ya localizadas; la tarea es
+  trivial o conversacional. Si el costo del subagente supera el ahorro de
+  contexto, es overkill.
+- **Archivos protegidos:** NUNCA delegues a un subagente la EDICIÓN de
+  `TurnManager.cs`, `ActionQueue.cs` ni `PlayerCombatActor.cs`. Leer/explorar sí;
+  editar lo hago yo en el hilo principal con tu aprobación.
+- Mapeo por modo y ejemplos: `Docs/dev/modes/_subagentes.md`.
+
+### Sobre skills propias (gaps de tooling)
+- Si detectás una operación de editor Unity repetitiva (mismo patrón manual
+  ≥2-3 veces: generar SOs en lote, poblar configs, etc.), PROPONÉ crear una skill
+  propia con `unity-skill-create`, describiendo qué automatiza y qué ahorra.
+  NUNCA la creés sin aprobación — solo proponés, Sebastián decide.
+
+
 ---
 
 ## Convenciones del Proyecto

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -537,3 +537,26 @@ cierren los milestones actuales:
   probar pasar el contenido de `UnityEntitlementLicense.xml` como secret
   `UNITY_LICENSE` + `UNITY_EMAIL`/`UNITY_PASSWORD` (experimento de ~15 min, sin
   garantía). Detalle de la investigación en el historial de chat 2026-06-09.
+- **Seguridad para features online (leaderboards / cloud save)** `[FUERA DE SCOPE
+  hasta que entren features online]`: notas para cuando se aborden leaderboards
+  (plan confirmado) y guardado cross-platform (plan confirmado). Registrado acá y
+  no en `_insights.md` porque ese archivo es para observaciones de gameplay/
+  playtesting, no infraestructura. Principio rector: **nunca confiar en el
+  cliente** (el build de Unity es decompilable; memoria y red son falsificables) →
+  toda validación que importe va del lado servidor.
+  - *Guardado local (hoy):* riesgo casi nulo (editar el propio save offline solo
+    afecta al tramposo). No invertir.
+  - *Leaderboards:* el cliente no es fuente de verdad. **Aprovechar el
+    determinismo por seed del juego** (ya probado en `RunMapGeneratorTests`): el
+    cliente envía seed + log de acciones, el servidor **re-simula la run** y
+    verifica el puntaje → un tramposo no puede forjar inputs que den un puntaje
+    imposible. Sumar auth (para banear), rate limiting y detección de anomalías.
+  - *Cloud save:* la amenaza es fuga de info por **broken access control** (que
+    un usuario lea el save de otro). Defensa #1: auth + autorización estricta
+    (cada user solo accede a SU save). Nunca meter secretos/credenciales en el
+    build de Unity. Cliente NUNCA habla directo con la DB: **Unity → API
+    autenticada (HTTPS) → DB**. Cifrado en tránsito y reposo. Compliance tipo GDPR
+    al guardar datos de usuario.
+  - *Multiplayer:* otra liga (estado autoritativo, anti-cheat, DDoS). Diferir.
+  - Conecta con la nota de **Infra online** de arriba: leaderboards/cloud save =
+    el escenario "backend" donde DB + servidor + auth dejan de ser teoría.

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -501,3 +501,39 @@ cierren los milestones actuales:
 - **DD-015 Narrativa**: viñetas, diálogo de hermanos, lore. Postponed hasta que
   se aborde la capa de narrativa explícitamente. Probable que entre como parte
   de M6c.
+- **Infra online (Docker / Base de datos / Nube / Despliegue)**
+  `[FUERA DE SCOPE salvo features online]`: ninguna es necesaria para el juego
+  tal como está en el GDD (roguelike single-player offline). Mapeo de cuándo se
+  volverían relevantes:
+  - *Save / meta-progresión (M6c):* se resuelve con **archivo local** (JSON a
+    `Application.persistentDataPath` o `PlayerPrefs`), NO con DB. Una DB real
+    solo entra con features online (cuentas, cloud saves, leaderboards, analytics).
+  - *Docker:* cero relevancia para el cliente (el juego se compila a ejecutable y
+    se distribuye por tienda). Solo aplica para empaquetar un backend, si alguna
+    vez existe.
+  - *Despliegue / Nube:* "publicar" un juego = distribución por tienda
+    (Steam/itch.io/app stores), no deploy web. Lo único de la nube con valor real
+    a mediano plazo **aunque el juego siga 100% offline** es **CI con GitHub
+    Actions** corriendo los tests EditMode en cada PR. Analytics y backend son
+    proyectos aparte y lejanos.
+  - Reflexión registrada 2026-06-09 a pedido de Sebastián (curiosidad / future work).
+- **CI con GitHub Actions (tests EditMode en cada PR)** `[PARQUEADO 2026-06-09 —
+  bloqueante del lado de Unity]`: la red de seguridad anti-regresión más valiosa
+  del proyecto (corre los 131 tests EditMode en cada PR, marca el merge en rojo
+  si algo se rompe). Repo público → minutos de Actions **gratis e ilimitados**;
+  Unity Personal → licencia **gratis**. **Por qué se parqueó:** Unity 6 migró al
+  sistema de licencias "Entitlement" (`UnityEntitlementLicense.xml` en
+  `C:\Users\<user>\AppData\Local\Unity\licenses\`) y **Unity eliminó la
+  activación manual de licencias Personal** en 2025. El flujo clásico `.alf`/`.ulf`
+  de GameCI quedó deprecado (la action `game-ci/unity-request-activation-file@v2`
+  ya falla) y no hay aún un camino oficial limpio para activar Personal de Unity 6
+  en CI. **Estado del trabajo:** el workflow `tests.yml` (usa
+  `game-ci/unity-test-runner@v4`, testMode editmode, cachea Library) está
+  **commiteado pero DESACTIVADO** (trigger solo `workflow_dispatch` → no corre en
+  PRs, nunca se pone en rojo). Para reactivar: cambiar el trigger a push/PR (ver
+  comentario en el archivo) + configurar el secret. La imagen Docker
+  `unityci/editor` para `6000.2.14f1` **existe y está soportada** (verificado).
+  **Para desbloquear:** revisar si GameCI ya soporta el formato Entitlement, o
+  probar pasar el contenido de `UnityEntitlementLicense.xml` como secret
+  `UNITY_LICENSE` + `UNITY_EMAIL`/`UNITY_PASSWORD` (experimento de ~15 min, sin
+  garantía). Detalle de la investigación en el historial de chat 2026-06-09.

--- a/Docs/dev/modes/_subagentes.md
+++ b/Docs/dev/modes/_subagentes.md
@@ -1,0 +1,107 @@
+# Subagentes — playbook de delegación por modo
+
+> **Qué es este archivo:** recurso compartido (igual que `_plantillas.md` y
+> `_marcadores.md`). Detalla CÓMO usar subagentes en cada modo. El **criterio
+> de cuándo delegar vs. hacerlo directo** vive en `CLAUDE.md` raíz
+> ("Sobre subagentes y delegación") porque debe estar siempre cargado. Acá está
+> el detalle operativo, que se carga on-demand para no pesar en cada sesión.
+>
+> **Cuándo leer este archivo:** al activar un modo y prever trabajo de fan-out o
+> paralelizable, o ante una decisión de delegación no trivial.
+
+---
+
+## Recordatorio del gate (resumen del criterio de CLAUDE.md)
+
+**Delegá** si: fan-out de lectura (≥3-4 archivos para una conclusión) ·
+paralelismo (≥2 sub-tareas independientes) · verificación adversarial
+independiente.
+
+**Hacelo directo** si: lookup de un dato en archivo conocido · edición puntual
+de 1-3 ubicaciones ya localizadas · tarea trivial/conversacional · el costo del
+subagente supera el ahorro de contexto (overkill).
+
+**Nunca** delegues la EDICIÓN de archivos protegidos (`TurnManager.cs`,
+`ActionQueue.cs`, `PlayerCombatActor.cs`). Leer/explorar sí; editar lo hace el
+hilo principal con aprobación de Sebastián.
+
+---
+
+## Tipos de subagente disponibles
+
+| Tipo | Para qué | Edita archivos |
+|------|----------|----------------|
+| `Explore` | Búsqueda/lectura read-only a lo ancho de muchos archivos; devuelve la conclusión, no el volcado de archivos | No |
+| `Plan` | Diseñar un plan de implementación / bocetar approaches; no ejecuta | No |
+| `general-purpose` | Tarea multi-step completa (buscar + editar + verificar) | Sí |
+
+> Regla práctica: empezá por el tipo más restringido que resuelva la tarea
+> (`Explore` antes que `general-purpose`). Menos superficie, menos riesgo.
+
+---
+
+## Mapeo por modo
+
+### `modo:gdd`
+- **`Explore`** para el barrido "qué está implementado en código vs. qué dice el
+  GDD" a lo ancho de muchos archivos. El ritual de este modo ya lee mucho; el
+  barrido de gaps es exactamente fan-out → delegalo y traé solo el mapa de
+  sistemas (✓/~/✗).
+
+### `modo:diseno`
+- **`Explore`** para reconocer cómo está hecho HOY el sistema que se va a tocar
+  (contratos, call sites, acoplamiento existente) antes de escribir el spec.
+- **`Plan`** para bocetar approaches alternativos cuando el diseño tiene más de
+  una salida razonable; el resultado alimenta las secciones `[PROPUESTA]` /
+  `[ALTERNATIVA]` del spec.
+
+### `modo:implementacion`
+- **`Explore`** para localizar call sites, firmas y puntos de inserción antes de
+  editar.
+- **`general-purpose`** para implementar piezas **aisladas e independientes** en
+  paralelo (p. ej. varios SOs/effects sin dependencias cruzadas). Cada agente
+  trabaja sobre su archivo; nada que toque protegidos.
+  - **Caveat protegidos:** si la pieza toca `TurnManager`/`ActionQueue`/
+    `PlayerCombatActor`, NO se delega la edición. El subagente puede mapear el
+    punto exacto; el cambio lo hace el hilo principal con aprobación.
+- **`/code-review`** (skill) al cerrar la sub-tarea, antes del PR.
+
+### `modo:revision`
+- Subagentes en **paralelo, uno por dimensión** del review:
+  1. Correctitud lógica / gameplay
+  2. Adherencia a `GOLDEN_RULES.md`
+  3. Arquitectura / acoplamiento / fugas de estado a UI
+- Cada uno devuelve su lista de issues priorizados; el hilo principal sintetiza
+  el Reporte de Revisión con la plantilla de `_plantillas.md`. La paralelización
+  acá da cobertura más amplia sin inflar el contexto del revisor.
+
+---
+
+## Cómo escribir un buen prompt de subagente
+
+- **Da el objetivo y el formato de salida.** El subagente devuelve solo su
+  mensaje final; pedile estructura (rutas + `file:line`, firmas, conclusión).
+- **Acotá el alcance.** Decile qué archivos/carpetas mirar y qué NO hacer
+  ("no modifiques nada, solo explorá y reportá").
+- **Pedí evidencia, no opinión.** Citas de líneas exactas > resúmenes vagos.
+- **Para paralelo:** lanzá los subagentes independientes en un mismo turno
+  (varias tool calls) para que corran concurrentes.
+
+---
+
+## Skills propias (gaps de tooling)
+
+Relacionado pero distinto de los subagentes (ver también CLAUDE.md raíz,
+"Sobre skills propias"). Si en cualquier modo aparece una operación de editor
+Unity **repetitiva** (mismo patrón manual ≥2-3 veces: generar SOs en lote,
+poblar configs, asignar arte por SerializedObject, etc.):
+
+1. **Proponer** —no crear— una skill propia con `unity-skill-create`,
+   describiendo qué automatiza y qué ahorra (tokens / clicks manuales / errores).
+2. Sebastián decide si vale la pena. Si sí, se crea y queda versionada en el repo.
+3. Nunca se crea una skill sin su aprobación explícita.
+
+> Patrón histórico que justificaría esto: los menús `Roguelike > Generate Relic
+> Assets`, `Setup Shop Config`, `Setup New Run Config` de M3 se corrieron a mano.
+> Si M4 trae un equivalente (p. ej. generar `EventDefinition` SOs en lote), es
+> candidato a skill propia.


### PR DESCRIPTION
## Qué incluye

Documentación de proceso de la sesión 2026-06-09 (no toca código de gameplay).

### Subagentes (capa de workflow nueva)
- **`CLAUDE.md`** (raíz, always-loaded): bloque **"Sobre subagentes y delegación"** con el gate de cuándo delegar (fan-out ≥3-4 archivos / paralelismo / verificación adversarial) vs. cuándo es overkill, + caveat de NO delegar edición de archivos protegidos. Más **"Sobre skills propias"**: detectar gaps de tooling repetitivo y *proponer* (`unity-skill-create`), Sebastián decide.
- **`Docs/dev/modes/_subagentes.md`** (nuevo, recurso compartido on-demand): playbook con tipos de subagente, mapeo por modo (gdd/diseño/implementación/revisión), guía de prompts y regla de skills propias.

### Future work
- **`_roadmap.md`**: infra online (Docker/DB/nube) marcada fuera de scope salvo features online; **CI con GitHub Actions parqueado** por bloqueante de licencias de Unity 6 (Entitlement / activación manual de Personal eliminada).

### CI (desactivado)
- **`.github/workflows/tests.yml`**: workflow de tests EditMode redactado pero **DESACTIVADO** (`workflow_dispatch` only → no corre en PRs, no se pone en rojo). Preservado para reactivar cuando se resuelva la licencia.

## Por qué dos capas
El criterio vive en CLAUDE.md (siempre cargado → aplica en todo turno, incluido conversacional); el detalle vive on-demand en `_subagentes.md` para no pesar en cada sesión.

🤖 Generated with [Claude Code](https://claude.com/claude-code)