### PR TITLE
feat(ui): tinte por tipo elemental en selectores Hoguera y Tienda

### DIFF
--- a/Assets/Scripts/Gameplay/Combat/CardHandView.cs
+++ b/Assets/Scripts/Gameplay/Combat/CardHandView.cs
@@ -391,15 +391,10 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 prefix = _turnManager.CurrentWorld == TurnManager.WorldSide.A ? "[A] " : "[B] ";
             }
 
-            // Tinte por tipo (C8): el prefijo [Tipo] toma el color del tipo vía rich
-            // text. ReadableOnDark mantiene legible el Negro sobre el fondo oscuro de
-            // la carta. Color desde la fuente única de verdad (ElementTypeColors).
-            string typePrefix = string.Empty;
-            if (activeCard.ElementType != ElementType.None)
-            {
-                string typeHex = ColorUtility.ToHtmlStringRGB(ElementTypeColors.ReadableOnDark(activeCard.ElementType));
-                typePrefix = $"<color=#{typeHex}>[{activeCard.ElementType}]</color> ";
-            }
+            // Tinte por tipo (C8→#104): delega al helper centralizado TypePrefix para
+            // que Hoguera, Tienda y combate compartan el mismo token rich-text.
+            string typePrefix = ElementTypeColors.TypePrefix(activeCard.ElementType);
+            if (!string.IsNullOrEmpty(typePrefix)) typePrefix += " ";
             string title = string.IsNullOrEmpty(prefix)
                 ? $"{typePrefix}{activeCard.CardName}"
                 : $"{prefix}{typePrefix}{activeCard.CardName}";

--- a/Assets/Scripts/Gameplay/Combat/ElementTypeColors.cs
+++ b/Assets/Scripts/Gameplay/Combat/ElementTypeColors.cs
@@ -72,6 +72,19 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             Luminance(background) > DarkTextThreshold ? DarkInk : LightInk;
 
         /// <summary>
+        /// Prefijo rich-text "[Tipo]" coloreado con el color legible sobre fondo oscuro
+        /// (ReadableOnDark). Fuente única de verdad del patrón que antes vivía inline en
+        /// CardHandView.BuildCardLabel. Devuelve string.Empty para ElementType.None (sin
+        /// prefijo). NO incluye espacio final ni separador — el caller decide el formato.
+        /// </summary>
+        public static string TypePrefix(ElementType type)
+        {
+            if (type == ElementType.None) return string.Empty;
+            string hex = ColorUtility.ToHtmlStringRGB(ReadableOnDark(type));
+            return $"<color=#{hex}>[{type}]</color>";
+        }
+
+        /// <summary>
         /// Atenúa un color preservando su alpha (para estados deshabilitados que
         /// igual deben dejar leer de qué tipo se trata).
         /// </summary>

--- a/Assets/Scripts/Run/Campfire/CampfireNodeController.cs
+++ b/Assets/Scripts/Run/Campfire/CampfireNodeController.cs
@@ -326,7 +326,7 @@ namespace RoguelikeCardBattler.Run.Campfire
                 string tokenA = CardToken(a);
                 string tokenB = CardToken(b);
                 bool sameName = (a != null ? a.CardName : "?") == (b != null ? b.CardName : "?");
-                bool sameType = SideElemType(a) == SideElemType(b);
+                bool sameType = SideType(a) == SideType(b);
                 return (sameName && sameType) ? tokenA : $"{tokenA} / {tokenB}";
             }
             return entry.SingleCard != null ? CardToken(entry.SingleCard) : "Carta";
@@ -340,7 +340,10 @@ namespace RoguelikeCardBattler.Run.Campfire
             return string.IsNullOrEmpty(p) ? c.CardName : $"{p} {c.CardName}";
         }
 
-        private static ElementType SideElemType(CardDefinition c) =>
+        // Null-safe CardDefinition → ElementType. Mismo nombre que el helper espejo
+        // de ShopNodeController.SideType para que ambos BuildCardSelectLabel se lean
+        // simétricos en paralelo.
+        private static ElementType SideType(CardDefinition c) =>
             c != null ? c.ElementType : ElementType.None;
 
         private int ComputeHealAmount()

