### PR TITLE
chore(tooling): cierra bypass del hook protect-files + limpieza (SUB-PR 6)

### DIFF
--- a/.claude/commands/cierre-sesion.md
+++ b/.claude/commands/cierre-sesion.md
@@ -1,3 +1,8 @@
+---
+description: Ritual de cierre y persistencia de sesión (cualquier modo)
+model: sonnet
+---
+
 # /cierre-sesion — Ritual de cierre y persistencia
 
 Ejecutá el ritual de cierre de sesión. Aplica al final de CUALQUIER sesión de

--- a/.claude/hooks/protect-files.js
+++ b/.claude/hooks/protect-files.js
@@ -2,14 +2,28 @@
 /**
  * PreToolUse hook — protege archivos criticos del proyecto.
  *
- * Bloquea Edit/Write/MultiEdit/NotebookEdit sobre archivos que, segun CLAUDE.md,
- * NO se modifican sin aprobacion explicita de Sebastian:
+ * Bloquea las escrituras sobre archivos que, segun CLAUDE.md, NO se modifican
+ * sin aprobacion explicita de Sebastian:
  *   - 3 archivos de combate (arquitectura sensible)
  *   - 3 docs que solo Sebastian edita (GOLDEN_RULES, GDD, DESIGN_DECISIONS)
+ *   - el propio hook (evita auto-desenganche silencioso; ver nota abajo)
  *
- * Mecanismo: lee el JSON del tool call por stdin; si el path apunta a un archivo
- * protegido, sale con codigo 2 (bloquea la herramienta y devuelve el mensaje a
- * Claude por stderr).
+ * Cubre DOS superficies de escritura:
+ *   1. Edit / Write / MultiEdit / NotebookEdit  -> via tool_input.file_path.
+ *   2. Bash con comandos del plugin Unity-MCP (`script-update-or-create`,
+ *      `script-delete`) que sobreescriben/borran .cs en disco SIN pasar por
+ *      Edit/Write. Sin este matcher, `npx unity-mcp-cli run-tool
+ *      script-update-or-create ... TurnManager.cs` editaba un protegido sin
+ *      prompt ni hook (agujero T1 de la auditoria integral 2026-06).
+ *
+ * Mecanismo: lee el JSON del tool call por stdin; si el target apunta a un
+ * archivo protegido, sale con codigo 2 (bloquea la herramienta y devuelve el
+ * mensaje a Claude por stderr).
+ *
+ * Riesgo residual conocido: el agente podria editar .claude/settings.json para
+ * desenganchar el hook y luego editar un protegido. Eso ya NO es silencioso —
+ * es una accion deliberada, visible en el diff y revisable. settings.json NO se
+ * protege a proposito (lo necesita el flujo update-config).
  *
  * Override puntual: si Sebastian autoriza editar uno de estos archivos, comenta
  * temporalmente el hook en .claude/settings.json o pidele que edite el a mano.
@@ -22,37 +36,60 @@ const PROTECTED = [
   'Docs/dev/GOLDEN_RULES.md',
   'Docs/design/_gdd.md',
   'Docs/design/DESIGN_DECISIONS.md',
+  '.claude/hooks/protect-files.js',
 ];
+
+// Comandos del plugin Unity-MCP que escriben/borran .cs en disco SIN pasar por
+// Edit/Write. Si aparecen en un Bash junto a un archivo protegido, se bloquea.
+const MCP_WRITE_TOOLS = ['script-update-or-create', 'script-delete'];
 
 function norm(p) {
   return String(p || '').replace(/\\/g, '/').toLowerCase();
+}
+
+function basename(p) {
+  const n = norm(p);
+  const i = n.lastIndexOf('/');
+  return i >= 0 ? n.slice(i + 1) : n;
+}
+
+function blocked(hit) {
+  process.stderr.write(
+    `BLOQUEADO por hook protect-files: "${hit}" es un archivo protegido ` +
+      `(ver CLAUDE.md > Sobre archivos). NO lo edites sin aprobacion explicita ` +
+      `de Sebastian. Si ya la tenes, pedile que confirme y desactive el hook ` +
+      `temporalmente, o que aplique el cambio a mano.`
+  );
+  process.exit(2);
 }
 
 let raw = '';
 process.stdin.setEncoding('utf8');
 process.stdin.on('data', (c) => (raw += c));
 process.stdin.on('end', () => {
-  let path = '';
+  let ti = {};
   try {
     const data = JSON.parse(raw || '{}');
-    const ti = data.tool_input || {};
-    path = ti.file_path || ti.notebook_path || ti.path || '';
+    ti = data.tool_input || {};
   } catch (_) {
     process.exit(0); // si no se puede parsear, no bloquear
   }
 
-  const target = norm(path);
-  if (!target) process.exit(0);
-
-  const hit = PROTECTED.find((p) => target.endsWith(norm(p)));
-  if (hit) {
-    process.stderr.write(
-      `BLOQUEADO por hook protect-files: "${hit}" es un archivo protegido ` +
-        `(ver CLAUDE.md > Sobre archivos). NO lo edites sin aprobacion explicita ` +
-        `de Sebastian. Si ya la tenes, pedile que confirme y desactive el hook ` +
-        `temporalmente, o que aplique el cambio a mano.`
-    );
-    process.exit(2);
+  // Superficie 1: Edit/Write/MultiEdit/NotebookEdit -> path directo.
+  const target = norm(ti.file_path || ti.notebook_path || ti.path || '');
+  if (target) {
+    const hit = PROTECTED.find((p) => target.endsWith(norm(p)));
+    if (hit) blocked(hit);
   }
+
+  // Superficie 2: Bash -> comandos MCP que escriben/borran .cs en disco.
+  const command = norm(ti.command || '');
+  if (command && MCP_WRITE_TOOLS.some((t) => command.includes(t))) {
+    const hit = PROTECTED.find(
+      (p) => command.includes(norm(p)) || command.includes(basename(p))
+    );
+    if (hit) blocked(hit);
+  }
+
   process.exit(0);
 });

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,8 +39,7 @@
       "Bash(which:*)",
       "Bash(npm -v)",
       "Bash(npm view:*)",
-      "Bash(npx --yes unity-mcp-cli@latest:*)",
-      "Bash(unity-mcp-cli run-tool:*)",
+      "Bash(npx unity-mcp-cli *)",
       "Bash(openupm:*)",
       "WebSearch",
       "WebFetch(domain:github.com)",
@@ -74,13 +73,14 @@
       "mcp__ai-game-developer__profiler-get-rendering-stats",
       "mcp__ai-game-developer__profiler-get-script-stats",
       "Bash(git check-ignore *)",
-      "Bash(node .claude/hooks/protect-files.js)",
-      "Read(//tmp/**)",
-      "Bash(npx unity-mcp-cli *)"
+      "Bash(node .claude/hooks/protect-files.js)"
     ],
     "deny": [
       "Bash(rm:*)",
       "Bash(rm -rf:*)",
+      "Bash(Remove-Item:*)",
+      "Bash(del:*)",
+      "Bash(rd /s:*)",
       "Bash(git push --force:*)",
       "Bash(git push -f:*)",
       "Bash(git reset --hard:*)",
@@ -90,7 +90,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit|Bash",
         "hooks": [
           {
             "type": "command",

--- a/Docs/dev/audits/2026-06/PLAN_PRE_M4.md
+++ b/Docs/dev/audits/2026-06/PLAN_PRE_M4.md
@@ -157,14 +157,32 @@ aprueba la edición en el hilo principal.
 - **D14 + T3 (proceso):** marcar los 4 specs (3E/3F/tint/C7) con header `> **ESTADO: IMPLEMENTADO — PR #N (fecha)**`; agregar campo Estado a la plantilla de Spec Técnico; agregar paso "marcar spec IMPLEMENTADO" a `/cierre-sesion`.
 - **HP (tras D-C):** si la verdad es 70 → subir `BattleScene.unity:434` + `TurnManager.cs:26`; si es 60 → corregir GOLDEN_RULES §9 (lo toca Sebastián) + nota de decisión.
 
-### SUB-PR 6 — Tooling: cerrar el bypass + limpieza `chore/tooling-hardening`
+### SUB-PR 6 — Tooling: cerrar el bypass + limpieza `chore/tooling-hardening` ✅ CERRADO 2026-06-14
 
 **Cierra:** T1, T3 (parte de proceso ya en sub-PR 5), T4, T10.
 **Esfuerzo:** S.
 
-- **T1 (mayor):** agregar al hook `protect-files.js` un matcher `Bash` que bloquee si el comando contiene `script-update-or-create|script-delete` junto a un nombre protegido + 1 entrada en `settings.json`.
-- **T4:** consolidar los 3 permisos MCP redundantes en uno; sacar `Read(//tmp/**)`; agregar `Remove-Item`/`del`/`rd /s` al deny (equivalentes PowerShell de `rm`).
-- **T10:** `model: sonnet` en frontmatter de `cierre-sesion.md` (resuelve también el frontmatter faltante de T6); correr `/fewer-permission-prompts` para curar el allowlist con datos reales.
+- [x] **T1 (mayor):** `protect-files.js` reescrito con DOS superficies — (1) la de
+      siempre (`Edit/Write/MultiEdit/NotebookEdit` por `file_path`) y (2) un matcher
+      `Bash` que bloquea (exit 2) si el comando contiene `script-update-or-create` o
+      `script-delete` junto a un path/basename protegido. Matcher de `settings.json`
+      ampliado a `…|Bash`. Validado: bloquea el vector MCP sobre los 3 protegidos
+      (path completo y basename, incl. backslashes) y NO rompe `tests-run`/`ping`/
+      `assets-refresh` ni `script-update-or-create` sobre archivos NO protegidos.
+- [x] **T1 residual (decisión de Sebastián 2026-06-14):** el propio hook
+      `.claude/hooks/protect-files.js` se sumó a `PROTECTED` → cierra la auto-edición
+      silenciosa del hook. Riesgo residual aceptado y documentado en el header del
+      hook: un bypass exige editar `settings.json` para desenganchar (acción
+      deliberada y visible en el diff). `settings.json` NO se protege (lo necesita
+      el flujo `update-config`).
+- [x] **T4:** 3 permisos MCP redundantes consolidados en `Bash(npx unity-mcp-cli *)`;
+      `Read(//tmp/**)` eliminado; `Remove-Item`/`del`/`rd /s` agregados al deny
+      (equivalentes PowerShell de `rm`).
+- [x] **T10:** `model: sonnet` + `description` en frontmatter de `cierre-sesion.md`
+      (resuelve también el frontmatter faltante de T6). `/fewer-permission-prompts`
+      corrido sobre las 50 sesiones recientes → **sin entradas nuevas**: todo lo
+      observado ya estaba allowlisted, es auto-allowed, o se excluye por regla
+      (código arbitrario / mutación). El allowlist ya estaba afinado.
 
 ---
 


### PR DESCRIPTION
## SUB-PR 6 — Tooling hardening (auditoría pre-M4)

Cierra **T1, T4, T10** del plan `Docs/dev/audits/2026-06/PLAN_PRE_M4.md §SUB-PR 6`.
Chore puro de tooling: **no toca `Assets/` ni archivos protegidos de combate**.

### T1 (mayor) — cierra el bypass real del hook protect-files
El hook solo enganchaba `Edit/Write/MultiEdit/NotebookEdit`. Como `Bash(npx unity-mcp-cli *)`
está auto-aprobado, un comando del plugin Unity-MCP que crea/borra scripts editaba un
archivo protegido (incluido el TurnManager) en disco **sin prompt ni hook**.

- `protect-files.js` reescrito con **dos superficies**: (1) la de siempre por `file_path`,
  y (2) un matcher `Bash` que bloquea (exit 2) si el comando contiene un tool de escritura
  MCP junto a un path o basename protegido.
- Matcher de `settings.json` ampliado a `Edit|Write|MultiEdit|NotebookEdit|Bash`.
- **Decisión de Sebastián (T1 residual):** el propio hook se suma a `PROTECTED` → cierra la
  auto-edición silenciosa. `settings.json` NO se protege (lo necesita `update-config`); el
  riesgo residual (desenganchar el hook vía `settings.json`) queda como acción deliberada y
  visible en el diff, documentada en el header del hook.

### T4 — limpieza de `settings.json`
- 3 permisos MCP redundantes consolidados en un solo `Bash(npx unity-mcp-cli *)`.
- `Read(//tmp/**)` eliminado (era de otra plataforma).
- `Remove-Item` / `del` / `rd /s` agregados al `deny` (equivalentes PowerShell de `rm`).

### T10 — `cierre-sesion.md` + allowlist
- `model: sonnet` + `description` en frontmatter de `cierre-sesion.md` (resuelve también el
  frontmatter faltante de T6).
- `/fewer-permission-prompts` corrido sobre las 50 sesiones recientes → **sin entradas nuevas**:
  todo lo observado ya estaba allowlisted, es auto-allowed, o se excluye por regla (código
  arbitrario / mutación).

### Validación
Probado por stdin contra el hook (exit codes):
- **Bloquea (2):** create/delete MCP sobre los 3 combat `.cs` (path completo, basename y
  backslashes); Edit de un protegido; Edit del propio hook.
- **Pasa (0):** `tests-run`, `ping`, `assets-refresh`; create de script sobre archivo NO
  protegido; Edit de archivo NO protegido.

`settings.json` valida como JSON; `node -c` del hook OK.

> Nota de comportamiento: el matcher Bash tiene un over-block deliberado — cualquier Bash que
> mencione literalmente un write-tool MCP **y** un basename protegido se bloquea (capturó hasta
> el harness de test y el mensaje de este commit). Para un hook de seguridad es el lado correcto
> en el que errar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
