### PR TITLE
docs: cierre auditoría integral 2026-06 (informe + plan pre-M4)

### DIFF
--- a/Docs/dev/audits/2026-06/AUDIT_REPORT.md
+++ b/Docs/dev/audits/2026-06/AUDIT_REPORT.md
@@ -1,0 +1,276 @@
+# Auditoría integral 2026-06 — Informe consolidado (Fase 5)
+
+> **Sesión de cierre:** 2026-06-12 · Síntesis inline, sin fan-out.
+> **Insumos:** `fase1_codigo_arquitectura.md`, `fase2_tests.md`, `fase3_docs.md`,
+> `fase4_workflow_tooling.md`. Este informe consolida **solo** hallazgos que
+> pasaron verificación adversarial en sus fases. Nada se re-derivó: cada ítem
+> mantiene su `archivo:línea` y su veredicto original.
+> **Plan de remediación:** `PLAN_PRE_M4.md` (secuencia, sub-PRs, qué entra a M4 /
+> qué a la cirugía pre-M5 / qué se descarta).
+
+---
+
+## 0. Veredicto global
+
+El proyecto está **estructuralmente sano**: capas respetadas, `ActionQueue`
+determinista, generador de mapa sin RNG no seedeado, presentación disciplinada,
+suite de 146 tests sólida para fórmulas y determinismo. **Cero hallazgos
+críticos** sobrevivieron el verify en las 4 fases.
+
+El riesgo real se concentra en cuatro frentes, ninguno urgente pero todos
+convenientes de cerrar **antes de M4/M5**:
+
+1. **Sincronización RunState↔combate al cierre** — 2 Retazos rotos HOY en el
+   flujo real + retry de derrota inutilizable. Bugs player-facing, fix barato.
+2. **Cuatro supuestos del core que M5/M6 rompen de frente** — todos en archivos
+   protegidos → conviene **una cirugía única diseñada y aprobada de TurnManager
+   pre-M5**, no cuatro aperturas incrementales.
+3. **La documentación describe el juego de hace dos milestones** — Momentum
+   (eliminado en M2) vigente en 5 docs; specs de Retazos prescriben el patrón
+   que CAUSA los bugs del frente 1. Envenena el contexto auto-cargado y el
+   onboarding.
+4. **Tooling con un bypass real de la protección de archivos** + carga muerta
+   de skills MCP + ruido de permisos.
+
+**Total consolidado:** 0 críticos · **13 hallazgos mayores** (10 código + 3
+tooling) + **14 mayores documentales** consolidados (18 hallazgos originales
+pre-consolidación, ver F3) · ~36 menores · **8 oportunidades** · ~9 descartados
+por verify.
+
+---
+
+## 1. Hallazgos de CÓDIGO (Fase 1)
+
+### Cluster A — Sincronización fin de combate / resets de run
+
+| ID | Severidad | Esfuerzo | Hallazgo | Ubicación | Destino |
+|---|---|---|---|---|---|
+| **H1** | Mayor | S | `RelicEndHealEffect` (R-END-2 "Curita con Estampa") es un **no-op**: escribe `RunState.PlayerCurrentHP` en `DispatchCombatEnd`, pero `ReportOutcome` (polling posterior) lo pisa con `_turnManager.PlayerHP`. Tests verdes porque no cubren el flujo con `BattleFlowController`. Origen: `RELICS.md:228` prescribe esta implementación. | `BattleFlowController.cs:117` | **Pre-M4** (fix + test T1) |
+| **H2** | Mayor | S (con H1) | `RelicElitePuristEffect` ("Caja Intacta") evalúa **HP stale**: lee `RunState.PlayerCurrentHP` en OnCombatEnd, que conserva el valor PRE-combate. Paga si ENTRASTE con vida llena, no si TERMINASTE — condición invertida. Mismo origen que H1 (`RELICS.md:240`). | `RelicElitePuristEffect.cs:17` | **Pre-M4** (con H1) |
+| **H3** | Mayor | S | Reintentar tras derrota arranca el combate con **1 HP**: la derrota guarda `PlayerCurrentHP=0`, el botón Reintentar limpia flags pero no restaura HP, `HasPlayerHPInitialized` sigue true → el 0 pasa como override y se clampa a 1. Loop de derrota casi garantizado. | `RunFlowController.cs:~651` | **Pre-M4** (fix + test T2) |
+| **H4** | Mayor | S-M | Dos paths de reset de run **divergentes**: los botones defeat/acto resetean in-place y pierden identidad del run (tipos a Rojo/Amarillo, `PendingStarterCard` anulada, mismo mapa). `RunSession.ResetForNewRun` sí regenera. TODO stale en `:701` ("cuando exista MainMenuScene" — existe hace meses). | `RunFlowController.cs:666,693` | **Pre-M4** |
+
+> Raíz compartida del cluster: `BattleFlowController.ReportOutcome` sincroniza
+> tarde y los resets in-place duplican lógica de `RunSession`. Los 4 se arreglan
+> en el mismo sub-PR coordinado con los tests T1/T2 de F2.
+
+### Cluster B — Readiness M5/M6 (los cuatro supuestos del core)
+
+> Los cuatro viven en TurnManager/actors (**protegidos**). Recomendación del
+> verify: **una cirugía única aprobada pre-M5** que resuelva el paquete completo.
+
+| ID | Severidad | Esfuerzo | Hallazgo | Ubicación | Destino |
+|---|---|---|---|---|---|
+| **H5** | Mayor | M (decisión) | Semántica **encolar-vs-ejecutar** sin decidir: efectividad/Estilo/hooks corren al encolar, el daño al ejecutar. Consecuencias no documentadas — enemigo muerto que igual ataca (`DamageAction.Execute` no chequea source vivo), Victory evaluada antes que Defeat (jugador en 0 HP puede ganar), +1 Estilo otorgado pre-block (SuperEficaz 100% bloqueado da carga), Spines encola represalia antes del golpe. Edge angosto hoy; con más Retazos/bosses M5 deja de serlo. | `TurnManager.cs:1065,634,856` | **Cirugía pre-M5** (decidir semántica) |
+| **H6** | Mayor | M | Cambio de mundo: un solo path, **presupuestado al jugador, sin initiator ni veto**. `TryChangeWorld` siempre chequea cap del jugador, siempre incrementa el contador, dispatchea OnWorldSwitch DESPUÉS de mutar (sin punto de veto). Sin Initiator → el Desfase Dimensional M5 dispararía los 4 Retazos Switch del jugador en cambios hostiles; los bosses M6 que bloquean el cambio no tienen dónde vetar. | `TurnManager.cs:763-786`, `WorldSwitchHookData.cs:14` | **Cirugía pre-M5** |
+| **H7** | Mayor | M | Tipo de enemigo **único, estático, leído del SO**; sin `TypeWorldB` ni `IsAnchor`. El jugador tiene la indirección correcta (`PlayerActiveType` deriva del mundo); el enemigo no — 3 call sites leen crudo del SO. **Es exactamente el bloque 4c del roadmap** — la extensión es limpia y acotada. | `TurnManager.cs:624,416,112`, `EnemyDefinition.cs:22` | **M4 bloque 4c** |
+| **H8** | Mayor | L | **Cero sustrato de status/debuff** + lógica de actors duplicada textualmente. `EffectType.ApplyStatus` cae al default LogWarning; ningún actor tiene contenedor de statuses; TakeDamage/GainBlock/LoseBlock/Heal son copias idénticas en ambos actors. Virus (block al 80%) y Sangrado (tick/expiración) son núcleo de M5. | `ICombatActor.cs`, `PlayerCombatActor.cs:97-110` vs `EnemyCombatActor.cs:35-48` | **Cirugía pre-M5** |
+| **H9** | Mayor | M | **Multi-acto sin representación**: `ActoCompleted` es bool, config single-act (un solo `defaultEnemy`/`bossRelicDrop`, HP enemigo fijo sin escalado). Introducir `CurrentAct` ya en M5 evita migrar el bool después. | `RunState.cs:32`, `RunCombatConfig.cs` | **Cirugía pre-M5** (anticipar) |
+
+### Cluster C — Fragilidad latente de inicialización
+
+| ID | Severidad | Esfuerzo | Hallazgo | Ubicación | Destino |
+|---|---|---|---|---|---|
+| **H10** | Mayor | S | **Carrera de Awake** en run nueva: `TryInheritBossFrom` regenera el mapa que `RunFlowController` ya pudo capturar. HOY funciona por orden de facto en el YAML de la escena — **sin contrato** (no hay DefaultExecutionOrder; reordenar la jerarquía rompe el mapa en silencio). | `RunSession.cs:147`, `RunFlowController.cs:71` | **Pre-M4** (lazy getter o DefaultExecutionOrder + comentario) |
+
+### Menores de código (al backlog, sin urgencia)
+
+- **Docs stale sobre gaps resueltos** (PhaseBased AI, `EffectType.Heal`+`HealAction`, `CalculateIntentValue`): SÍ implementados (Sub-PR D, 2026-05-07) pero listados como pendientes → **insumo directo de F3** (D11). *(menor, S)*
+- `RelicTurnEnergyEveryN` (Reloj de Cocina): counter **sangra entre combates** (sin reset OnCombatStart, a diferencia de siblings). Resolver como decisión de diseño + fix simétrico. *(menor, S)*
+- `RelicAccSkillStacker`: pending de energía cruza combates (mismo fix). *(menor, S)*
+- Sin validación SO↔efecto: el reset de counters depende del array Hooks del asset → test que cargue `.asset` reales (= T5 de F2). *(menor, S)*
+- Orden de hooks T1 (OnPlayerTurnStart antes que OnCombatStart): decisión documentada, footgun para Retazos futuros — documentar como regla de autoría en RELICS.md. *(menor, S)*
+- `SaveSmokeTest` vivo en BattleScene (sin `#if UNITY_EDITOR`, corre en builds, sobreescribe `save_v1.json` cada combate). Inocuo hoy; mayor cuando M6c lea ese archivo. **Borrarlo es gratis.** *(menor, S)*
+- Topologías hardcode 8 nodos vs `totalNodes` editable sin clamp/OnValidate. Validación de 5 líneas. *(menor, S)*
+- `SceneTransitionManager`: `_isTransitioning` sin recuperación — soft-lock no alcanzable hoy, pero sin hardening un KillAll futuro lo rompe sin síntoma. *(menor, S)*
+- Comentario engañoso `TurnManager.cs:856` (promete detección de victoria post-hook que no ocurre) — trampa para autores futuros. *(menor, S — absorbido por la cirugía H5)*
+- `currentWorld` no se resetea en `InitializeCombat` (lo salva la recarga de escena; muerde si M6 encadena combates sin recarga). *(menor, S)*
+- Residuo de M17: End Turn no chequea `IsPlayingAttack` → clic durante animación difiere la resolución de la carta al turno enemigo. *(menor, S)*
+- `RelicDebugOverlay` muta `RunState.Relics` directo → AcquisitionOrder duplicado en playtesting (editor-only). Fix: `RemoveRelic()` que normalice. *(menor, S)*
+- Recompensa post-combate **NO randomizada** (siempre las primeras N del RewardPool, sin TODO); oro +10 hardcodeado. Distorsiona playtests de economía. *(menor, S-M)*
+- `RunFlowController` **god-object** (885 LOC) + duplicación espejo Shop↔Campfire (~150-180 LOC/archivo; `GetWhiteSprite` ×4). Sin riesgo funcional hoy — **extraer ANTES de 4b** (EventNodeController sería la 3ª copia). *(menor, M)*
+
+### Oportunidades de código
+
+- Migrar fin-de-combate de polling a evento (`OnCombatFinished`) — nota de diseño pre-M5, sin bug actual.
+- `UIFactory` central en Core/UI (patrón create-text/button/panel forkeado ×4+).
+- `EnemyIntentType` extensible + íconos (gap del enum, no de la view).
+- `EnsureEventSystem` ×3 divergentes → helper único en Core.
+- Base `RelicEffectBase<THookData>` antes de la ola de efectos M5/M6.
+- `MaxStyleCharges` expuesto por TurnManager (HUD hardcodea "/5").
+
+---
+
+## 2. Hallazgos de TESTS (Fase 2)
+
+La suite (146 tests, 17 archivos) es **100% sintética** — cero `.asset` reales,
+cero `AssetDatabase`. Excelente red para fórmulas y determinismo; **casi nula
+para integración, flujo y datos reales**. Los agujeros se concentran donde viven
+los bugs de F1.
+
+### Top 8 tests (orden = riesgo eliminado / esfuerzo)
+
+Los **3 primeros documentan bugs reales de F1 como tests que HOY FALLAN** —
+ejecutables, no narrativa. Van **antes** de la cirugía: los que pasan congelan
+el comportamiento que la cirugía no debe romper; los que fallan son la spec
+ejecutable de los fixes.
+
+| # | Test propuesto | Agujero | Esfuerzo | Estado hoy | Destino |
+|---|---|---|---|---|---|
+| 1 | `ReportOutcome_AfterCombatEndHook_PreservesRelicHeal` | T1 (H1/H2) | M | **FALLA** = bug confirmado | **Pre-M4**, con fix H1/H2 |
+| 2 | `RunState_AfterDefeatWithZeroHp_RetryPathRestoresPlayableHp` | T2 (H3) | S | **FALLA**; puro RunState | **Pre-M4**, con fix H3 |
+| 3 | `StyleCharge_SuperEffectiveHitFullyBlocked_DoesNotGrantCharge` | T3 (H5) | S | depende de decisión | **Cirugía pre-M5** (fuerza decisión pre/post-block) |
+| 4 | `RelicAssets_AllDeclaredHooksAreDispatchable` | T5 | S | falta | **Pre-M4** (única validación datos↔código) |
+| 5 | `RelicGrantEffects_OnRealTurnManager_MutateState` (×10 param.) | T6 | M | falta | **Pre-M4** (media tabla de relics gana asserts) |
+| 6 | `GrantStyleCharge_Overshoot_ResetsAndGrantsSingleBonus` | T7 | S | falta | **Pre-M4** (invariante GOLDEN_RULES §4) |
+| 7 | `InitializeCombat_SecondCall_ResetsStyleStateAndRelicCounters` | T4 | S | falta | **Pre-M4** (congela contrato pre-cirugía) |
+| 8 | `NeutralCard_Applies90PercentDamage` | T9 | S | falta | **Pre-M4** (regla de balance viva) |
+
+Suplentes con apetito: **T8** `InitializeDeck_CalledTwice_DoesNotDuplicateStarterCard` (S), **T10** round-trip de tipos NewRun→combate (M).
+
+### Backlog de tests (con dueño)
+
+- **T11** RunMapGenerator: aciclicidad solo por rango, `AssignBossAct1` sin test, DepthPools múltiples nunca ejercitados. *(M)*
+- **T12** `TryChangeWorld`: ciclo B→A sin test, gate `_initialized==false` sin test, assert del modo debug que no valida nada. → **junto a la cirugía H6 pre-M5**. *(S)*
+- **T13** Transiciones de nodo post-victoria + ciclo `LastNodeOutcome`. Requiere **extraer la lógica a método estático puro primero** → junto al desguace de RunFlowController antes de 4b. *(L con refactor; S después)*
+
+---
+
+## 3. Hallazgos DOCUMENTALES (Fase 3)
+
+Problema dominante y sistémico: **la documentación describe el juego de hace dos
+milestones.** Ningún hallazgo es bug de código nuevo; el riesgo es de **proceso**
+— docs canónicos que inducen errores a futuro y contexto auto-cargado que
+describe sistemas muertos.
+
+> **GOLDEN_RULES.md y _gdd.md son archivos de Sebastián** (el hook bloquea a
+> Claude). El informe los marca pero **Sebastián los edita**; el texto propuesto
+> ya está en `fase3_docs.md §5`.
+
+### Cluster 1 — Momentum/One More: mecánica muerta documentada como vigente
+
+| ID | Sev | Esf | Hallazgo | Destino |
+|---|---|---|---|---|
+| **D1** | Mayor | M | `COMBAT_ARCHITECTURE`, `GLOSSARY`, `DEV_ONBOARDING` describen Momentum/FreePlays como sistema vigente (diagrama PlayCard, entradas de glosario, "HUD con Momentum"). Realidad: grep da 1 match — el comentario que afirma su ausencia. HUD real `"Estilo: X/5"`. | **Paquete docs (i)** |
+| **D2** | Mayor | M | `COMBAT_ARCHITECTURE` no menciona NINGÚN subsistema M2/M3 (hooks de Retazos, Contador de Estilo, HealAction, PhaseBased, pipeline de fin de combate). Estructuralmente vencido. | **Paquete docs (i)** (mismo PR) |
+| **D3** | Mayor | S | `GLOSSARY` congelado pre-M2: 21 entradas solo-M1, cero términos M2/M3, mantiene 2 entradas de sistema muerto. | **Paquete docs (i)** |
+
+### Cluster 2 — GOLDEN_RULES vencido o ambiguo (Sebastián edita)
+
+| ID | Sev | Esf | Hallazgo | Destino |
+|---|---|---|---|---|
+| **D4** | Mayor | — | §4:119 "+1 carga cuando hace daño SuperEficaz" no especifica pre/post-block; el código otorga **PRE-block**. **Es DECISIÓN de diseño** (ligada a H5). | **Decisión de Sebastián** → si post-block, entra a cirugía pre-M5 |
+| **D5** | Mayor | S | Tres ⏳ completamente vencidos: PhaseBased (M2-D), Shop (M3-3D), Campfire (M3-3C). | **Sebastián** (texto en F3 §5) |
+| **D6** | Mayor | S | §10:268 "pendiente, ver DD-017" — DD-017 cerrada 2026-05-07 (opción C); se shipearon 4 Retazos de cambio. | **Sebastián** (F3 §5) |
+
+### Cluster 3 — Docs de Retazos prescriben el patrón roto (raíz documental de H1/H2)
+
+| ID | Sev | Esf | Hallazgo | Destino |
+|---|---|---|---|---|
+| **D7** | Mayor | S | `RELICS.md:217-218,228,240` llama "vía segura" a la mutación directa de `PlayerCurrentHP` en OnCombatEnd = la receta literal de H1. Ironía: menciona GrantHeal como alternativa y la descarta — es exactamente al revés. | **Paquete docs (ii)**, con fix H1/H2 |
+| **D8** | Mayor | S | `m3_hooks_spec.md:364-368` [CERRADO 3] prescribe el mismo patrón; internamente inconsistente (su tabla :436 usa GrantHeal correcto). | **Paquete docs (ii)** |
+| **D9** | Mayor | S | El spec documenta la semántica encolar-vs-ejecutar pero NO sus dos consecuencias (Estilo pre-block; acciones encoladas se ejecutan aunque el actor muera). Componentes de H5. | **Paquete docs (ii)**, tras decisión D4/H5 |
+| **D10** | Mayor | S | `m3_hooks_spec.md:607-614` [IMPL 1] afirma que las cartas neutras NO dispatchean OnDamageDealt y "Reabrir en 3B" — la reapertura ocurrió y se implementó (8º dispatch); el spec nunca registró el cierre. | **Paquete docs (ii)** |
+
+### Cluster 4 — Docs técnicos con números/gaps fantasma
+
+| ID | Sev | Esf | Hallazgo | Destino |
+|---|---|---|---|---|
+| **D11** | Mayor | S | `_tech_snapshot`: "53 archivos C#" (real 108); TurnManager "735 loc" y "~960" contradiciéndose (real 1088); "Restricciones conocidas" lista 3 gaps resueltos hace un mes. | **Paquete docs (iii)** |
+| **D12** | Mayor | S | `Combat/CLAUDE.md:13-22`: 4 LOC vencidos (TurnManager 735 vs 1088) y omite CombatHudView/CombatBackgroundView. Contexto auto-cargado. | **Paquete docs (iii)** |
+| **D13** | Mayor | S | `Combat/CLAUDE.md:85-86` "Efectividad SOLO al daño del jugador... NUNCA al enemigo" **contradice DD-018** (bidireccional), GOLDEN_RULES §3 y el código. Inconsistencia interna a 2 líneas. Peligroso: es lo que un implementador lee antes de tocar combate. | **Paquete docs (iii)** (prioridad alta del paquete) |
+
+### Cluster 5 — Specs sin cerrar
+
+| ID | Sev | Esf | Hallazgo | Destino |
+|---|---|---|---|---|
+| **D14** | Mayor | S | Los 4 specs restantes (3E, 3F, tint, C7-arte) están **100% implementados** pero se presentan como "listo para implementación" con handoffs vigentes — riesgo de tomar un handoff como tarea pendiente. | **Paquete docs (iii)** + arreglo de proceso T3/F4 |
+
+### Barrido ⏳ — huérfanos netos (regla cerrada por diseño sin sub-tarea dueña)
+
+- **Cartas con efecto WorldSwitch (§2):** Retazos ✓ (M3) pero las cartas no; `EffectType` sin WorldSwitch; ningún bloque del roadmap lo agenda. → **adoptar o declarar diferido**.
+- **Tiers de economía DD-009 (§8):** un solo `goldReward=10`; cartas de oro no existen. **Agravante: el balance de tienda 2026-06-04 se calibró asumiendo ~10 oro/nodo — la economía vigente contradice los tiers del doc.** → **adoptar o declarar diferido (con la contradicción explícita)**.
+- Huérfanos tolerables/diferidos: rangos DD-010 (balance), categoría "De mundo", consumibles (rastreado), elite con mecánica única (micro).
+
+### 🆕 HP base: discrepancia confirmada (cabo suelto de F3, resuelto en F5)
+
+| Sev | Esf | Hallazgo | Destino |
+|---|---|---|---|
+| Menor | S | **GOLDEN_RULES §9 dice "HP base 70"; el juego corre con 60.** Verificado: `BattleScene.unity:434` serializa `playerMaxHP: 60`, coincidiendo con el default de `TurnManager.cs:26`. No es drift de un solo lado — código y escena concuerdan en 60; **el doc es el que está vencido, o hubo una decisión de balance no registrada.** | **Sebastián decide** la verdad (subir escena+código a 70, o corregir §9 a 60). Si es 60 deliberado → nota en GOLDEN_RULES |
+
+### Menores documentales (al backlog de la pasada de docs)
+
+- **GDD (Sebastián):** "One More" residual (:6, :115); DD-010 con rangos contradictorios duplicados; "tres categorías" donde DD-014 cerró 2; Mundo B "Futurista" vs "Cyberpunk" (inconsistencia interna).
+- **MECHANIC_DUALITY.md** se autodenomina "biblia activa" con sección "One More". OJO: su §6.2 tiene la ÚNICA definición buena de "transdimensional".
+- **"Transdimensional" con 3 usos inconsistentes** — alinear GOLDEN_RULES §6 y GLOSSARY con la definición existente de MECHANIC_DUALITY:143-149 (no crear una nueva).
+- **GOLDEN_RULES §4:122-125** — no especifica el destino del contador con bonus pendiente; el código acumula >5 sin reset ni clamp. Decidir: ¿acumula o capea?
+- **_tech_snapshot menores:** "suite 142/142" (header dice 146); "No gh CLI" (gh 2.92.0 usado en #96-#108); "No CI/CD" (impreciso, tests.yml parqueado); LOC menores corridos.
+- **Combat/CLAUDE.md:37-39** lista como "futuros que requieren aprobación" dos ya implementados (Heal, PhaseBased).
+- **m3_hooks_spec:** 5 referencias de línea corridas (citar métodos, no líneas); naming de payloads divergió.
+- **Verificación positiva:** DD-022/023 SÍ están pegados en DESIGN_DECISIONS (en disco, **sin commitear**).
+
+---
+
+## 4. Hallazgos de WORKFLOW / TOOLING (Fase 4)
+
+| ID | Sev | Esf | Hallazgo | Destino |
+|---|---|---|---|---|
+| **T1** | Mayor | S | **Bypass real del hook protect-files.** El hook solo engancha `Edit\|Write\|MultiEdit\|NotebookEdit`; `Bash(npx unity-mcp-cli *)` está auto-aprobado y permite `script-update-or-create`/`script-delete` del plugin MCP, que **sobreescriben `.cs` en disco — incluido TurnManager.cs — sin prompt ni hook.** | **Pre-M4** (matcher Bash en el hook + T9 cierra el otro lado) |
+| **T2** | Mayor | S | `DEV_ONBOARDING.md` describe el juego pre-M2/M3: Momentum en el HUD, popup "MOMENTUM +1", solo 4 commands (falta `/cierre-sesion`), "Dónde mirar primero" 100% combate (ignora el Run layer post-M3). | **Paquete docs (i)** (mismo PR que D1-D3) |
+| **T3** | Mayor (proceso) | S | El paso "marcar spec como IMPLEMENTADO" (D14) **no tiene dueño**: ni la plantilla de Spec Técnico tiene campo Estado, ni `/cierre-sesion` ni `_modo_implementacion` lo mencionan. | **Pre-M4** (editar cierre-sesion + plantilla + marcar 4 specs retro) |
+| **T4** | Menor | S | Ruido en `settings.json`: 3 permisos MCP redundantes superpuestos, `Read(//tmp/**)` de otra plataforma, deny solo cubre `rm` (falta `Remove-Item`/`del`/`rd` de PowerShell). | **PR de tooling** |
+| **T5** | Menor | S | Higiene de memoria: 2 huérfanas no indexadas (`project_next_phase.md`, `project_newrun_3e_spec.md`); MEMORY.md (~10 KB) viola su regla "1 línea por memoria" (la sección "Estado actual" son párrafos largos). | **Higiene al cierre de auditoría** |
+| **T6** | Menor | S | Conteos de tools inconsistentes (77 reales vs "~70" WORKFLOW_GUIDE vs "~73" DEV_ONBOARDING); `/cierre-sesion` omitido en WORKFLOW_GUIDE §4; `cierre-sesion.md` sin frontmatter. | **Paquete docs (i)** (mismo PR que T2) |
+| **T9** | Oportunidad | S | **~36 de 77 skills Unity-MCP son carga muerta desactivable** vía `tool-set-enabled-state` (profiler de control, package-*, mutación de assets/prefabs/gameobjects, script-read/delete/update-or-create…). NO borrar carpetas (se regeneran). **Cierra parcialmente T1** (deshabilitar script-update-or-create mata el vector principal). | **Decisión de Sebastián** (1 llamada, reversible) |
+| **T10** | Oportunidad | S | `model: sonnet` en frontmatter de `cierre-sesion.md` (automatiza el hábito manual + resuelve T6); `/fewer-permission-prompts` para curar el allowlist objetivamente (insumo de T4). | **PR de tooling** |
+
+### Sanos auditados (sin hallazgo)
+
+`protect-files.js` (lógica interna correcta; el único agujero es la superficie
+T1); los 7 archivos de `Docs/dev/modes/`; los 4 commands `modo-*`; el
+`.gitignore` de `.claude/`; `settings.local.json` (1 regla coherente, **sin drift**).
+
+---
+
+## 5. Descartados por el verify (consolidado)
+
+### De Fase 1 (código)
+- **Efectividad stale si el mundo cambia entre prepare y resolve:** falso — la efectividad depende del elemento de la carta (fijado al preparar) y del tipo del enemigo (inmutable en combate); `currentWorld` no entra al cálculo.
+- **Softlock por cola pendiente:** el guard de Update solo bloquea el AUTO end-turn; el botón End Turn drena la cola.
+- **Muerte del callback de PlayAttackOnce (energía perdida/carta en limbo):** modos de muerte no alcanzables (guard `_isPlayingAttack` + botones deshabilitados + animator sin otros callers).
+- **PhaseBased "sin estado" como mayor:** factualmente exacto pero ya trackeado en Future work.
+
+### De Fase 2 (tests)
+- **T4 (mitad):** el reset de Estilo/Bonus en `InitializeCombat` SÍ existe y los counters SÍ tienen test intra-combate; lo que queda sin red es el cross-combate (degradado a caracterización + documentación del counter de R-6).
+
+### De Fase 3 (docs)
+- **C6 (DispatchCombatEnd como "divergencia" del spec):** lectura forzada — el spec prescribe punto y momento de invocación y el código lo cumple literalmente; la extracción del helper es refactor interno no contradictorio.
+
+### De Fase 4 (tooling)
+- **Drift settings.json ↔ settings.local.json** (sospecha del plan): no existe — el local tiene 1 regla coherente.
+- **7 de 10 tips del agente de Claude Code:** features inexistentes o mal descritas (output styles con JSON de reglas, frontmatter `paths:`, `promptCacheConfig`, `/batch`, hook `PermissionRequest` como lo describió), o de valor marginal (SessionStart con assets-refresh, PreCompact snapshot).
+- **Hook PostToolUse para de-scope** de settings/.slnx: mecanismo incorrecto — la auto-modificación la hace el harness, no una tool Edit/Write, así que el hook nunca dispararía. Alternativa viable si se quiere automatizar: git pre-commit hook. Veredicto: nice-to-have; el paso manual del ritual ya lo cubre.
+
+---
+
+## 6. Tabla maestra de prioridad
+
+| Frente | Items | Severidad | Esfuerzo total | Cuándo |
+|---|---|---|---|---|
+| **Bugs player-facing** | H1, H2, H3, H4 + tests T1, T2 | Mayor | S-M | **Pre-M4** (sub-PR 1) |
+| **Red de tests pre-cirugía** | T4-T9 (tests 4-8) | — | S-M | **Pre-M4** (sub-PR 2) |
+| **Verdad documental** | D1-D3, D7-D14, T2, T6, HP | Mayor (proceso) | M | **Pre-M4** (sub-PRs 3-5, paquetes i/ii/iii) |
+| **Seguridad del tooling** | T1, T3, T4, T9, T10 | Mayor | S | **Pre-M4** (sub-PR 6 + decisión T9) |
+| **Bloque 4c del roadmap** | H7 | Mayor | M | **M4 (ya agendado)** |
+| **Cirugía única de TurnManager** | H5, H6, H8, H9 + tests T3, T12 + decisión D4 | Mayor | M-L | **Pre-M5 (diseño aprobado)** |
+| **Desguace de RunFlowController** | god-object + dup Shop↔Campfire + T13 | Menor | M | **Antes de 4b** |
+| **Backlog de menores** | ~20 ítems S | Menor | S c/u | Oportunista |
+
+Detalle de secuencia, dependencias y sub-PRs en **`PLAN_PRE_M4.md`**.
+
+---
+
+*Fase 5 cerrada 2026-06-12. Síntesis inline (sin fan-out). Verificación del
+cabo suelto: `BattleScene.unity:434` = `playerMaxHP: 60`. Consumo F5: ~6
+lecturas (4 checkpoints + 2 memorias) + 2 greps + escritura de los 2
+entregables; cero subagentes.*

--- a/Docs/dev/audits/2026-06/PLAN_PRE_M4.md
+++ b/Docs/dev/audits/2026-06/PLAN_PRE_M4.md
@@ -1,0 +1,220 @@
+# Plan de remediación pre-M4 — Auditoría integral 2026-06
+
+> **Sesión:** 2026-06-12 (Fase 5). **Estado: PROPUESTA.** Sebastián aprueba qué
+> entra al roadmap, en qué orden y qué se difiere/descarta.
+> **Insumo:** `AUDIT_REPORT.md` (este plan no re-deriva hallazgos, los secuencia).
+> **Filosofía:** sub-PRs chicos estilo M3 (un tema por PR, mergeable solo,
+> reversible), ordenados por dependencia. Nada toca archivos protegidos salvo la
+> cirugía pre-M5, que va aparte con diseño aprobado.
+
+---
+
+## 0. Mapa de decisiones que bloquean trabajo
+
+**D-A, D-B y D-C resueltas por Sebastián el 2026-06-12** (abajo, con sus
+consecuencias). **D-D sigue abierta** (se decide al actualizar el roadmap de M4).
+
+| Decisión | Resolución (2026-06-12) | Consecuencia operativa |
+|---|---|---|
+| **D-A. Semántica del Estilo: ¿pre o post-block?** (D4/H5) | **PRE-block (ratificado).** Todo golpe SuperEficaz otorga carga aunque el enemigo lo bloquee al 100%. = comportamiento actual del código. | **SIN cambio de lógica.** ① El test T3 **se INVIERTE**: pasa a `StyleCharge_SuperEffectiveHitFullyBlocked_StillGrantsCharge` (asserta que SÍ otorga). ② GOLDEN_RULES §4 (Sebastián): "+1 carga cuando el ataque es SuperEficaz; el bloqueo del enemigo NO anula la carga". ③ Corregir el comentario "daño real" de `TurnManager.cs:634` para aclarar que el pre-block es intencional (edit chico, protegido → Sebastián aprueba; va con el paquete docs/comentarios). |
+| **D-B. Contador de Estilo: ¿acumula >5 o capea a 5?** (A12) | **Capea a 5.** | **ES UN BUG a arreglar.** El código hoy acumula >5 vía relics (`TurnManager.cs:992-996`; solo `SetStyleChargesForTest` clampa). Fix pequeño en TurnManager (protegido → Sebastián aprueba) que **acompaña al test T7** (`GrantStyleCharge_Overshoot_ResetsAndGrantsSingleBonus`). El test hoy fallaría → documenta el bug. |
+| **D-C. HP base: ¿60 o 70?** | **60.** | Código y escena ya están en 60 → **sin cambio de código**. Corregir GOLDEN_RULES §9 (Sebastián) de 70 → 60. |
+| **D-D. Huérfanos: ¿adoptar o diferir?** cartas WorldSwitch + tiers DD-009 | **ABIERTA** | Se decide al actualizar el roadmap de M4. |
+
+> **Impacto de D-A en la cirugía pre-M5:** como el Estilo queda pre-block por
+> diseño, ese punto **sale** del alcance de la cirugía (era un "si es post-block"
+> condicional). La cirugía pre-M5 se concentra en H5 (resto de la semántica
+> encolar-vs-ejecutar: Defeat vs Victory, actor muerto que ataca), H6, H8, H9.
+> **Impacto de D-B:** el cap a 5 es un fix chico y aislado en TurnManager — se
+> puede hacer ya (con aprobación de edición del protegido), no necesita esperar
+> a la cirugía.
+
+---
+
+## 1. Secuencia por dependencias
+
+```
+                    ┌─────────────────────────────────────────────┐
+   DECISIONES  →    │ D-A pre/post-block · D-B cap Estilo · D-C HP │
+                    └─────────────────────────────────────────────┘
+                                      │
+        ┌─────────────────────────────┼─────────────────────────────┐
+        ▼                             ▼                             ▼
+  ┌───────────┐               ┌───────────────┐            ┌──────────────┐
+  │ SUB-PR 1  │  bugs sync    │  SUB-PR 6     │ seguridad  │ SUB-PRs 3-5  │ docs
+  │ H1-H4     │ ◄── tests ──► │  tooling T1   │ tooling    │ paquetes i/  │
+  │ +T1,T2    │   T1,T2        │  T3,T4,T9,T10│            │ ii/iii       │
+  └───────────┘               └───────────────┘            └──────────────┘
+        │  (T1/T2 dependen del fix; los demás tests son independientes)
+        ▼
+  ┌───────────┐
+  │ SUB-PR 2  │  red de tests pre-cirugía (T4-T9)
+  └───────────┘
+        │
+        ▼  (todo lo anterior cerrado = base estable)
+  ┌─────────────────────────────────────────────┐
+  │  M4 bloque 4a/4b/4c (roadmap existente)      │  ← H7 = 4c
+  │  + desguace RunFlowController ANTES de 4b    │
+  └─────────────────────────────────────────────┘
+        │
+        ▼  (con la red de tests como contrato congelado)
+  ┌─────────────────────────────────────────────┐
+  │  CIRUGÍA ÚNICA DE TURNMANAGER (pre-M5)        │  H5,H6,H8,H9 + T3,T12 + D-A
+  │  diseño aprobado · archivos protegidos       │
+  └─────────────────────────────────────────────┘
+```
+
+Los sub-PRs 1, 3-5 y 6 son **independientes entre sí** → pueden ir en paralelo o
+en cualquier orden. El sub-PR 2 (tests T1/T2) depende del sub-PR 1. La cirugía
+pre-M5 depende de que la red de tests esté completa.
+
+---
+
+## 2. Sub-PRs pre-M4 (detalle)
+
+### SUB-PR 1 — Fix de sincronización fin-de-combate + retry `feat/fix-combat-end-sync`
+
+**Cierra:** H1, H2, H3, H4 (+ tests T1, T2 que los documentan).
+**Esfuerzo:** M (el cluster comparte raíz; un solo PR coherente).
+**No toca protegidos** (BattleFlowController y RunFlowController no lo son).
+
+- Sincronizar `RunState.PlayerCurrentHP` **antes** de `DispatchCombatEnd`, o que el ctx de relics lea/escriba el HP del actor → arregla H1 y H2 de raíz.
+- Botón Reintentar: restaurar HP jugable antes de re-inicializar combate → H3.
+- Unificar los dos paths de reset: los botones defeat/acto pasan por `RunSession.ResetForNewRun` (o cargan MainMenuScene) → H4; de paso resuelve el TODO stale de `:701`.
+- **Tests incluidos (escribir PRIMERO, deben fallar, luego pasar):**
+  - `ReportOutcome_AfterCombatEndHook_PreservesRelicHeal` (T1)
+  - `RunState_AfterDefeatWithZeroHp_RetryPathRestoresPlayableHp` (T2)
+- Obstáculo conocido (T1): mockear/extraer `SceneTransitionManager.LoadScene` de `ReportOutcome`.
+- **Coordina con:** paquete docs (ii) — el fix invalida la "vía segura" de RELICS.md (D7/D8).
+
+### SUB-PR 2 — Red de tests pre-cirugía + cap de Estilo `feat/test-net-pre-surgery`
+
+**Cierra:** T3, T4, T5, T6, T7, T9 (los 6 tests pendientes del top 8) + el fix
+del cap a 5 (D-B) + suplentes opcionales.
+**Esfuerzo:** S-M (todos EditMode puros, verificados factibles uno a uno) + un
+fix chico en TurnManager.
+**Depende de:** D-A y D-B (ambas ya resueltas → desbloqueado).
+**Incluye 1 edición de archivo protegido** (cap a 5 en TurnManager) → Sebastián
+aprueba la edición en el hilo principal.
+
+- `RelicAssets_AllDeclaredHooksAreDispatchable` (T5) — única validación datos↔código; carga los 23 `.asset` reales.
+- `RelicGrantEffects_OnRealTurnManager_MutateState` ×10 param. (T6) — media tabla de relics gana asserts de conducta.
+- `StyleCharge_SuperEffectiveHitFullyBlocked_StillGrantsCharge` (T3, **invertido por D-A**) — ratifica que el pre-block otorga carga aunque el golpe se bloquee al 100%. Hoy PASA (congela comportamiento).
+- `GrantStyleCharge_Overshoot_ResetsAndGrantsSingleBonus` (T7) — invariante de D-B (cap a 5). **Hoy FALLA** → documenta el bug; se arregla en este mismo PR con el cap en `TurnManager.cs:992-996`.
+- `InitializeCombat_SecondCall_ResetsStyleStateAndRelicCounters` (T4) — congela el contrato; documenta el counter que sangra (R-6).
+- `NeutralCard_Applies90PercentDamage` (T9) — regla de balance viva.
+- **Suplentes si hay apetito:** T8 (`InitializeDeck` ×2), T10 (round-trip de tipos).
+- **Propósito:** estos tests **congelan el comportamiento que la cirugía pre-M5 no debe romper.** Por eso van antes.
+
+### SUB-PR 3 — Docs paquete (i): Momentum → Estilo `docs/momentum-to-style`
+
+**Cierra:** D1, D2, D3, B11 + **T2 y T6 de F4** (mismo PR, todos son docs de onboarding/arquitectura).
+**Esfuerzo:** M (reescritura de COMBAT_ARCHITECTURE; S para los demás).
+
+- `COMBAT_ARCHITECTURE.md`: reescribir con Estilo + flujo Prepare/Resolve + subsistemas M2/M3 (hooks, HealAction, PhaseBased, pipeline fin-de-combate).
+- `GLOSSARY.md`: purgar entradas muertas, agregar términos M2/M3.
+- `DEV_ONBOARDING.md`: HUD real, popup real, 5 commands, "Dónde mirar primero" con el Run layer (T2).
+- Unificar conteo de skills a "~75+, ver `unity-tool-list`" (T6); agregar `/cierre-sesion` a WORKFLOW_GUIDE §4.
+
+### SUB-PR 4 — Docs paquete (ii): verdad de Retazos `docs/relics-truth`
+
+**Cierra:** D7, D8, D9, D10.
+**Esfuerzo:** S.
+**Coordina con:** SUB-PR 1 (el fix de H1/H2 define cuál es la "vía segura" real).
+**Depende de:** decisión D-A (D9 documenta las consecuencias de la semántica).
+
+- `RELICS.md`: corregir §217-218/228/240 — la mutación directa de `PlayerCurrentHP` en OnCombatEnd es el patrón ROTO; GrantHeal sobre el actor es la vía correcta. Agregar regla de autoría (orden de hooks T1 OnPlayerTurnStart/OnCombatStart).
+- `m3_hooks_spec.md`: corregir [CERRADO 3] y la inconsistencia con su tabla :436; registrar el cierre de [IMPL 1] (8º dispatch de cartas neutras); subsección "Consecuencias de la semántica" tras D-A; arreglar referencias de línea corridas (citar métodos).
+
+### SUB-PR 5 — Docs paquete (iii): números y estado `docs/numbers-and-state`
+
+**Cierra:** D11, D12, D13, D14 + el arreglo de proceso T3 + HP (tras D-C).
+**Esfuerzo:** S (mecánico).
+
+- `_tech_snapshot.md`: 108 scripts, TurnManager 1088 LOC, purgar "Restricciones conocidas" (3 gaps resueltos), suite 146, gh CLI presente, CI parqueado, LOC corridos.
+- `Combat/CLAUDE.md`: LOC actuales, agregar CombatHudView/CombatBackgroundView, **corregir D13** (efectividad bidireccional — DD-018; es lo más peligroso del paquete), sacar Heal/PhaseBased de "futuros que requieren aprobación".
+- **D14 + T3 (proceso):** marcar los 4 specs (3E/3F/tint/C7) con header `> **ESTADO: IMPLEMENTADO — PR #N (fecha)**`; agregar campo Estado a la plantilla de Spec Técnico; agregar paso "marcar spec IMPLEMENTADO" a `/cierre-sesion`.
+- **HP (tras D-C):** si la verdad es 70 → subir `BattleScene.unity:434` + `TurnManager.cs:26`; si es 60 → corregir GOLDEN_RULES §9 (lo toca Sebastián) + nota de decisión.
+
+### SUB-PR 6 — Tooling: cerrar el bypass + limpieza `chore/tooling-hardening`
+
+**Cierra:** T1, T3 (parte de proceso ya en sub-PR 5), T4, T10.
+**Esfuerzo:** S.
+
+- **T1 (mayor):** agregar al hook `protect-files.js` un matcher `Bash` que bloquee si el comando contiene `script-update-or-create|script-delete` junto a un nombre protegido + 1 entrada en `settings.json`.
+- **T4:** consolidar los 3 permisos MCP redundantes en uno; sacar `Read(//tmp/**)`; agregar `Remove-Item`/`del`/`rd /s` al deny (equivalentes PowerShell de `rm`).
+- **T10:** `model: sonnet` en frontmatter de `cierre-sesion.md` (resuelve también el frontmatter faltante de T6); correr `/fewer-permission-prompts` para curar el allowlist con datos reales.
+
+---
+
+## 3. Decisiones de Sebastián fuera de PR (archivos protegidos)
+
+Estos NO son sub-PRs de Claude — Sebastián los edita (el hook lo bloquea):
+
+- **GOLDEN_RULES.md:** D5, D6 (texto listo en `fase3_docs.md §5`), D4/§4 (tras D-A), §4:122-125 (tras D-B), §9 HP (tras D-C), "transdimensional" (alinear con MECHANIC_DUALITY:143-149), §2 cartas WorldSwitch (asignar dueño o diferir).
+- **_gdd.md:** "One More" residual, DD-010 rangos duplicados, "tres categorías", Mundo B Futurista/Cyberpunk.
+- **MECHANIC_DUALITY.md:** nota de cabecera o archivar la sección "One More" (preservando §6.2).
+
+---
+
+## 4. Cirugía única de TurnManager (pre-M5) — NO pre-M4
+
+> **Va aparte, con diseño aprobado, en `modo:diseno` dedicado.** Toca los 3
+> archivos protegidos. La red de tests del sub-PR 2 es su contrato congelado.
+
+**Paquete a resolver de una sola apertura** (en vez de 4 incrementales):
+
+- **H5** — decidir y documentar el resto de la semántica encolar-vs-ejecutar:
+  drain post-hook, Defeat prioritario sobre Victory, `DamageAction.Execute` sin
+  chequeo de source vivo (enemigo muerto que ataca), comentario engañoso de
+  `:856`. **El sub-punto del Estilo pre/post-block YA NO entra** (D-A lo cerró
+  como pre-block; el cap a 5 de D-B se hace antes en el sub-PR 2).
+- **H6** — firma de `TryChangeWorld` con Initiator + punto de veto (Desfase Dimensional M5, bosses M6 que bloquean el cambio).
+- **H8** — sustrato de status/debuff + extraer la lógica duplicada de actors a un punto de intercepción único (Virus block 80%, Sangrado tick/expiración). **Esfuerzo L — el más grande del paquete.**
+- **H9** — introducir `CurrentAct` (evita migrar el bool `ActoCompleted` después).
+- **Tests asociados:** T12 (ciclo B→A, gate, modo debug). (T3 ya se cubre en el sub-PR 2.)
+- **Oportunidades a absorber:** base `RelicEffectBase<THookData>`, `MaxStyleCharges` expuesto, migrar fin-de-combate a evento, `currentWorld` reset en `InitializeCombat`.
+
+**Esfuerzo total:** M-L. **Riesgo:** alto (archivos protegidos) → de ahí la
+exigencia de red de tests completa + diseño aprobado antes de abrir.
+
+---
+
+## 5. Dentro de M4 (roadmap existente, no remediación)
+
+- **H7** = bloque **4c** (transdim+ancla): tipo de enemigo con `TypeWorldB`/`IsAnchor`, indirección como la del jugador. El verify confirmó que la extensión es limpia y acotada. Ya agendado.
+- **Desguace de `RunFlowController`** (god-object 885 LOC + duplicación Shop↔Campfire): **antes de 4b** (EventNodeController sería la 3ª copia). Habilita el test T13 (extraer transiciones de nodo a método estático puro). Esfuerzo M.
+
+---
+
+## 6. Diferido / descartado
+
+**Diferido al backlog (oportunista, sin urgencia):**
+- Menores de código S sueltos: `SaveSmokeTest` (borrar gratis), clamp de `totalNodes`, hardening de `SceneTransitionManager`, residuo M17 End-Turn-durante-animación, `RelicDebugOverlay.RemoveRelic()`, counters que sangran entre combates (R-6/skill-stacker, decisión + fix simétrico).
+- Recompensa post-combate no randomizada (distorsiona playtests; S-M).
+- Oportunidades de refactor: `UIFactory`, `EnsureEventSystem` helper único, `EnemyIntentType` extensible.
+- T11 (RunMapGenerator), T13 (transiciones de nodo) → backlog con dueño.
+
+**Diferido por diseño (huérfanos tolerables):** rangos DD-010 (balance), categoría "De mundo", consumibles (rastreado), elite con mecánica única.
+
+**A decidir si se adoptan o se declaran diferidos (D-D):** cartas WorldSwitch, tiers DD-009 (con su contradicción de balance explícita en el roadmap).
+
+**Descartado (ver `AUDIT_REPORT.md §5`):** efectividad stale, softlock por cola, muerte de PlayAttackOnce, PhaseBased "sin estado", drift settings↔local, 7/10 tips de Claude Code, hook PostToolUse para de-scope, C6.
+
+---
+
+## 7. Orden recomendado de ejecución
+
+1. **Pasada de decisiones** (D-A, D-B, D-C; D-D al cerrar roadmap) — corta, conversacional o `modo:diseno`.
+2. **SUB-PR 1** (bugs sync + tests T1/T2) — lo más valioso, bugs player-facing.
+3. **SUB-PR 6** (tooling T1) — cierra el agujero de seguridad; barato e independiente.
+4. **SUB-PRs 3-5** (docs) — en paralelo a lo anterior; sanea el contexto auto-cargado antes de seguir codeando.
+5. **SUB-PR 2** (resto de la red de tests) — completa el contrato.
+6. **Higiene de memoria** (T5) — al cerrar la auditoría (ver nota de cierre).
+7. **M4:** desguace de RunFlowController → 4a → 4b → 4c (H7).
+8. **Cirugía única de TurnManager** (pre-M5) — con la red de tests como contrato.
+
+---
+
+*Plan propuesto 2026-06-12. Es propuesta: Sebastián aprueba alcance, orden y qué
+entra al roadmap. Detalle de cada hallazgo en `AUDIT_REPORT.md`.*

--- a/Docs/dev/audits/2026-06/fase0_scoping.md
+++ b/Docs/dev/audits/2026-06/fase0_scoping.md
@@ -1,0 +1,122 @@
+# Auditoría integral 2026-06 — Fase 0: Scoping
+
+> **Sesión:** 2026-06-10 · **Modo:** auditoría dedicada (solo lectura, sin fixes)
+> **Regla de la sesión:** hallazgos → ítems de roadmap/pulidos con aprobación de
+> Sebastián. Verificación adversarial antes de entrar al reporte final.
+> **Output final:** `AUDIT_REPORT.md` en esta carpeta (Fase 5).
+
+---
+
+## 1. Inventario real (medido en disco, no según docs)
+
+| Superficie | Medido | Lo que dicen los docs |
+|---|---|---|
+| Scripts runtime (`Assets/Scripts/**/*.cs`) | **108** | `_tech_snapshot` dice "53 archivos C#" |
+| Scripts editor (`Assets/Editor/`) | 4 | snapshot solo lista 1 (RelicSoGenerator) en su sección Editor |
+| Archivos de test (`Assets/Tests/EditMode/`) | 17 | ✓ coincide (suite 146/146) |
+| `TurnManager.cs` LOC | **1088** | snapshot dice 735 (árbol) y ~960 (tabla protegidos) — inconsistente consigo mismo |
+| `RunFlowController.cs` LOC | 885 | no reportado — hoy es el 2º archivo más grande |
+| `CombatUIController.cs` LOC | 752 | snapshot dice 710 |
+| Docs activos (`Docs/**/*.md`, sin `_archive`) | ~29 | — |
+| Tooling `.claude/` | settings.json + settings.local.json, 1 hook (`protect-files.js`), 5 commands, ~85 skills Unity-MCP | — |
+
+**Nota:** el delta 53→108 no es alarmante en sí (los 23 relic effects + ~10 hook
+data + M3 explican la mayoría), pero confirma que `_tech_snapshot` arrastra
+números de antes de M3 en varias secciones. Va al barrido de Fase 3.
+
+## 2. Señales detectadas durante el scoping (a verificar en su fase)
+
+Sin verificar todavía — solo lo que saltó leyendo los 4 archivos base:
+
+- **[→F3]** `GOLDEN_RULES.md` no se actualiza desde 2026-04-28 (pre-M2-cierre).
+  Estados ⏳ visiblemente vencidos: §7 Shop/Campfire ⏳ (implementados en 3C/3D),
+  §6 "PhaseBased pendiente en M2" (M2 Sub-PR D lo implementó). El barrido
+  completo de ⏳ (¿implementado? ¿dueño en milestone? ¿huérfano?) es el corazón
+  de Fase 3.
+- **[→F3]** `_tech_snapshot` con drift interno (LOC de TurnManager en 3 valores
+  distintos, conteo de scripts, sección Editor incompleta, "suite 142/142" en
+  sección Tests vs 146 en header).
+- **[→F1]** `RunFlowController` (885 LOC) creció hasta ser el 2º archivo del
+  proyecto sin estar en ninguna lista de vigilancia — instancia Campfire, Shop,
+  mapa, RelicInventoryView y panel de resolve. Candidato a revisión de
+  acoplamiento antes de que 4b (eventos) le sume otro controller.
+- **[→F2]** Los gaps conocidos del snapshot ("Restricciones conocidas") dicen
+  que PhaseBased no está implementado, pero el roadmap M2-D dice que sí, con
+  tests. Hay que ver cuál miente y si el test realmente cubre rangos de HP.
+
+## 3. Plan de fan-out por fase
+
+Presupuesto relativo estimado (sobre el gasto total de la auditoría):
+
+| Fase | Tema | Mecánica | Agentes est. | Costo rel. |
+|---|---|---|---|---|
+| 1 | Código y arquitectura | Workflow multi-agente | ~10-15 | ~35-40% |
+| 2 | Tests | Workflow chico | ~5-7 | ~15% |
+| 3 | Coherencia documental | Workflow chico | ~6-8 | ~20% |
+| 4 | Workflow Claude + tooling | Mayormente inline + 1-2 agentes | ~2-3 | ~10-15% |
+| 5 | Síntesis | Inline (consolidación) | 0-1 | ~10% |
+
+### Fase 1 — Código y arquitectura → `fase1_codigo_arquitectura.md`
+- **Find (paralelo, 5 lectores por subsistema):**
+  1. Combat core (TurnManager, ActionQueue, actors, Actions/) — solo lectura
+  2. Relics (dispatcher, hooks, 23 effects, RelicInstance)
+  3. Run layer (RunFlowController, BattleFlowController, RunState/Session, Shop/Campfire/NewRun)
+  4. Map + datos (RunMapGenerator, configs, Cards/, Enemies/, Save/)
+  5. Presentación (CombatUIController + 4 views, RunMapView, RelicInventoryView, Core/UI)
+  Cada lector devuelve JSON: violaciones GOLDEN_RULES §12 (capas), acoplamientos,
+  duplicación, deuda escondida (TODOs, workarounds, números mágicos).
+- **Lente M5/M6 (paralelo con lo anterior):** 1 agente dedicado leyendo
+  TurnManager + EnemyCombatActor + EnemyMove contra los requisitos concretos de
+  M5 (fases al 50%, Desfase Dimensional, debuffs Sangrado/Virus, 2 tipos por
+  boss) y M6 (transdim, ancla, bloqueo de cambio): qué va a doler y dónde.
+- **Barrier:** dedup + triage de hallazgos (descartar cosméticos).
+- **Verify (paralelo):** 1 verificador adversarial por hallazgo mayor:
+  ¿es real? ¿es relevante para M5/M6? ¿ya está resuelto/registrado en roadmap?
+- Riesgo de desproporción: BAJO-MEDIO. Si el find devuelve >25 hallazgos
+  mayores, freno antes del verify y propongo recorte.
+
+### Fase 2 — Tests → `fase2_tests.md`
+- 3 lectores en paralelo: (a) inventario real de qué ASSERTA cada uno de los 17
+  archivos (no qué dice cubrir), (b) superficie de riesgo sin tocar: flujo de
+  run completo (NewRun→mapa→combate→outcome→reward), transiciones de RunState,
+  BattleFlowController, edge cases del Contador de Estilo (cap, -1 en 0,
+  no-acumulable, interacción con relics de switch), (c) cruce con los gaps
+  que Fase 1 haya marcado como riesgo M5/M6.
+- Verify liviano: confirmar que cada "agujero" reportado de verdad no está
+  cubierto (grep dirigido sobre los tests).
+- Cierre: top 5-10 tests propuestos, ordenados por riesgo eliminado/esfuerzo.
+
+### Fase 3 — Coherencia documental → `fase3_docs.md`
+- **Barrido ⏳ (1 agente):** tabla exhaustiva de TODOS los ⏳ de GOLDEN_RULES →
+  estado real en código (implementado/parcial/no) + dueño en roadmap (bloque
+  concreto) o **HUÉRFANO**. Precedente DD-022: 6 semanas sin dueño.
+- **Cruces (3 agentes en paralelo):** (a) GDD ↔ GOLDEN_RULES ↔ DESIGN_DECISIONS
+  (decisiones cerradas no reflejadas, contradicciones), (b) docs técnicos ↔
+  código (números viejos, promesas falsas, secciones vencidas de _tech_snapshot,
+  COMBAT_ARCHITECTURE, GLOSSARY, Combat/CLAUDE.md), (c) specs en `Docs/dev/specs/`
+  ↔ implementación mergeada (¿algún spec promete algo que no llegó?).
+- Verify: confirmación puntual contra código de cada "violación" reportada.
+
+### Fase 4 — Workflow Claude + tooling → `fase4_workflow_tooling.md`
+- Inline (yo, sin fan-out): `settings.json` + `settings.local.json` (drift entre
+  ambos, permisos), `hooks/protect-files.js` (¿cubre los 3 protegidos? ¿bypasses?),
+  5 commands, archivos de modos, MEMORY.md (memorias vencidas), CLAUDE_WORKFLOW_GUIDE.
+- 1-2 agentes: costo/beneficio de las ~85 skills Unity-MCP (cuáles se usan según
+  historial de docs/PRs) + tips de Claude Code no aplicados a esta escala de
+  proyecto.
+
+### Fase 5 — Síntesis → `AUDIT_REPORT.md`
+- Inline: consolidar SOLO hallazgos que pasaron verify. Formato: severidad
+  (crítico/mayor/menor/oportunidad), esfuerzo estimado (S/M/L), propuesta
+  de destino (roadmap M4/M5/pulido/descartar + por qué).
+
+## 4. Criterios transversales
+
+- Todo hallazgo entra con referencia `archivo:línea` verificable.
+- "Prefiero 10 sólidos que 40 especulativos": el verify mata especulación;
+  los descartados quedan listados en una sección corta "descartados y por qué".
+- Cada fase cierra con: archivo escrito + resumen corto en chat + consumo
+  aproximado + GO/NO-GO de Sebastián.
+
+---
+*Consumo Fase 0: mínimo (~4 lecturas de docs + 3 globs + 1 conteo; sin subagentes).*

--- a/Docs/dev/audits/2026-06/fase1_codigo_arquitectura.md
+++ b/Docs/dev/audits/2026-06/fase1_codigo_arquitectura.md
@@ -1,0 +1,234 @@
+# Auditoría integral 2026-06 — Fase 1: Código y arquitectura
+
+> **Método:** 6 lectores paralelos por subsistema (~108 scripts) → 56 hallazgos
+> brutos → dedup a 24 (4 "críticos" + 20 mayores) → 9 verificadores
+> adversariales (cada cadena causal re-leída en código, chequeo de "ya
+> registrado" contra _roadmap/_tech_snapshot/_insights/Combat-CLAUDE.md).
+> **Resultado:** 0 críticos, **10 mayores confirmados**, ~14 menores, 3
+> oportunidades, 3 sub-claims descartados.
+> **Consumo:** ~1.05M tokens de subagentes (find ~500k + verify ~530k).
+
+---
+
+## Resumen ejecutivo
+
+El proyecto está estructuralmente sano: capas respetadas, ActionQueue
+determinista, generador de mapa sin RNG no seedeado, presentación disciplinada.
+Los problemas reales se concentran en **tres clusters**:
+
+1. **Sincronización RunState↔combate al cierre** — dos Retazos rotos HOY en el
+   flujo real (H1, H2) + el retry de derrota inutilizable (H3) + resets
+   divergentes (H4). Todos comparten la raíz: `BattleFlowController.ReportOutcome`
+   sincroniza tarde y los resets in-place duplican lógica de `RunSession`.
+2. **Cuatro supuestos del core que M5/M6 rompen de frente** (H6-H9): switch
+   solo-jugador sin veto/initiator, tipo de enemigo único y estático, cero
+   sustrato de status/debuff, acto único como bool. Todos viven en archivos
+   protegidos → **conviene UNA cirugía diseñada y aprobada de TurnManager antes
+   de M5, no cuatro aperturas incrementales.**
+3. **Semántica encolar-vs-ejecutar** (H5): efectividad/Estilo/hooks corren al
+   encolar, el daño al ejecutar. Es diseño documentado (m3_hooks_spec), pero
+   tiene consecuencias no documentadas (enemigo muerto que ataca, Victory
+   evaluada antes que Defeat, carga de Estilo con daño 100% bloqueado, Spines
+   resuelve antes que el golpe que la causa). Hay que DECIDIR la semántica, no
+   solo parcharla.
+
+---
+
+## Hallazgos MAYORES confirmados (10)
+
+### Cluster A — Sincronización de fin de combate / resets de run
+
+**H1. `RelicEndHealEffect` (R-END-2 "Curita con Estampa") es un no-op en el
+flujo real** — `BattleFlowController.cs:117`
+El efecto escribe `RunState.PlayerCurrentHP` durante `DispatchCombatEnd`
+(sincrónico, dentro de `CheckCombatEndConditions`), pero `ReportOutcome`
+(polling posterior) pisa incondicionalmente ese valor con
+`_turnManager.PlayerHP`, que nunca recibió el heal. Los tests pasan porque no
+cubren el flujo con `BattleFlowController`. **Origen: el propio spec
+`RELICS.md:228` prescribe esta implementación.**
+*Fix sugerido:* sincronizar RunState antes de `DispatchCombatEnd`, o que el
+ctx lea/escriba el HP del actor. Esfuerzo S.
+
+**H2. `RelicElitePuristEffect` ("Caja Intacta") evalúa HP stale** —
+`RelicElitePuristEffect.cs:17`
+Lee `RunState.PlayerCurrentHP` en OnCombatEnd, que durante el combate conserva
+el valor PRE-combate (verificado por grep exhaustivo: nada sincroniza antes).
+Paga si ENTRASTE con vida llena, no si TERMINASTE con vida llena — condición
+invertida. Agravante: si R-END-2 corre antes en la cadena, puede inflar el
+valor stale. Mismo origen que H1 (`RELICS.md:240`) — **arreglarlos juntos**.
+Esfuerzo S (con H1).
+
+**H3. Reintentar tras derrota arranca el combate con 1 HP** —
+`RunFlowController.cs:~651`
+La derrota guarda `PlayerCurrentHP=0`; el botón Reintentar limpia flags pero no
+restaura HP; `HasPlayerHPInitialized` sigue true así que el 0 pasa como
+override y `TurnManager.InitializeCombat` lo clampa a 1. El botón es inútil en
+la práctica (loop de derrota casi garantizado). Bug player-facing verificado
+eslabón por eslabón. Esfuerzo S.
+
+**H4. Dos paths de reset de run divergentes: los botones de defeat/acto
+resetean in-place y pierden la identidad del run** — `RunFlowController.cs:666,693`
+`RunState.Reset()` devuelve los tipos a Rojo/Amarillo y anula
+`PendingStarterCard`; los botones resetean sin pasar por NewRunScene → "nueva
+run" con identidad default silenciosa, mazo de 9 cartas (sin la dual drafteada)
+y el MISMO mapa (no regenera, a diferencia de `RunSession.ResetForNewRun`).
+Relacionado: el TODO stale de `RunFlowController.cs:701` ("cuando exista
+MainMenuScene" — existe desde hace meses); cargar MainMenuScene vía
+`ResetForNewRun` resolvería ambos. Esfuerzo S-M.
+
+### Cluster B — Readiness M5/M6 (los cuatro supuestos del core)
+
+> Los cuatro viven en TurnManager/actors (protegidos). Recomendación operativa
+> del verify: **diseñar una cirugía única aprobada pre-M5** que resuelva el
+> paquete completo, en vez de abrir el protegido cuatro veces.
+
+**H5. Semántica encolar-vs-ejecutar sin decidir + daño de Retazos sin
+ProcessAll** — `TurnManager.cs:1065, 634, 856`
+Verificado: `RelicEnqueueExtraDamage` solo encola (el drain ocurre en el
+próximo ProcessAll del flujo natural — diseño documentado en
+`m3_hooks_spec.md:391`); `DamageAction.Execute` no chequea source vivo →
+enemigo muerto por daño de Retazo igual ejecuta su ataque ya encolado;
+`CheckCombatEndConditions` evalúa Victory con return ANTES que Defeat →
+victoria posible con jugador en 0 HP. Además: +1 Estilo se otorga pre-block
+(SuperEficaz 100% absorbido da carga — la redacción de GOLDEN_RULES §4 no lo
+prohíbe explícitamente, pero la lectura natural de "hace daño" sí); Spines
+encola la represalia ANTES del golpe que la causa (inversión FIFO); y el
+comentario de `:856` promete una detección de victoria que el código no cumple.
+Hoy el escenario letal es un edge angosto; con más Retazos/bosses M5 deja de
+serlo. *Fix sugerido:* decidir y documentar la semántica (¿drain post-hook?
+¿Defeat prioritario sobre Victory? ¿Estilo post-block?) como parte de la
+cirugía única. Esfuerzo M (decisión + cambios acotados).
+
+**H6. Cambio de mundo: un solo path, presupuestado al jugador, sin initiator
+ni veto** — `TurnManager.cs:763-786`, `WorldSwitchHookData.cs:14`
+Verificado por grep: `TryChangeWorld` es el único mutador de `currentWorld` en
+producción; siempre chequea el cap del jugador, siempre incrementa
+`_worldSwitchesUsed`, siempre dispatchea OnWorldSwitch DESPUÉS de mutar (sin
+punto de veto). El hook no lleva Initiator → el Desfase Dimensional de M5
+dispararía los 4 Retazos Switch del jugador en cambios hostiles, y los bosses
+M6 que bloquean el cambio no tienen dónde vetar. No existe contador de cartas
+jugadas por turno (cero hits). Esfuerzo M (diseño de firma + payload).
+
+**H7. Tipo de enemigo único, estático, leído del SO; sin TypeWorldB ni
+IsAnchor** — `TurnManager.cs:624,416,112`, `EnemyDefinition.cs:22`
+El jugador tiene la indirección correcta (`PlayerActiveType` deriva del mundo);
+el enemigo no — 3 call sites leen crudo del SO y `EnemyCombatActor` no tiene
+noción de tipo. Bloquea 4c (transdim+ancla), el boss M5 (un tipo por mundo) y
+M6. **Es exactamente el bloque 4c del roadmap** — este hallazgo confirma su
+alcance y que la extensión es limpia y acotada. Esfuerzo M (ya agendado).
+
+**H8. Cero sustrato de status/debuff + lógica de actors duplicada textualmente** —
+`ICombatActor.cs`, `PlayerCombatActor.cs:97-110` vs `EnemyCombatActor.cs:35-48`
+`EffectType.ApplyStatus` existe en el enum y cae al default LogWarning (única
+referencia = la declaración). Ningún actor tiene contenedor de statuses;
+TakeDamage/GainBlock/LoseBlock/Heal son copias idénticas en ambos actors —
+Virus (block al 80%) obligaría a tocar DOS clases sin punto de intercepción, y
+Sangrado necesita tick/expiración que el turn flow no contempla. Statuses son
+núcleo de M5. Esfuerzo L (diseño nuevo dentro de la cirugía).
+
+**H9. Multi-acto sin representación: `ActoCompleted` bool, config single-act** —
+`RunState.cs:32`, `RunCombatConfig.cs`
+Cero hits de `CurrentAct`; un solo `defaultEnemy`/`bossRelicDrop`; HP enemigo
+fijo sin escalado por acto. M6 lo fuerza todo a la vez; introducir `CurrentAct`
+ya en M5 evita migrar el bool después. Esfuerzo M.
+
+### Cluster C — Fragilidad latente de inicialización
+
+**H10. Carrera de Awake en run nueva: `TryInheritBossFrom` regenera el mapa
+que `RunFlowController` ya pudo haber capturado** — `RunSession.cs:147`,
+`RunFlowController.cs:71`
+La cadena es real (MainMenu crea RunSession DDOL sin configs → mapa fallback →
+RunScene regenera al heredar configs). HOY funciona porque el GameObject
+RunSession precede a RunFlowController en el YAML de la escena y el orden de
+facto lo respeta — **sin contrato** (no hay DefaultExecutionOrder; reordenar la
+jerarquía de RunScene rompería el mapa en silencio). Bonus verificado:
+`RunState.Reset` en MainMenu queda atado al mapa fallback y funciona por
+coincidencia de StartNodeId. *Fix sugerido:* inicialización explícita (lazy
+getter o DefaultExecutionOrder + comentario). Esfuerzo S.
+
+---
+
+## Menores confirmados (al backlog, sin urgencia)
+
+- **Docs stale sobre gaps resueltos** (reportado por 4 lectores independientes):
+  PhaseBased AI, `EffectType.Heal`+`HealAction` y `CalculateIntentValue`
+  (Defend+Heal) **SÍ están implementados** (Sub-PR D, 2026-05-07; Combat/CLAUDE.md
+  ya lo registra) pero `_tech_snapshot` "Restricciones conocidas" y menciones del
+  roadmap los siguen listando como pendientes. → insumo directo para Fase 3.
+- `RelicTurnEnergyEveryN` (Reloj de Cocina): counter sangra entre combates (sin
+  reset OnCombatStart, a diferencia de sus siblings R-ACC-2/R-DMG-2). Resolver
+  como DECISIÓN de diseño (el wording del asset lo hace defendible) + fix simétrico.
+- `RelicAccSkillStacker`: pending de energía cruza combates (mismo fix).
+- Sin validación SO↔efecto: el reset de counters depende del array Hooks del
+  asset; fix útil = test EditMode que cargue los `.asset` reales de Relics y
+  valide hooks declarados vs consumidos (hoy ningún test carga assets reales).
+- Orden de hooks T1 (OnPlayerTurnStart antes que OnCombatStart): decisión
+  documentada (evitar ClearBlock), pero footgun real para Retazos futuros que
+  combinen ambos hooks — documentar en RELICS.md como regla de autoría.
+- `SaveSmokeTest` vivo en BattleScene (sin `#if UNITY_EDITOR`, corre en builds,
+  sobreescribe `save_v1.json` en cada combate). Hoy inocuo (cero consumidores
+  del save); se vuelve mayor el día que meta-progresión (M6c) lea ese archivo.
+  Borrarlo es gratis.
+- Topologías hardcode 8 nodos vs `totalNodes` editable sin clamp/OnValidate:
+  foot-gun latente de inspector (grafo roto en silencio). Validación de 5 líneas.
+- `SceneTransitionManager`: `_isTransitioning` sin recuperación — soft-lock no
+  alcanzable hoy (verificado: no hay KillAll, SetUpdate(true), safe mode on),
+  pero sin hardening un KillAll futuro lo rompe sin síntoma.
+- Comentario engañoso `TurnManager.cs:856` (promete detección de victoria
+  post-hook que no ocurre) — trampa para autores de Retazos futuros.
+- `currentWorld` no se resetea en `InitializeCombat` (hoy lo salva la recarga
+  de escena; muerde si M6 encadena combates sin recarga).
+- Residuo de M17: End Turn no chequea `IsPlayingAttack` → clic durante la
+  animación de ataque difiere la resolución de la carta al turno enemigo.
+- `RelicDebugOverlay` muta `RunState.Relics` directo → AcquisitionOrder
+  duplicado en sesiones de playtesting (editor-only; molesto para lo que el
+  tool quiere probar). Fix: `RemoveRelic()` en RunState que normalice.
+- Recompensa post-combate NO randomizada (siempre las primeras N del
+  RewardPool — sin TODO que lo marque); oro +10 hardcodeado en nodos
+  placeholder; reward distorsiona playtests de economía.
+- `RunFlowController` god-object (885 LOC, ~20 métodos Build*/Show*/flow,
+  verificado método por método) y duplicación espejo Shop↔Campfire (~150-180
+  LOC/archivo de helpers idénticos; `GetWhiteSprite` ×4). Ambos sin riesgo
+  funcional hoy — pero **extraer ANTES de 4b** (EventNodeController sería la
+  3ª copia).
+
+## Oportunidades
+
+- Migrar fin-de-combate de polling a evento (`OnCombatFinished`) — nota de
+  diseño pre-M5, sin bug actual.
+- `UIFactory` central en Core/UI (patrón create-text/button/panel forkeado ×4+).
+- `EnemyIntentType` extensible + íconos (el switch del HUD cubre todos los
+  valores actuales; el gap es del enum, no de la view).
+- `EnsureEventSystem` ×3 divergentes → helper único en Core.
+- Base `RelicEffectBase<THookData>` antes de la ola de efectos M5/M6.
+- `MaxStyleCharges` expuesto por TurnManager (HUD hardcodea "/5").
+
+## Descartados por el verify (y por qué)
+
+- **Efectividad stale si el mundo cambia entre prepare y resolve:** falso — la
+  efectividad jugador→enemigo depende del elemento de la carta (fijado al
+  preparar) y del tipo del enemigo (inmutable en combate); `currentWorld` no
+  entra al cálculo.
+- **Softlock por cola pendiente:** el guard de Update solo bloquea el AUTO
+  end-turn; el botón End Turn drena la cola vía ExecuteEnemyTurn.
+- **Muerte del callback de PlayAttackOnce (energía perdida/carta en limbo):**
+  los modos de muerte afirmados no son alcanzables — guard `_isPlayingAttack` +
+  botones deshabilitados + animator del jugador sin otros callers (queda solo
+  el residuo End-Turn-durante-animación, listado en menores).
+- **PhaseBased "sin estado" como mayor:** factualmente exacto pero ya
+  trackeado en Future work (strategy pattern IA + play-mode tests pre-M5).
+
+## Insumos para fases siguientes
+
+- **Fase 2 (tests):** los tests de Relics no cubren el flujo con
+  BattleFlowController (por eso H1/H2 pasan verdes); ningún test carga los
+  `.asset` reales; el flujo derrota→retry no tiene test; candidatos directos.
+- **Fase 3 (docs):** gaps resueltos listados como pendientes en _tech_snapshot
+  y roadmap; `RELICS.md:228,240` prescribe el patrón que causa H1/H2;
+  GOLDEN_RULES §4 ambiguo en "daño real" (¿post-block?); _tech_snapshot con
+  LOC/conteos viejos (53 vs 108 scripts).
+
+---
+*Fase 1 cerrada 2026-06-11. Verify adversarial: 9 grupos, 24 hallazgos, 152
+lecturas de verificación. Veredictos: 10 confirmados-mayor, 14 menores
+(confirmados o degradados con núcleo real), 3 oportunidades, 3 descartados.*

--- a/Docs/dev/audits/2026-06/fase2_tests.md
+++ b/Docs/dev/audits/2026-06/fase2_tests.md
@@ -1,0 +1,213 @@
+# Auditoría integral 2026-06 — Fase 2: Tests
+
+> **Método:** 6 lectores paralelos (3 inventarios de la suite + 3 lectores de
+> superficie de riesgo: run flow, Contador de Estilo, cruce con hallazgos F1)
+> → consolidación a 13 agujeros → 13 verificadores adversariales livianos
+> (grep dirigido + lectura puntual, default refutar).
+> **Resultado:** 12 agujeros confirmados, 1 parcialmente cubierto.
+> **Consumo:** ~433k tokens de subagentes (20 agentes, 308 tool uses; el
+> fan-out inicial se recuperó cacheado del run interrumpido el 2026-06-11).
+
+---
+
+## Qué cubre DE VERDAD la suite hoy (17 archivos, 146 tests)
+
+La suite es **100% sintética** — cero `.asset` reales, cero `AssetDatabase` —
+y cubre bien la **lógica pura en aislamiento**:
+
+- Matriz de efectividad 6×6 completa (39 casos) + multiplicadores 1.5x/0.75x
+  aplicados en combate real (vía `CombatTestBase` + TurnManager).
+- Block-antes-de-HP, draw con reshuffle, clamps de heal.
+- Happy path del Contador de Estilo: +1 por SuperEficaz, decremento por hit
+  enemigo, no-negativo, bonus a las 5 cargas, bonus no acumulable.
+- Límites de world switch A→B (no el ciclo de vuelta B→A).
+- Determinismo por seed: mapa, stock de tienda, draft de NewRun.
+- Lógica de apply de Hoguera (heal %, upgrades, idempotencia) y Tienda
+  (oro, guards, clonado, precio escalado del remove).
+- Ordering y filtrado del `RelicHookDispatcher` (con stubs `RecordingEffect`).
+- Helpers de color/arte (contratos de datos).
+
+**Lo que NO cubre** (de ahí salen los agujeros):
+1. **Integración entre capas** — ningún test junta TurnManager +
+   BattleFlowController + RunState; ahí viven los bugs confirmados en F1
+   (H1/H2 pasan verdes por esto).
+2. **La mitad del catálogo de relics**: 10 efectos Grant-based testeados solo
+   con `Assert.DoesNotThrow` y `TurnManager=null` — cero asserts de mutación.
+3. **Boundaries y timing del Estilo**: carga pre-block/pre-hook, overshoot >5
+   vía relics, resets entre combates.
+4. **Contrato datos↔código**: los 23 `.asset` de Retazos jamás se cargan.
+5. **Progresión del run**: transiciones de nodo, derrota→retry, round-trip de
+   tipos elegidos en NewRun hasta el combate.
+
+En síntesis: excelente red para regresiones de fórmulas y determinismo; casi
+nula para flujo, integración y datos reales.
+
+### Inventario por archivo (tests / qué asserta)
+
+| Archivo | Tests | Cubre de verdad | Blind spot principal |
+|---|---|---|---|
+| ElementEffectivenessTests | 39 | matriz 6×6 (solo enum, no multiplicadores) | sin contexto de DamageAction |
+| RelicEffectsTests | 17 | mutación de Amount, counters, gold, heal con cap | 10 Grant-based solo DoesNotThrow; nunca con BattleFlowController |
+| ShopTests | 12 | oro, guards, clonado, remove escalado, filtro por tipo | hooks de compra; pools edge (None,None) |
+| DamageEffectivenessTests | 10 | 1.5x/0.75x ambas direcciones, happy path Estilo | Estilo con block enemigo; carta None 90%; mutación por hook |
+| CampfireTests | 8 | heal %, upgrades, idempotencia, hook de opciones | persistencia post-combate del heal |
+| NewRunTests | 8 | filtro/determinismo de draft, inyección al deck, tipos | round-trip hasta el combate; idempotencia de InitializeDeck |
+| RelicHookDispatcherTests | 8 | filtrado, AcquisitionOrder, payloads mutables | solo stubs, TurnManager=null en todos |
+| ElementTypeColorsTests | 8 | opacidad, distinguibilidad, luminancia, prefijos | — (menor) |
+| RunMapGeneratorTests | 5 | determinismo topología/enemigos, invariantes básicos | aciclicidad solo por rango; sin boss; un solo DepthPool |
+| CardArtTests | 5 | contrato de datos del arte (defaults, clones, dual) | — (render se valida en Play, correcto) |
+| TurnManagerTests | 4 | init, end turn, Victory/Defeat por overkill | orden Victory-vs-Defeat; fallback de tipos None |
+| WorldSwitchLimitTests | 4 | límite A→B, unlimited debug, bonus suma | ciclo B→A; gate sin init; counter en modo debug |
+| HealActionTests | 4 | heal con cap, no-ops, intent value | RelicGrantHeal |
+| PlayerCombatActorTests | 3 | block antes de HP, reshuffle | maxHandSize, GainEnergy cap |
+| ActionQueueTests | 2 | FIFO, filtrado de nulls | guard de re-entrada, eventos |
+| DefinitionTypeDefaultsTests | 2 | defaults de ElementType | — (menor) |
+| CombatTestBase | — | base compartida (GameObject + TurnManager en EditMode) | — |
+
+---
+
+## Agujeros confirmados por el verify (12)
+
+> Todos pasaron verificación adversarial (default refutar): se buscó
+> activamente un test existente que cubriera el claim y se validó la
+> factibilidad EditMode del test propuesto.
+
+### TOP — los que más riesgo eliminan por esfuerzo
+
+**T1. Flujo OnCombatEnd → ReportOutcome jamás testeado en conjunto** *(M)*
+Ningún test instancia TurnManager + BattleFlowController juntos. Es
+exactamente el agujero por el que H1 (heal de R-END-2 pisado por
+`BattleFlowController.cs:115-119`) y H2 (Purist lee HP stale) pasan verdes.
+`RelicEffectsTests.cs:150-157` testea el efecto aislado con `TurnManager=null`.
+*Test:* `ReportOutcome_AfterCombatEndHook_PreservesRelicHeal` — hoy FALLA
+(documenta el bug ejecutable). Obstáculo único: mockear/extraer el
+`SceneTransitionManager.LoadScene` de `ReportOutcome:131`.
+
+**T2. Derrota → Reintentar arranca con HP=0: cero tests con "Retry"** *(S)*
+Confirmado eslabón por eslabón: el handler (`RunFlowController.cs:650-658`)
+solo toca flags (contraste: el botón Exit en :664 SÍ llama `Reset()`);
+`EnsurePlayerHpInitialized` (`RunState.cs:148-150`) hace early-return con HP
+ya inicializado → el 0 persiste. Es H3 de F1 hecho test.
+*Test:* `RunState_AfterDefeatWithZeroHp_RetryPathRestoresPlayableHp` — puro
+RunState, sin MonoBehaviour. Hoy FALLA.
+
+**T3. Estilo otorga carga por "daño fantasma"** *(S)*
+`TurnManager.cs:634-637`: la carga se decide con `finalAmount` PRE-block y
+PRE-hook. Un hit SuperEficaz 100% absorbido por block enemigo igual carga.
+Ningún test de Estilo usa enemigo con block (verificado: el más cercano,
+`SuperEffectiveHit_GrantsStyleCharge`, usa block=0 implícito).
+*Test:* `StyleCharge_SuperEffectiveHitFullyBlocked_DoesNotGrantCharge` +
+gemelo con relic OnDamageDealt que mutea a 0. Sirve también para forzar la
+DECISIÓN de diseño de H5 (¿pre o post block? GOLDEN_RULES §4 es ambiguo).
+
+**T4. Reset entre combates** *(S — parcialmente cubierto, núcleo real)*
+El verify refutó la mitad: el reset de Estilo en `InitializeCombat:282-284`
+existe y los counters SÍ se testean *dentro* de un combate. Lo NO cubierto:
+ningún test llama `InitializeCombat()` dos veces, y
+`RelicTurnEnergyEveryNEffect` NO tiene reset en OnCombatStart (sus siblings
+sí) mientras el dispatcher persiste entre combates (`RunSession`).
+*Test:* `InitializeCombat_SecondCall_ResetsStyleStateAndRelicCounters` —
+congela el contrato y documenta el counter que sangra (menor de F1).
+
+**T5. Cero tests cargan los 23 `.asset` reales de Retazos** *(S)*
+Grep: 0 hits de `AssetDatabase|LoadAsset` en toda la suite. Un hook mal
+tipeado en un `.asset` pasa los 146 tests. Whitelist real de hooks
+despachados: 7 en TurnManager + `OnCampfireOptionsBuilt` + `OnShopStockBuilt`.
+*Test:* `RelicAssets_AllDeclaredHooksAreDispatchable` — FindAssets
+`t:RelicDefinition`, valida Effect≠null, Hooks⊆whitelist. Extensible a
+Cards/Enemies. Es el candidato directo de F1 (validación SO↔efecto).
+
+**T6. 10 efectos Grant-based solo con DoesNotThrow** *(M)*
+`RelicEffectsTests.cs:260-288` (`GrantBasedEffects_TurnManagerNull_DoNotThrow`)
+es el ÚNICO test de OpenBlock/OpenDraw/OpenEnergy/TurnDraw/TurnBlock/
+SwitchHeal/SwitchBlock/SwitchStyleCharge/SwitchDamage/EliteSpines — con
+TurnManager=null, o sea bypass total de la lógica. TurnManager expone
+PlayerBlock/PlayerEnergy/PlayerHP/PlayerHandCount para los asserts.
+*Test:* `RelicGrantEffects_OnRealTurnManager_MutateState` parametrizado
+(TestCaseSource) — ~media tabla del catálogo gana verificación de conducta.
+
+**T7. Sin clamp superior de StyleCharges vía relics** *(S)*
+`RelicGrantStyleCharge(3)` estando en 4 deja `_styleCharges=7` sin reset ni
+bonus (la condición de `IncrementStyleCharges:989-997` exige el paso exacto
+por >=5 con bonus en 0... y el path de relics nunca se testeó con TurnManager
+real). Viola GOLDEN_RULES §4 (Estilo nunca >5). Boundary extra sin test:
+decremento enemigo desde charges==1.
+*Test:* `GrantStyleCharge_Overshoot_ResetsAndGrantsSingleBonus` (vía
+reflection o wrapper de test — patrón ya usado en RunMapGeneratorTests).
+
+**T8. `PendingStarterCard` sin idempotencia ni consumo** *(S)*
+`InitializeDeck` tiene guard anti-duplicado (`Deck.Count>0` early-return)
+pero NADA lo testea, y `PendingStarterCard` nunca se anula tras inyectarse
+(el comentario de `RunState.cs:49` dice "consumed" — el código no lo hace).
+Retry no la resetea, Reset sí → divergencia H4.
+*Test:* `InitializeDeck_CalledTwice_DoesNotDuplicateStarterCard` — puro C#.
+
+**T9. Regla "carta None = 90% daño" sin un solo test** *(S)*
+`TurnManager.cs:611-622` activo en producción; DamageEffectivenessTests solo
+usa cartas tipadas (las None del fixture tienen cost:99, injugables).
+*Test:* `NeutralCard_Applies90PercentDamage` — trivial, asegura una regla de
+balance viva + el redondeo de `Mathf.RoundToInt`.
+
+**T10. Round-trip de tipos NewRun → combate jamás cerrado** *(M)*
+La escritura está testeada (`ApplySelection_WritesChosenTypes`); la lectura
+no: 0 hits de `ConfigureCombat(` en la suite — los tests usan
+`SetPlayerTypesForTest` que lo BYPASSEA. El fallback silencioso a defaults
+(`TurnManager.cs:257-258`) enmascararía exactamente el bug que esto cazaría.
+*Test:* `InitializeCombat_WithRunStateTypes_PlayerActiveTypeMatchesSelection`
++ caracterización del fallback con tipos None.
+
+### Backlog (confirmados, menor prioridad)
+
+**T11.** RunMapGenerator: aciclicidad solo por rango de índices (un back-edge
+en rango pasaría), `AssignBossAct1` (`RunSession.cs:102-117`) sin test alguno,
+DepthPools múltiples nunca ejercitados (el fixture usa un pool 0-99). *(M)*
+
+**T12.** `TryChangeWorld`: ciclo B→A sin test (el toggle solo se ejercita en
+una dirección), gate `_initialized==false` sin test, y el assert del modo
+debug (`GreaterOrEqual(WorldSwitchesUsed, 0)`) no valida nada — siempre pasa.
+*(S — natural hacerlo junto con la cirugía H6 pre-M5)*
+
+**T13.** Transiciones de nodo post-victoria (`CompleteNode`,
+`RunFlowController.cs:453-482`: AvailableNodes/CompletedNodes/posición) y el
+ciclo `LastNodeOutcome` — toda la progresión por el mapa sin red. Requiere
+**extraer la lógica a método estático puro primero** (refactor S, encaja con
+el desguace del god-object M12 de F1). *(L con el refactor; S después)*
+
+## Refutados / degradados por el verify
+
+- **T4 (mitad):** el reset de Estilo/Bonus en `InitializeCombat` SÍ existe y
+  los counters SÍ tienen test intra-combate (`RelicEffectsTests.cs:215-227`);
+  lo que queda sin red es el cross-combate (queda en T4, degradado a
+  caracterización + documentación del counter de R-6).
+
+---
+
+## Propuesta de cierre: los 8 tests que más riesgo eliminan
+
+Orden = riesgo eliminado / esfuerzo. Los tres primeros **documentan bugs
+reales de F1 como tests que hoy fallan** (ejecutables, no narrativa):
+
+| # | Test | Agujero | Esfuerzo | Nota |
+|---|---|---|---|---|
+| 1 | `ReportOutcome_AfterCombatEndHook_PreservesRelicHeal` | T1 (H1/H2) | M | falla hoy = bug H1 confirmado ejecutable |
+| 2 | `RunState_AfterDefeatWithZeroHp_RetryPathRestoresPlayableHp` | T2 (H3) | S | falla hoy; puro RunState |
+| 3 | `StyleCharge_SuperEffectiveHitFullyBlocked_DoesNotGrantCharge` | T3 (H5) | S | fuerza la decisión de diseño pre/post-block |
+| 4 | `RelicAssets_AllDeclaredHooksAreDispatchable` | T5 | S | única validación datos↔código; barata |
+| 5 | `RelicGrantEffects_OnRealTurnManager_MutateState` (×10 param.) | T6 | M | media tabla de relics gana asserts reales |
+| 6 | `GrantStyleCharge_Overshoot_ResetsAndGrantsSingleBonus` | T7 | S | invariante GOLDEN_RULES §4 |
+| 7 | `InitializeCombat_SecondCall_ResetsStyleStateAndRelicCounters` | T4 | S | congela contrato pre-cirugía M5 |
+| 8 | `NeutralCard_Applies90PercentDamage` | T9 | S | regla de balance viva, test trivial |
+
+Suplentes si hay apetito: T8 (`InitializeDeck` ×2, S), T10 (round-trip de
+tipos, M). T11-T13 al backlog con dueño (T12 → cirugía pre-M5; T13 → junto
+al desguace de RunFlowController antes de 4b).
+
+**Nota de timing:** los 8 son EditMode puros (verificado uno a uno por el
+verify) y conviene escribirlos ANTES de la cirugía de TurnManager pre-M5 —
+los que pasan congelan el comportamiento que la cirugía no debe romper; los
+que fallan son la spec ejecutable de los fixes de F1.
+
+---
+*Fase 2 cerrada 2026-06-12. Verify adversarial: 13 verificadores, 12
+confirmados, 1 degradado, 0 falsos. Consumo F2: ~433k tokens de subagentes
+(20 agentes; fan-out inicial recuperado de caché del run interrumpido).*

--- a/Docs/dev/audits/2026-06/fase3_docs.md
+++ b/Docs/dev/audits/2026-06/fase3_docs.md
@@ -1,0 +1,274 @@
+# Auditoría integral 2026-06 — Fase 3: Coherencia documental
+
+> **Método:** 4 finders en paralelo (barrido ⏳ de GOLDEN_RULES + 3 cruces:
+> GDD↔GOLDEN_RULES↔DESIGN_DECISIONS, docs técnicos↔código, specs↔implementación)
+> → 16 ítems ⏳ + 38 hallazgos de cruce → verify adversarial por lotes (9
+> verificadores: cada cita releída en el doc, cada afirmación de código
+> reproducida con grep/lectura propia).
+> **Resultado:** 37 hallazgos confirmados (18 mayores + 19 menores, 1 de ellos
+> verificación positiva), 1 descartado, 9/9 filas del barrido confirmadas
+> (varias con correcciones de precisión que se integran abajo).
+> **Consumo:** ~594k tokens de subagentes en el run final + el gasto parcial del
+> run interrumpido por usage limit el 2026-06-12 (el resume por
+> `resumeFromRunId` recuperó el fan-out de caché).
+
+---
+
+## Resumen ejecutivo
+
+La documentación tiene **un problema dominante y sistémico: describe el juego
+de hace dos milestones.** Los hallazgos se agrupan en cinco clusters:
+
+1. **Momentum/One More como sistema "vigente" en 5 docs** — COMBAT_ARCHITECTURE,
+   GLOSSARY y DEV_ONBOARDING describen con diagramas y entradas de glosario una
+   mecánica eliminada en M2 (PR #89); el GDD y MECHANIC_DUALITY arrastran
+   "One More" como nombre de la mecánica central. Quien onboardee con esos docs
+   aprende un juego que no existe.
+2. **GOLDEN_RULES congelado en 2026-04-28** — 3 ⏳ completamente vencidos
+   (PhaseBased, Shop, Campfire), 1 referencia a DD-017 "pendiente" (cerrada
+   hace un mes), la ambigüedad §4 pre/post-block confirmada, y 2 reglas donde
+   el código diverge de la letra (contador >5 con bonus pendiente; "transdimensional"
+   usado con 3 significados distintos).
+3. **Los specs/docs de Retazos prescriben el patrón que causa H1/H2** —
+   RELICS.md y m3_hooks_spec [CERRADO 3] llaman "vía segura" exactamente al
+   patrón roto (escribir `RunState.PlayerCurrentHP` en OnCombatEnd, que
+   `ReportOutcome` pisa). Mientras no se corrijan, **cada Retazo OnCombatEnd
+   nuevo de M5/M6 nacerá con el mismo bug.**
+4. **_tech_snapshot y Combat/CLAUDE.md con números/gaps fantasma** — 53 vs 108
+   scripts, TurnManager en 3 valores (735/~960/real 1088), sección
+   "Restricciones conocidas" entera vencida (los 3 gaps resueltos en Sub-PR D),
+   y Combat/CLAUDE.md negando DD-018 (efectividad bidireccional) dos líneas
+   antes de afirmarla.
+5. **Huérfanos del barrido ⏳** — 2 reglas cerradas por diseño sin dueño en
+   ningún milestone (cartas con efecto WorldSwitch; tiers de oro DD-009, donde
+   además la economía vigente se calibró contradiciendo los tiers del doc).
+
+**Lectura transversal:** ningún hallazgo es bug de código nuevo (eso fue Fase 1);
+el riesgo es de PROCESO — docs canónicos que inducen errores a futuro (cluster 3
+es el más peligroso) y onboarding/contexto de Claude que describe sistemas
+muertos (clusters 1-2-4 envenenan el contexto auto-cargado).
+
+---
+
+## 1. Barrido ⏳ de GOLDEN_RULES.md (16 ítems, exhaustivo)
+
+Última actualización del doc: **2026-04-28** (línea 333) — pre-cierre de M2.
+
+| § | Ítem ⏳ | Estado real | Dueño | Nota |
+|---|---|---|---|---|
+| §2 | Cartas con efecto WorldSwitch + Items/Retazos (:62) | **parcial** | Retazos: M3 ✓ · cartas: **HUÉRFANO** | Mitad Retazos VENCIDA (R-SW-1..4 + GrantBonusWorldSwitch). `EffectType` sin WorldSwitch (CardEnums.cs:36-44); ningún bloque del roadmap lo agenda. |
+| §2 | Cambio afecta tipo de transdimensionales | no | M4-4c | Cubierto explícito (_roadmap.md:117-118). |
+| §2 | Cambio NO afecta anclas | no | M4-4c | Cubierto (_roadmap.md:119-120). |
+| §5 | Mazo inicial DD-002/008/020 (tipos+pool+composición+afinidad) | **parcial** | M4-4a | Selección de tipos + draft dual + 10ª carta ✓ (3E). Afinidad: 0 hits en código. Starter actual = **7 entries base + 1 drafteada = 8 cartas** (corrección del verify; no 10). |
+| §5 | Tamaño del mazo DD-010 (10 exactas → 20-25) | **parcial** | inicio-en-10: 4a · rangos: **HUÉRFANO** | Crecimiento sin límite ✓. Los rangos 15-20/20-25 no figuran como tarea de balance en ningún milestone (objetivo de diseño, no feature — huérfano tolerable). |
+| §5 | Mejora de cartas DD-013 | **parcial** | mecanismo: M3-3C ✓ · datos+guard: 4a · eventos: 4b | Mecanismo completo desde 3C. Faltan: upgrades en las 18 caras NewRunFaces, test guard DD-023 (0 tests cargan SOs reales), eventos como lugar de mejora. Corrección del verify: `CanUpgrade` dual usa **OR** (aHas \|\| bHas), no "ambos" como dice _roadmap.md:93-94 — el roadmap exagera. |
+| §6 | "PhaseBased: declarado, no implementado aun" (:188) | **implementado** | M2-D ✓ (PR #91) | **⏳ VENCIDO** — TurnManager.cs:464-480 con filtro HP% y fallback. Debe pasar a ✓. |
+| §6 | Categorías dimensionales DD-014 (estándar/ancla) | no | M4-4c | Cubierto (transdim+ancla+ficha doble). |
+| §6 | Bosses DD-004 (2 tipos, fases, Sangrado/Virus) | no | M5 | M5 lo desglosa completo; depende de 4c. Building block: PhaseBased ya filtra por HP%. |
+| §7 | Shop (:221) | **implementado** | M3-3D ✓ (PR #96) | **⏳ VENCIDO** salvo consumibles (sin sistema; decisión diferida RASTREADA en _roadmap.md:337, no huérfano puro). ShopTests = **14** casos hoy (roadmap dice 13). |
+| §7 | Campfire (:222) | **implementado** | M3-3C ✓ (PR #94) | **⏳ VENCIDO** — descansar + mejorar + hook, 8 tests. |
+| §7 | Event (:223) | no | M4-4b | Único ⏳ de §7 legítimo (placeholder en RunFlowController.cs:377-402). |
+| §8 | Economía DD-009 (tiers 10-20/30-50/100, cartas de oro) | **parcial** | **HUÉRFANO** | Oro+gasto+Retazos de oro ✓. Tiers NO: un solo `goldReward=10` (RunCombatConfig.cs:12), +10 plano en nodos (RunFlowController.cs:356,402); cartas de oro no existen. Nadie lo agenda. **Agravante: el balance de tienda 2026-06-04 se calibró asumiendo ~10 oro/nodo — la economía vigente contradice los tiers del doc** (_roadmap.md:329-331). |
+| §9 | Actos DD-011 (3 actos, escalada) | no | M6 (a/b) | **Discrepancia código↔doc detectada de paso: `playerMaxHP = 60` (TurnManager.cs:26) vs "HP base 70" (§9)** — no pasó por verify adversarial (fila 'no'); confirmar si la escena serializa 70 antes de reportarlo en el informe final. Micro-huérfano: "elite con mecánica única" en Acto 1. |
+| §10 | Retazos DD-012 | **parcial** | M3 ✓ · eventos: 4b · "De mundo": diferida (huérfana aceptable) | ~80% VENCIDO (sistema entero desde M3). Sub-pendiente "ver DD-017" también VENCIDO (cerrada opción C 2026-05-07). Correcciones del verify: son **4** Retazos de cambio (R-SW-1..4, DD-017 decía 2-3), y TurnManager despacha **7 hooks en 8 call sites** (los otros 2 del enum los despachan Campfire/Shop). |
+| §11 | Meta-progresión DD-006/016 | no | M6c | Cubierto. |
+
+**Huérfanos netos del barrido:** cartas con efecto WorldSwitch (§2) y tiers de
+economía DD-009 (§8) — mismo patrón que DD-022 (regla cerrada por diseño sin
+sub-tarea dueña). Huérfanos tolerables/diferidos: rangos de DD-010 (balance),
+categoría "De mundo" (fuera de contenido base por diseño), consumibles
+(rastreado como decisión), elite con mecánica única (micro).
+
+---
+
+## 2. Hallazgos MAYORES confirmados (18)
+
+### Cluster 1 — Momentum/One More: mecánica muerta documentada como vigente
+
+**D1 (=A7+B10+B12+B14+B16).** `COMBAT_ARCHITECTURE.md`, `GLOSSARY.md` y
+`DEV_ONBOARDING.md` describen Momentum/FreePlays como sistema vigente: big
+picture (:8), diagrama PlayCard entero ("Check energy or Momentum" → "Consume
+Momentum free play"), entradas de glosario FreePlays/Momentum (:17,19) y "HUD
+con Energy, Momentum" (DEV_ONBOARDING:10). Realidad: grep de Momentum/FreePlay
+en Assets/Scripts da UN match — el comentario `TurnManager.cs:592` que afirma su
+ausencia. HUD real: `"Estilo: X/5"` (CombatHudView.cs:157); popup real
+`"WEAK!\n+ESTILO"` (CombatFeedbackView.cs:139). Además el diagrama PlayCard no
+refleja la API real Prepare/Resolve que consume CardHandView (B12), y los
+popups ya no viven en CombatUIController sino en CombatFeedbackView (B16).
+*Fix:* reescritura de los 3 docs (Estilo + flujo Prepare/Resolve). Esfuerzo M.
+
+**D2 (=B13).** `COMBAT_ARCHITECTURE.md` no menciona NINGUNO de los subsistemas
+de M2/M3 que hoy son centrales al combate: hooks de Retazos (9 hooks, 8
+dispatches), Contador de Estilo, HealAction, PhaseBased, ni el pipeline de fin
+de combate (DispatchCombatEnd → ReportOutcome → RunState). Estructuralmente
+vencido, no solo desactualizado. *Fix:* junto con D1. Esfuerzo M (mismo PR).
+
+**D3 (=B15).** `GLOSSARY.md` congelado pre-M2: 21 entradas solo-M1, cero
+términos de M2/M3 (Estilo, Retazo, hooks, RunState, Hoguera, Tienda, NewRun,
+RunMapGenerator…) y mantiene 2 entradas de sistema muerto. Esfuerzo S.
+
+### Cluster 2 — GOLDEN_RULES.md vencido o ambiguo (archivo de Sebastián)
+
+**D4 (=A1).** §4:119 "+1 carga cuando un ataque hace daño SuperEficaz" no
+especifica pre/post-block; el código otorga PRE-block (`finalAmount > 0` antes
+de encolar el DamageAction — TurnManager.cs:634-637; el block se consume
+después en TakeDamage). Un SuperEficaz 100% bloqueado da carga. El comentario
+del código dice "daño real", sugiriendo que el autor tampoco vio la sutileza.
+Confirmado por test T3 de Fase 2. **Es DECISIÓN de diseño, no solo redacción**
+(¿pre-block intencional o bug?) — ligada a H5 de Fase 1. *Fix:* Sebastián
+decide y precisa §4; si la respuesta es post-block, entra a la cirugía pre-M5.
+
+**D5 (=A2+A3, + barrido §6/§7).** Tres ⏳ completamente vencidos: PhaseBased
+(:188, implementado en M2-D), Shop (:221) y Campfire (:222, ambos M3). El ✓ del
+header de §6 agrava la inconsistencia interna. *Fix:* texto propuesto en
+sección 5 para que Sebastián pegue.
+
+**D6 (=A4).** §10:268 "Inclusión en contenido base: pendiente, ver DD-017" —
+DD-017 cerrada 2026-05-07 (opción C) y aplicada en 3B; se shipearon 4 Retazos
+de cambio (DD decía 2-3). *Fix:* misma pasada que D5.
+
+### Cluster 3 — Docs de Retazos prescriben el patrón roto (raíz documental de H1/H2)
+
+**D7 (=B17).** `RELICS.md:217-218,228,240` declara "mutación de
+`PlayerCurrentHP` permitida" y llama a la mutación directa "la vía segura".
+`RelicEndHealEffect.cs:22` implementa la receta LITERAL (su comentario cita al
+doc) y el resultado es H1: `ReportOutcome` pisa el valor después
+(BattleFlowController.cs:117). Para R-END-4 la condición lee HP stale
+pre-combate (H2). **Ironía verificada: el doc menciona GrantHeal como
+alternativa y lo descarta — es exactamente al revés** (GrantHeal sobre el actor
+sobrevive porque ReportOutcome copia `_turnManager.PlayerHP`). Esfuerzo S
+(nota de advertencia + regla de autoría), coordinado con el fix de H1/H2.
+
+**D8 (=C3).** `m3_hooks_spec.md:364-368` ([CERRADO 3]) prescribe el mismo
+patrón, con snippet literal de `PlayerCurrentHP`. El spec es además
+internamente inconsistente: su tabla :436 usa GrantHeal (correcto) mientras
+[CERRADO 3] prescribe la escritura directa. Esfuerzo S (junto con D7).
+
+**D9 (=C2).** El spec de hooks documenta la semántica encolar-vs-ejecutar pero
+NO sus dos consecuencias conocidas: (a) Estilo pre-block (cero menciones de
+block en relación al otorgamiento), (b) acciones encoladas se ejecutan aunque
+el actor haya muerto antes en la cola (ActionQueue.cs:50-80 sin chequeo de
+muerte; cero menciones en el spec). Son los componentes de H5. *Fix:* subsección
+"Consecuencias de la semántica" en el spec, tras la decisión de D4/H5.
+
+**D10 (=C1).** `m3_hooks_spec.md:607-614` ([IMPL 1]) afirma que el path de
+cartas neutras NO dispatchea OnDamageDealt y "Reabrir en Sub-PR 3B" — la
+reapertura ocurrió, se implementó y aprobó (8º dispatch, TurnManager.cs:608-621
+con comentario explícito), pero el spec nunca registró el cierre y sigue
+afirmando lo contrario al código (también habla de "7 puntos" cuando son 8).
+Esfuerzo S.
+
+### Cluster 4 — Docs técnicos con números/gaps fantasma
+
+**D11 (=B1+B2+B4).** `_tech_snapshot.md`: "53 archivos C#" (:299, real 108);
+TurnManager "735 loc" (:347) y "~960" (:472) contradiciéndose entre sí (real
+1088); y la sección "Restricciones conocidas" (:534-537) lista 3 gaps de
+TurnManager **resueltos hace un mes** (PhaseBased/Heal/CalculateIntentValue,
+Sub-PR D) — cuarta fuente independiente que lo confirma. Esfuerzo S.
+
+**D12 (=B8).** `Combat/CLAUDE.md:13-22` "Estado actual": 4 LOC vencidos
+(TurnManager 735 vs 1088, +48%) y el bloque omite CombatHudView y
+CombatBackgroundView que el propio doc marca extraídos más abajo. Es contexto
+auto-cargado para todo trabajo en Combat/. Esfuerzo S.
+
+**D13 (=A14).** `Combat/CLAUDE.md:85-86` — "Efectividad: SOLO aplica a daño de
+carta del jugador... NUNCA a daño del enemigo" **contradice DD-018** (cerrada:
+bidireccional), GOLDEN_RULES §3:99 y el código (ApplyEnemyToPlayerEffectiveness,
+TurnManager.cs:597,655-667). El bullet siguiente del MISMO doc dice "-1 al
+recibir SuperEficaz del enemigo" — inconsistencia interna a 2 líneas de
+distancia. Peligroso: es la regla que un implementador lee antes de tocar
+combate. Esfuerzo S.
+
+### Cluster 5 — Specs sin cerrar
+
+**D14 (=C7).** Los 4 specs restantes (3E, 3F, tint, C7-arte) están **100%
+implementados promesa por promesa** (verificado ítem a ítem, incluyendo conteos
+de tests: 8/5/10/5) pero se presentan como "cerrado en diseño / listo para
+implementación" con prompts de handoff vigentes — riesgo de que alguien tome un
+handoff como tarea pendiente. *Fix:* header de estado "IMPLEMENTADO — PR #X
+MERGED" o mover a `specs/_archive/`. Esfuerzo S.
+
+---
+
+## 3. Menores confirmados (al backlog de la pasada de docs)
+
+- **GDD (archivo de Sebastián):** "One More" residual en :6 y :115 (A6);
+  DD-010 con "10–12 cartas" y DOS bloques duplicados de tamaño final con rangos
+  contradictorios 20-25 vs 20-30/30-40 (A9); "tres categorías" dimensionales
+  donde DD-014 cerró 2 (A10); Mundo B "Futurista" en secciones tempranas
+  (:57,70,86,87) vs "Cyberpunk" en sus propias DD-012/013 y en GOLDEN_RULES
+  (A11 — inconsistencia interna del GDD además del cruce).
+- **MECHANIC_DUALITY.md** se autodenomina "biblia de identidad jugable" activa
+  con sección entera "One More" (A8). Fix: nota de cabecera o archivar. OJO:
+  su §6.2 contiene la ÚNICA definición buena de "transdimensional" (ver
+  siguiente).
+- **"Transdimensional" con 3 usos inconsistentes** (A13, corregido por verify):
+  GOLDEN_RULES §2:66 referencia "(ver §6)" pero §6 no usa el término; §9/GDD lo
+  presentan como novedad de Acto 2; DD-014 lo usa como paraguas de
+  estándar+ancla. SÍ está definido en MECHANIC_DUALITY.md:143-149 y la relación
+  con 4c ya está clarificada en _roadmap.md:122-125 — el fix es alinear
+  GOLDEN_RULES §6 y GLOSSARY con esa definición existente, no crear una nueva.
+- **GOLDEN_RULES §4:122-125** (A12, matizado por verify): el doc SÍ cubre que
+  no se genera segundo bonus; lo no especificado es el destino del CONTADOR con
+  bonus pendiente — el código acumula >5 sin reset ni clamp
+  (TurnManager.cs:992-996; el clamp 0-5 solo existe en SetStyleChargesForTest).
+  Decidir: ¿acumula o capea?
+- **_tech_snapshot** menores: "suite 142/142" en :209 (header del mismo archivo
+  ya dice 146) (B3); "No gh CLI" (:530) — gh 2.92.0 instalado y usado en
+  #96-#108 (B5); "No CI/CD configurado" (:529) — impreciso, tests.yml existe
+  parqueado (B6); LOC menores corridos (PlayerCombatActor 246, UIController
+  752, CardHandView 501, HudView 344) (B7).
+- **Combat/CLAUDE.md:37-39** lista como "cambios futuros que requieren
+  aprobación" dos ya implementados (Heal, PhaseBased); el tercero
+  (CalculateIntentValue) sigue válido (B9, matizado).
+- **COMBAT_ARCHITECTURE:75-91** "monolito de 1400+ líneas... se descompone
+  incrementalmente" — descomposición completa desde 2026-05-01 (B11; absorbido
+  por D1/D2).
+- **m3_hooks_spec**: 5 referencias de línea a TurnManager corridas (mejor citar
+  métodos, no líneas) (C4); naming de payloads divergió sin nota
+  (`CampfireOptionsBuiltHookData` vs `CampfireOptionsHookData` del spec) (C5).
+- **Verificación positiva (A5):** DD-022 y DD-023 SÍ están pegados en
+  DESIGN_DECISIONS.md (:61-62, footer 2026-06-10) — micro-pendiente del reorden
+  M4 cerrado; el cambio está en disco sin commitear.
+
+## 4. Descartados por el verify (1)
+
+- **C6 (DispatchCombatEnd como "divergencia" del spec):** lectura forzada — el
+  spec prescribe punto y momento de invocación y el código lo cumple
+  literalmente (TurnManager.cs:721-731 dentro de CheckCombatEndConditions); la
+  extracción del helper es refactor interno no contradictorio.
+
+## 5. Propuesta de texto para GOLDEN_RULES (Sebastián pega; hook bloquea a Claude)
+
+1. §6:188 → `✓ PhaseBased: filtra moves por rango de HP (MinHpPercent/MaxHpPercent), fallback a todos los moves si ningún rango cubre (M2 Sub-PR D).`
+2. §7:221 → `✓ Shop (Tienda): comprar cartas, Retazos y eliminar cartas (M3 Sub-PR 3D). Consumibles: diferidos, sin sistema aún (decisión pendiente, roadmap).`
+3. §7:222 → `✓ Campfire (Hoguera): descansar (heal % de MaxHP) o mejorar 1 carta (M3 Sub-PR 3C).`
+4. §10:268 → `**De cambio**: incluidos en contenido base como demo de la categoría — 4 Retazos (R-SW-1..4). DD-017 cerrada (opción C, 2026-05-07).`
+5. §4:119 → precisar pre/post-block **después de decidir D4** (si pre-block se
+   ratifica: `+1 carga cuando el ataque es SuperEficaz y el daño calculado pre-block es > 0 (el bloqueo del enemigo NO anula la carga)`).
+6. §4:122-125 → precisar destino del contador con bonus pendiente (tras decidir A12).
+7. §2:62 → desglosar: Retazos ✓ (M3) / cartas WorldSwitch ⏳ **+ asignar dueño**.
+
+## 6. Insumos para fases siguientes
+
+- **Fase 4 (workflow/tooling):** DEV_ONBOARDING.md describe Momentum en el HUD
+  (parte de D1) — auditarlo completo en F4 que ya lo toca; los docs de modos
+  remiten a plantillas que asumen specs con marca de estado (D14 sugiere
+  agregar al ritual de `modo:implementacion` el paso "marcar spec como
+  IMPLEMENTADO al mergear"; la regla de `/cierre-sesion` ya cubre roadmap pero
+  NO specs). MEMORY.md: el micro-pendiente DD-022/023 ya se cerró (A5).
+- **Fase 5 (síntesis / PLAN_PRE_M4):** los fixes documentales se agrupan
+  naturalmente en 3 paquetes: (i) pasada Momentum→Estilo (D1-D3, B11, mismo
+  PR docs); (ii) verdad de Retazos (D7-D10 + decisión D4/A12, coordinado con el
+  fix H1/H2 y la cirugía pre-M5); (iii) números/estado (D11-D14, mecánico).
+  GOLDEN_RULES y GDD van aparte (Sebastián). Huérfanos a adoptar o declarar
+  diferidos: cartas WorldSwitch, tiers DD-009 (con su contradicción de
+  balance), rangos DD-010, elite única.
+- **Pendiente de confirmación puntual (no pasó verify):** HP base 60
+  (TurnManager.cs:26) vs 70 (GOLDEN_RULES §9) — chequear el valor serializado
+  en BattleScene antes del informe final.
+
+---
+*Fase 3 cerrada 2026-06-12. Verify adversarial: 9 lotes, 47 ítems verificados
+(38 cruces + 9 filas de barrido con claim de código), 37+9 confirmados (varios
+con correcciones de precisión integradas), 1 descartado (C6).*

--- a/Docs/dev/audits/2026-06/fase4_workflow_tooling.md
+++ b/Docs/dev/audits/2026-06/fase4_workflow_tooling.md
@@ -1,0 +1,228 @@
+# Auditoría integral 2026-06 — Fase 4: Workflow Claude + tooling
+
+> **Sesión:** 2026-06-12 · Solo lectura. Plan: `fase0_scoping.md` §Fase 4.
+> Mecánica: inline (settings, hook, commands, modos, MEMORY.md, guías) +
+> 2 agentes (skills Unity-MCP, tips de Claude Code). Todo hallazgo verificado
+> contra disco/git antes de entrar acá; lo descartado va en §5.
+
+---
+
+## 0. Inventario verificado
+
+| Superficie | Medido |
+|---|---|
+| `.claude/` trackeado en git | `settings.json`, `hooks/protect-files.js`, 5 commands (verificado con `git ls-files`) |
+| `.claude/settings.local.json` | gitignored (regla `.claude/*` + excepciones), 1 sola regla personal — sin drift |
+| Skills Unity-MCP | **77 carpetas** (no ~85 como decía el scoping, no ~73/~70 como dicen DEV_ONBOARDING/WORKFLOW_GUIDE) |
+| Hook | 1 (PreToolUse `protect-files.js`), cubre los **6** protegidos (3 código + 3 docs) |
+| Memoria persistente | MEMORY.md (~10 KB) + 15 archivos; **2 huérfanos no indexados** |
+
+---
+
+## 1. Hallazgos MAYORES
+
+### T1 — El hook protect-files tiene un bypass real vía Bash/MCP (MAYOR, fix S)
+
+- **[CÓDIGO ACTUAL]** El hook solo se engancha a `Edit|Write|MultiEdit|NotebookEdit`
+  (`settings.json:93`). Cualquier escritura que NO pase por esas tools no se
+  intercepta.
+- **[CÓDIGO ACTUAL]** `settings.json:79` auto-aprueba `Bash(npx unity-mcp-cli *)`
+  (y `:43` `Bash(unity-mcp-cli run-tool:*)`). Por esa vía se puede invocar
+  `script-update-or-create` / `script-delete` / `assets-modify` del plugin
+  Unity-MCP, que **sobreescriben archivos `.cs` en disco** — incluido
+  `TurnManager.cs` — sin prompt de permiso y sin pasar por el hook.
+- Vector secundario, menor: `git checkout:*` / `git restore:*` auto-aprobados
+  pueden revertir un protegido en silencio (riesgo bajo: revierte, no inventa).
+- **Escenario realista de accidente:** una sesión de `modo:implementacion` con
+  MCP conectado elige `script-update-or-create` en vez de Edit para tocar un
+  protegido → la protección entera queda en la disciplina del modelo.
+- **Propuesta (no aplicada, solo lectura):** dos capas complementarias —
+  1. Agregar al hook un matcher `Bash` que bloquee si el comando contiene
+     `script-update-or-create|script-delete` junto a un nombre protegido
+     (cambio chico en `protect-files.js` + 1 entrada en `settings.json`).
+  2. Deshabilitar en el plugin las tools de mutación de scripts que no se usan
+     (ver T9 — cierra el mismo agujero desde el otro lado).
+
+### T2 — DEV_ONBOARDING.md describe el juego pre-M2 (MAYOR, cluster D1 de F3)
+
+Auditado completo (insumo de Fase 3). Confirmado contra código:
+
+| Línea | Dice | Realidad |
+|---|---|---|
+| 10 | HUD con "Energy, **Momentum**, World y Switches" | Momentum eliminado en M2 (PR #89). Única ocurrencia en `Assets/Scripts`: un comentario histórico en `TurnManager.cs:592` que dice "ese sistema desaparece" |
+| 14 | popup "**MOMENTUM +1**" al pegar WEAK | el feedback hoy es del Contador de Estilo |
+| 29 | TurnManager "orquesta turnos, ..., **momentum**" | ídem |
+| 12-13 | prueba con `StrikeBasic.asset` / `WeakSlime.asset` | los assets SÍ existen (verificado) — la receta sigue siendo usable, solo el resultado descrito está viejo |
+| 45 | MCP "da **~73 tools**" | 77 skills en disco; WORKFLOW_GUIDE:130 dice "~70" — 3 números distintos en 3 docs |
+| 57-58 | "activan los **4 modos**" | falta `/cierre-sesion` (5º command, agregado en #108) |
+| 28-34 | "Dónde mirar primero" | 100% combate; ignora todo el Run layer post-M3 (`RunFlowController` 885 LOC, NewRunScene, mapa) y las otras escenas |
+
+Destino sugerido: entra al paquete (i) "pasada Momentum→Estilo" de Fase 5
+(D1-D3, B11) + una pasada de actualización M3 (esfuerzo S, mismo PR docs).
+
+### T3 — D14: el paso "marcar spec como IMPLEMENTADO" no tiene dueño (MAYOR de proceso)
+
+Evaluado dónde encaja (insumo de F3). Confirmado el triple gap:
+
+- La plantilla de Spec Técnico (`_plantillas.md:74-142`) **no tiene campo
+  Estado** — un spec no puede "cerrarse" porque no hay dónde.
+- El checklist de `/cierre-sesion` (`cierre-sesion.md:9-33`) cubre roadmap
+  (pasos 1-2), snapshot (3), memoria (4), milestone (5), git (6) — **specs: nada**.
+- "Cierre de una sub-tarea sustantiva" de `_modo_implementacion.md:128-134`
+  verifica compilación/tests/flujo — tampoco menciona el spec.
+
+**Propuesta de encaje** (el merge ocurre a nivel sesión, no dentro del modo —
+el dueño natural es el ritual de cierre):
+
+1. **`/cierre-sesion`** — nuevo paso entre el 1 y el 2: *"Specs: si esta sesión
+   mergeó un PR que implementa un spec de `Docs/dev/specs/`, agregar al header
+   del spec `> **ESTADO: IMPLEMENTADO** — PR #N (YYYY-MM-DD)`"*.
+2. **`_plantillas.md`** — la plantilla de Spec Técnico gana una línea de header
+   `> **ESTADO: BORRADOR | CERRADO | IMPLEMENTADO (PR #N)**`.
+3. Opcional (refuerzo): 1 línea en el cierre de `_modo_implementacion.md`.
+
+Los 4 specs ya mergeados sin marca (D14) se marcan retroactivamente en el
+mismo PR de docs de Fase 5.
+
+---
+
+## 2. Hallazgos MENORES
+
+### T4 — Ruido y huecos en `settings.json`
+
+- **Redundancia:** `:42` `npx --yes unity-mcp-cli@latest:*`, `:43`
+  `unity-mcp-cli run-tool:*` y `:79` `npx unity-mcp-cli *` se superponen (la
+  `:79` subsume a las otras en la práctica). Consolidar en una.
+- **Resto de otra plataforma:** `:78` `Read(//tmp/**)` no aplica en Windows.
+- **Deny incompleto para PowerShell:** el shell por defecto ES PowerShell y el
+  deny solo cubre `rm:*` / `rm -rf:*` (`:82-83`, la segunda redundante con la
+  primera). `Remove-Item`, `del`, `rd /s` no están. Mismo espíritu, otra sintaxis.
+- `settings.local.json`: 1 regla, coherente con su `$comment`. **Sin drift** —
+  la sospecha del plan no se confirmó.
+
+### T5 — Higiene de memoria persistente
+
+- **2 huérfanos no indexados en MEMORY.md** (existen en disco, nunca se cargan):
+  `project_next_phase.md` (2026-05-07, "M3 entrando en diseño" — vencidísima) y
+  `project_newrun_3e_spec.md` (3E cerrado, PR #97). → borrar; lo vigente ya
+  vive en otras memorias. La primera además tiene el frontmatter mal formado
+  (`type:` fuera de `metadata:`).
+- **Indexadas pero cerradas** (candidatas a borrar/condensar en la higiene de
+  cierre de auditoría): `project_shop_3d_spec` (PR #96 merged),
+  `project_m4_reorder_pending` (cerrado salvo el commit pendiente),
+  `project_dev_tooling_mcp` ("las 4 fases hechas (cerrado)"),
+  `project_art_audit_plan` (11.7 KB para un tail opcional).
+- **MEMORY.md (~10 KB) viola su propia regla** ("1 línea por memoria, nunca
+  contenido" — CLAUDE_WORKFLOW_GUIDE:25-30): la sección "Estado actual" son
+  párrafos largos que duplican las memorias de proyecto. Es carga inicial cara
+  en CADA sesión — exactamente lo que la guía §2 dice evitar.
+- **DD-022/023:** la memoria es EXACTA, no vencida — `git status` confirma
+  `M Docs/design/DESIGN_DECISIONS.md` aún sin commitear al 2026-06-12. (El
+  insumo de F3 cerró el micro-pendiente de *disco*; el commit sigue pendiente.)
+
+### T6 — Inconsistencias menores en guías
+
+- Conteo de tools: 77 reales vs "~70" (WORKFLOW_GUIDE:130) vs "~73"
+  (DEV_ONBOARDING:45). Unificar o decir "~75+, ver `unity-tool-list`".
+- WORKFLOW_GUIDE §4 lista los commands `modo-*` pero no `/cierre-sesion`
+  (que §2.6 sí explica). Coherencia interna a medias.
+- `cierre-sesion.md` es el único command **sin frontmatter**
+  (description/argument-hint) — los otros 4 lo tienen.
+
+### Sanos (auditados, sin hallazgo)
+
+- `protect-files.js`: cubre los 6 protegidos, normaliza separadores,
+  case-insensitive, fail-open razonable ante JSON inválido. El único agujero
+  es el de superficie (T1), no de lógica interna.
+- Los 7 archivos de `Docs/dev/modes/`: sin drift Momentum, sin referencias
+  muertas, consistentes entre sí y con CLAUDE.md raíz. La política de testing
+  de `_modo_implementacion` y el playbook de `_subagentes.md` están al día.
+- Los 4 commands `modo-*`: consistentes con la regla de activación.
+- `.gitignore` de `.claude/`: correcto (skills excluidas = regenerables;
+  settings/hooks/commands re-incluidos; `settings.local.json` ignorado como
+  prometen los docs).
+
+---
+
+## 3. Oportunidades (agentes)
+
+### T9 — Skills Unity-MCP: ~36 de 77 son carga muerta desactivable (OPORTUNIDAD, esfuerzo S)
+
+Agente de análisis de uso (evidencia en docs/specs/commits/settings):
+
+- **Con evidencia de uso o pre-aprobadas en settings (~22):** tests-run,
+  console-get-logs, scene-*, editor-application-get-state, assets-find/get-data,
+  gameobject-find/component-get, screenshot-*, profiler-get-* (solo lectura),
+  script-execute, ping, unity-tool-list y sistema. → mantener.
+- **Carga muerta probable (~36):** profiler de control (start/stop/save/load/
+  module ×8 — overkill para un juego de turnos 1v1), package-* ×4,
+  reflection-* ×2, mutación de assets/prefabs (copy/delete/move/modify/
+  material/prefab-* ×11), mutación de gameobjects ×7, editor-*-set ×2,
+  script-read/delete/update-or-create ×3, type-get-json-schema,
+  screenshot-isolated, console-clear-logs. Cero referencias en specs, modos,
+  roadmap o commits.
+- **Mecanismo correcto:** `tool-set-enabled-state` (persiste en el plugin).
+  **NO borrar carpetas** — `unity-skill-generate` las regeneraría todas.
+  Reversible en 1 llamada si M4 las necesita (p. ej. re-habilitar assets-* si
+  se aprueba una skill propia de generación de SOs).
+- **Beneficio:** lista de skills por sesión 77→~41 (ahorro de contexto real,
+  aunque la cifra exacta de tokens del agente es estimativa), menos superficie
+  de mutación accidental, y **cierra parcialmente el bypass T1** (deshabilitar
+  `script-update-or-create`/`script-delete` mata el vector principal).
+
+### T10 — Tips de Claude Code aplicables (filtrados adversarialmente)
+
+Del segundo agente sobrevivieron al verify **3 de 10** propuestas (el resto
+citaba features inexistentes — ver §5):
+
+1. **`model: sonnet` en el frontmatter de `cierre-sesion.md`** (esfuerzo: 1
+   línea). Los commands soportan override de modelo por frontmatter; hoy el
+   "/model sonnet para abaratar" es un hábito manual documentado en memoria.
+   Automatizarlo elimina el paso y el riesgo de olvidarlo. De paso resuelve T6
+   (frontmatter faltante).
+2. **`/fewer-permission-prompts`** (skill built-in, 1 corrida): escanea
+   transcripts reales y propone el allowlist — insumo objetivo para la
+   limpieza de T4 en vez de curarla a mano.
+3. **De-scope automático de `settings.json`/`.slnx`:** el dolor es real (paso 6
+   de /cierre-sesion existe por eso), pero la propuesta del agente (hook
+   PostToolUse) NO funciona — la auto-modificación la hace el harness, no una
+   tool Edit/Write, así que el hook nunca dispararía. Alternativa que sí
+   funciona si se quiere automatizar: **git pre-commit hook** que rechace
+   commits que incluyan esos 2 archivos salvo flag explícito. Veredicto: nice
+   to have; el paso manual del ritual ya lo cubre. Decidir en F5.
+
+---
+
+## 4. Resumen para Fase 5
+
+| ID | Severidad | Tema | Esfuerzo | Destino sugerido |
+|---|---|---|---|---|
+| T1 | MAYOR | Bypass de protect-files vía Bash/MCP | S | Fix inmediato (hook + T9) |
+| T2 | MAYOR | DEV_ONBOARDING pre-M2/M3 | S | Paquete docs (i) Momentum→Estilo |
+| T3 | MAYOR (proceso) | Specs sin marca de cierre (D14) | S | Editar cierre-sesion + plantillas + marcar 4 specs retro |
+| T4 | MENOR | Ruido/huecos en settings.json | S | PR de tooling |
+| T5 | MENOR | Higiene de memoria (2 huérfanas, índice pesado) | S | Higiene al cierre de auditoría |
+| T6 | MENOR | Conteos de tools y omisiones en guías | S | Mismo PR docs que T2 |
+| T9 | OPORTUNIDAD | Deshabilitar ~36 skills muertas | S | 1 llamada tool-set-enabled-state (decisión de Sebastián) |
+| T10 | OPORTUNIDAD | model:sonnet en cierre-sesion + /fewer-permission-prompts | S | PR de tooling |
+
+## 5. Descartados y por qué
+
+- **Drift settings.json ↔ settings.local.json** (sospecha del plan): no existe —
+  el local tiene 1 regla coherente.
+- **7 de 10 tips del agente de Claude Code:** output styles con JSON de reglas,
+  frontmatter `paths:` en commands, `promptCacheConfig`/TTL en settings,
+  comando `/batch` para worktrees, hook `PermissionRequest` como lo describió —
+  **features inexistentes o mal descritas** (alucinadas); SessionStart con
+  assets-refresh (latencia en cada sesión para cubrir un caso que la regla
+  "no switchear con Unity abierto" ya previene); PreCompact snapshot de memoria
+  (valor marginal).
+- **Hook PostToolUse para de-scope** tal como lo propuso el agente: mecanismo
+  incorrecto (ver T10.3).
+- **"Suite 146/146" y conteos de skills de agentes** (78 vs 77): corregidos a
+  los valores medidos en disco.
+
+---
+*Consumo Fase 4: 2 subagentes (~48k + ~72k tokens de subagente) + inline
+(~25 lecturas, 4 greps/globs, 3 comandos git/fs de verificación). Verify: cada
+hallazgo de §1-§3 confirmado contra disco/git; lo no confirmable, descartado (§5).*


### PR DESCRIPTION
## Qué incluye

Cierre de la auditoría integral de solo lectura (6 fases). Solo agrega docs en `Docs/dev/audits/2026-06/` — cero cambios de código.

- **AUDIT_REPORT.md** — consolidación de hallazgos que pasaron verify adversarial: 0 críticos; 13 mayores (10 código + 3 tooling) + 14 mayores documentales; ~36 menores; 8 oportunidades; ~9 descartados con justificación. Tabla maestra de prioridad.
- **PLAN_PRE_M4.md** — remediación en 6 sub-PRs estilo M3 + cirugía única de TurnManager pre-M5. Decisiones D-A/B/C resueltas (Estilo pre-block · cap de Estilo a 5 · HP base 60); D-D abierta.
- **fase0–fase4** — checkpoints por fase, verificados contra disco/git.

## Notas
- DD-022/023 va en un PR aparte (`docs/dd-022-023`) — cambio de diseño, no auditoría.
- El cap de Estilo a 5 (D-B) quedó identificado como bug de código real (TurnManager acumula >5) → se arregla en el futuro sub-PR 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)