--- a/Assets/Scripts/Run/Campfire/CampfireNodeController.cs
+++ b/Assets/Scripts/Run/Campfire/CampfireNodeController.cs
@@ -311,10 +311,10 @@ namespace RoguelikeCardBattler.Run.Campfire
         // ──────────────────────────────────────────────
 
         /// <summary>
-        /// Etiqueta para el botón de selección de carta. Para duales muestra los
-        /// nombres de ambos lados (A y B) — la mejora aplica a ambos mundos, así
-        /// que el jugador ve qué carta está mejorando en cada uno. Para singles
-        /// muestra simplemente el nombre.
+        /// Etiqueta para el botón de selección de carta. Muestra el prefijo de tipo
+        /// coloreado antes del nombre (reutiliza ElementTypeColors.TypePrefix). Para
+        /// duales muestra AMBOS lados con su tipo y color propios; colapsa a un solo
+        /// token solo si nombre Y tipo coinciden en los dos lados.
         /// </summary>
         private static string BuildCardSelectLabel(CardDeckEntry entry)
         {
@@ -323,12 +323,25 @@ namespace RoguelikeCardBattler.Run.Campfire
             {
                 CardDefinition a = entry.DualCard.SideA;
                 CardDefinition b = entry.DualCard.SideB;
-                string nameA = a != null ? a.CardName : "?";
-                string nameB = b != null ? b.CardName : "?";
-                return nameA == nameB ? nameA : $"{nameA} / {nameB}";
+                string tokenA = CardToken(a);
+                string tokenB = CardToken(b);
+                bool sameName = (a != null ? a.CardName : "?") == (b != null ? b.CardName : "?");
+                bool sameType = SideElemType(a) == SideElemType(b);
+                return (sameName && sameType) ? tokenA : $"{tokenA} / {tokenB}";
             }
-            return entry.SingleCard != null ? entry.SingleCard.CardName : "Carta";
+            return entry.SingleCard != null ? CardToken(entry.SingleCard) : "Carta";
         }
+
+        // Token rich-text "[Tipo] Nombre" para una CardDefinition (o "?" si es null).
+        private static string CardToken(CardDefinition c)
+        {
+            if (c == null) return "?";
+            string p = ElementTypeColors.TypePrefix(c.ElementType);
+            return string.IsNullOrEmpty(p) ? c.CardName : $"{p} {c.CardName}";
+        }
+
+        private static ElementType SideElemType(CardDefinition c) =>
+            c != null ? c.ElementType : ElementType.None;
 
         private int ComputeHealAmount()
         {

--- a/Assets/Scripts/Run/Shop/ShopNodeController.cs
+++ b/Assets/Scripts/Run/Shop/ShopNodeController.cs
@@ -385,9 +385,32 @@ namespace RoguelikeCardBattler.Run.Shop
         private void CreateItemButton(RectTransform parent, ShopItem item, float yMin, float yMax)
         {
             bool affordable = !item.Purchased && _state.Gold >= item.Price;
+
+            // Prefijo de tipo coloreado SOLO en el render — item.Title NO se muta
+            // para no romper ShopTests (que comparan Title por igualdad de string).
+            string typeTint = string.Empty;
+            if (item.Kind == ShopItemKind.Card && item.CardPayload != null)
+            {
+                CardDeckEntry e = item.CardPayload;
+                if (e.DualCard != null)
+                {
+                    ElementType ta = SideType(e.DualCard.SideA);
+                    ElementType tb = SideType(e.DualCard.SideB);
+                    typeTint = ta == tb
+                        ? ElementTypeColors.TypePrefix(ta)
+                        : $"{ElementTypeColors.TypePrefix(ta)}{ElementTypeColors.TypePrefix(tb)}";
+                }
+                else if (e.SingleCard != null)
+                {
+                    typeTint = ElementTypeColors.TypePrefix(e.SingleCard.ElementType);
+                }
+                if (!string.IsNullOrEmpty(typeTint)) typeTint += " ";
+            }
+
+            string titled = $"{typeTint}{item.Title}";
             string label = item.Purchased
-                ? $"{item.Title}  (comprado)"
-                : $"{item.Title} — {item.Price} oro\n<{item.Description}>";
+                ? $"{titled}  (comprado)"
+                : $"{titled} — {item.Price} oro\n<{item.Description}>";
             Button btn = CreateButtonRaw(parent, $"Item_{item.Title}", label, 0.05f, yMin, 0.95f, yMax, affordable);
             if (affordable)
             {
@@ -484,8 +507,11 @@ namespace RoguelikeCardBattler.Run.Shop
         // ──────────────────────────────────────────────
 
         /// <summary>
-        /// Etiqueta para el botón de selección de carta. Para duales muestra ambos
-        /// lados (A / B); para singles el nombre. Espejo de CampfireNodeController.
+        /// Etiqueta para el botón de selección de carta. Muestra el prefijo de tipo
+        /// coloreado antes del nombre (reutiliza ElementTypeColors.TypePrefix). Para
+        /// duales muestra AMBOS lados con su tipo y color propios; colapsa a un solo
+        /// token solo si nombre Y tipo coinciden en los dos lados. Espejo de
+        /// CampfireNodeController.BuildCardSelectLabel.
         /// </summary>
         private static string BuildCardSelectLabel(CardDeckEntry entry)
         {
@@ -494,11 +520,21 @@ namespace RoguelikeCardBattler.Run.Shop
             {
                 CardDefinition a = entry.DualCard.SideA;
                 CardDefinition b = entry.DualCard.SideB;
-                string nameA = a != null ? a.CardName : "?";
-                string nameB = b != null ? b.CardName : "?";
-                return nameA == nameB ? nameA : $"{nameA} / {nameB}";
+                string tokenA = CardToken(a);
+                string tokenB = CardToken(b);
+                bool sameName = (a != null ? a.CardName : "?") == (b != null ? b.CardName : "?");
+                bool sameType = SideType(a) == SideType(b);
+                return (sameName && sameType) ? tokenA : $"{tokenA} / {tokenB}";
             }
-            return entry.SingleCard != null ? entry.SingleCard.CardName : "Carta";
+            return entry.SingleCard != null ? CardToken(entry.SingleCard) : "Carta";
+        }
+
+        // Token rich-text "[Tipo] Nombre" para una CardDefinition (o "?" si es null).
+        private static string CardToken(CardDefinition c)
+        {
+            if (c == null) return "?";
+            string p = ElementTypeColors.TypePrefix(c.ElementType);
+            return string.IsNullOrEmpty(p) ? c.CardName : $"{p} {c.CardName}";
         }
 
         private void RefreshGoldText()

--- a/Assets/Tests/EditMode/ElementTypeColorsTests.cs
+++ b/Assets/Tests/EditMode/ElementTypeColorsTests.cs
@@ -83,5 +83,48 @@ namespace RoguelikeCardBattler.Tests.EditMode
             Assert.AreEqual(raw.a, dimmed.a, 1e-4f, "Dim debe preservar el alpha");
             Assert.Less(Luminance(dimmed), Luminance(raw), "Dim debe oscurecer");
         }
+
+        // ── TypePrefix (#104) ─────────────────────────────────────────────────
+
+        [Test]
+        public void TypePrefix_None_ReturnsEmpty()
+        {
+            Assert.AreEqual(string.Empty, ElementTypeColors.TypePrefix(ElementType.None),
+                "None no debe generar prefijo");
+        }
+
+        [Test]
+        public void TypePrefix_ColoredType_ContainsNameInBrackets()
+        {
+            string prefix = ElementTypeColors.TypePrefix(ElementType.Rojo);
+            StringAssert.Contains("[Rojo]", prefix, "El prefijo debe contener el nombre del tipo entre corchetes");
+            StringAssert.StartsWith("<color=#", prefix, "El prefijo debe abrirse con rich-text de color");
+            StringAssert.EndsWith("</color>", prefix, "El prefijo debe cerrarse con </color>");
+        }
+
+        [Test]
+        public void TypePrefix_HexMatchesReadableOnDark_ForRojoAndNegro()
+        {
+            // Verifica que el hex embebido es el de ReadableOnDark (no el de For).
+            foreach (ElementType type in new[] { ElementType.Rojo, ElementType.Negro })
+            {
+                string expected = ColorUtility.ToHtmlStringRGB(ElementTypeColors.ReadableOnDark(type));
+                string prefix = ElementTypeColors.TypePrefix(type);
+                StringAssert.Contains(expected, prefix,
+                    $"El hex de {type} debe coincidir con ReadableOnDark");
+            }
+        }
+
+        [Test]
+        public void TypePrefix_AllNonNoneTypes_ProduceNonEmptyPrefixWithName()
+        {
+            foreach (ElementType type in ColoredTypes)
+            {
+                string prefix = ElementTypeColors.TypePrefix(type);
+                Assert.IsNotEmpty(prefix, $"{type} debe producir prefijo no vacío");
+                StringAssert.Contains($"[{type}]", prefix,
+                    $"{type} debe incluir su nombre entre corchetes");
+            }
+        }
     }
 }

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -471,16 +471,15 @@ categoría de hook) registrados en `_insights.md`.
 Ideas que pueden volverse milestones cuando el GDD las priorice o cuando se
 cierren los milestones actuales:
 
-- **Legibilidad de tipo/color de carta en selectores (Hoguera + Tienda)**
-  `[CANDIDATO PRE-M4 — pulido]`: los selectores de "mejorar carta" (Hoguera) y
-  "eliminar carta" (Tienda) listan las cartas como texto plano ("Strike / Strike
-  (B)", "Defend / Defend (B)") sin indicar el **tipo elemental / color** de la
-  carta — justo en un juego donde el tipo es central. Mejora: tintar el label /
-  agregar un chip de color reusando el helper `ElementTypeColors` (de C8) +
-  posiblemente el prefijo `[Tipo]` como en combate/NewRun. Barato (helper ya
-  existe, sólo cambia presentación en `CampfireNodeController` y `ShopNodeController`).
-  Detectado en playtest 2026-06-05. Candidato a hacer **antes de arrancar M4**,
-  como parte del pulido de identidad de carta (junto con C7 cara de carta).
+- ~~**Legibilidad de tipo/color de carta en selectores (Hoguera + Tienda)**~~
+  **IMPLEMENTADO 2026-06-09** (PR #104, branch `feat/type-tint-selectors`):
+  `ElementTypeColors.TypePrefix` nuevo método centralizado; aplicado en
+  `CampfireNodeController.BuildCardSelectLabel`, `ShopNodeController.BuildCardSelectLabel`
+  y `ShopNodeController.CreateItemButton` (render del stock). Refactor
+  behavior-preserving de `CardHandView.BuildCardLabel` para consumir el nuevo
+  helper. Tests: `ElementTypeColorsTests.cs` ampliado con 4 casos nuevos
+  (TypePrefix None, token con corchetes, hex coincide con ReadableOnDark, todos
+  los tipos producen prefijo no vacío). Suite EditMode: 146/146 (4 nuevos).
 - **Refactor cross-cutting de los `Initialize()` de las views**: introducir un
   struct `ViewRefs` compartido en lugar de 25+ parámetros. Tiene sentido HACER
   después de Fase 4 cerrada (cuando las 3 views estén estables). ~30 min.

--- a/Docs/dev/_tech_snapshot.md
+++ b/Docs/dev/_tech_snapshot.md
@@ -7,7 +7,19 @@
 > En `modo:implementacion` se lee OBLIGATORIAMENTE antes de cualquier cambio que
 > afecte arquitectura o componentes críticos.
 >
-> **Última actualización:** 2026-06-05 — **Auditoría de arte, slot C7 (cara de carta,
+> **Última actualización:** 2026-06-09 — **Pulido pre-M4 #104 (tinte tipo en
+> selectores)**. `ElementTypeColors` gana `TypePrefix(ElementType)` — token
+> rich-text `<color=#hex>[Tipo]</color>` sin espacio final, fuente única de
+> verdad del patrón que antes vivía inline en `CardHandView`. Aplicado en 3
+> sitios: `CampfireNodeController.BuildCardSelectLabel`, `ShopNodeController.
+> BuildCardSelectLabel` y `ShopNodeController.CreateItemButton` (render del
+> stock). Refactor behavior-preserving en `CardHandView.BuildCardLabel` (consume
+> `TypePrefix` en vez del inline). `ElementTypeColorsTests.cs` ampliado: **146/146**
+> (142 previos + 4 nuevos: TypePrefix None/token/hex/all-types). `ShopTests` y
+> `CampfireTests` siguen intactos (no se tocó `BuildStock`).
+> **Validado:** compilación limpia, EditMode **146/146** (142 previos + 4 nuevos).
+>
+> **Última actualización previa:** 2026-06-05 — **Auditoría de arte, slot C7 (cara de carta,
 > habilitación de CÓDIGO)** en branch `feat/c7-card-art` (spec
 > `Docs/dev/specs/art_c7_card_art_spec.md`). `CardDefinition` gana el campo
 > `[SerializeField] Sprite art` + getter `Art` (paralelo a `EnemyDefinition.Avatar`),
@@ -399,7 +411,7 @@ RelicSoGenerator.cs                   ← MenuItem "Roguelike/Generate Relic Ass
                                         (idempotente — saltea archivos existentes)
 ```
 
-### Tests (`Assets/Tests/EditMode/`) — 17 archivos (suite EditMode 142/142)
+### Tests (`Assets/Tests/EditMode/`) — 17 archivos (suite EditMode 146/146)
 
 ```
 CombatTestBase.cs                ← helper compartido
@@ -421,9 +433,9 @@ NewRunTests.cs                   ← M3 Sub-PR 3E (8 casos: draft/dual/tipos)
 RunMapGeneratorTests.cs          ← M3 Sub-PR 3F (5 casos: determinismo topología/
                                    enemigos, divergencia por seed, DAG válido,
                                    start/end forzados — blinda el refactor horizontal)
-ElementTypeColorsTests.cs        ← Auditoría de arte C8 (6 casos: tinte por tipo —
-                                   colores distintos, contraste de texto, levante de
-                                   Negro sobre oscuro, Dim preserva alpha)
+ElementTypeColorsTests.cs        ← C8 (6 casos) + #104 (4 casos TypePrefix: None vacío,
+                                   token con corchetes, hex==ReadableOnDark, all-types
+                                   no vacíos) = 10 casos totales
 CardArtTests.cs                  ← Auditoría de arte C7 (5 casos: campo Art default
                                    null, set/omit en SetDebugData, persistencia en el
                                    clon de upgrade, herencia dual por mundo, resolución


### PR DESCRIPTION
## Summary

- `ElementTypeColors.TypePrefix(ElementType)` nuevo método estático: token `<color=#hex>[Tipo]</color>` sin espacio final. Fuente única de verdad que centraliza el patrón antes inline en `CardHandView`.
- `CampfireNodeController.BuildCardSelectLabel` y `ShopNodeController.BuildCardSelectLabel` actualizados: cada carta muestra su prefijo de tipo coloreado; duales muestran ambos lados; colapso solo si nombre Y tipo coinciden en los dos lados.
- `ShopNodeController.CreateItemButton`: prefijo en el RENDER del stock (solo `Kind==Card`); `item.Title` no se muta → `ShopTests` intactos.
- `CardHandView.BuildCardLabel`: refactor behavior-preserving para consumir `TypePrefix` en vez del inline.
- `ElementTypeColorsTests.cs` ampliado con 4 casos nuevos: TypePrefix None, token con corchetes, hex coincide con ReadableOnDark, todos los tipos no None producen prefijo.

## Test plan

- [ ] Compilación limpia en Unity (zero console errors)
- [ ] `Window > Test Runner > EditMode > Run All` — suite completa verde (146 esperados: 142 previos + 4 nuevos)
- [ ] `ShopTests` y `CampfireTests` siguen verdes sin modificaciones
- [ ] Nodo Hoguera: botones de mejora muestran `[Tipo]` coloreado; cartas duales con ambos lados
- [ ] Nodo Tienda — stock: cartas con prefijo; Retazos y "Eliminar carta" sin prefijo; dual con ambos tokens
- [ ] Nodo Tienda — panel "eliminar carta": igual que Hoguera
- [ ] Negro legible sobre fondo oscuro (levantado por `ReadableOnDark`)
- [ ] Combate sin cambios visibles (regresión del refactor de `CardHandView`)

Closes #104

🤖 Generated with [Claude Code](https://claude.ai/claude-code)