### PR TITLE
docs(workflow): actualiza el bullet del hook protect-files (post SUB-PR 6)

### DIFF
--- a/Docs/dev/CLAUDE_WORKFLOW_GUIDE.md
+++ b/Docs/dev/CLAUDE_WORKFLOW_GUIDE.md
@@ -134,9 +134,14 @@ Tu estilo de colaboración ya está definido: **vos diseñás, Claude implementa
 - **Permisos** — `.claude/settings.json` (compartido, commiteado) +
   `.claude/settings.local.json` (personal, gitignored). Precedencia:
   `deny > ask > allow`.
-- **Hook de protección** — `.claude/hooks/protect-files.js` bloquea Edit/Write
-  sobre los 6 archivos protegidos (3 de combate + GOLDEN_RULES + GDD +
-  DESIGN_DECISIONS). Para una edición autorizada, comentá el hook en `settings.json`
+- **Hook de protección** — `.claude/hooks/protect-files.js` (PreToolUse) bloquea
+  la escritura sobre los archivos protegidos por DOS superficies: (1)
+  `Edit/Write/MultiEdit/NotebookEdit` por `file_path`, y (2) `Bash` con los
+  comandos del plugin Unity-MCP (`script-update-or-create`/`script-delete`) que
+  antes editaban `.cs` en disco sin pasar por el hook. Protege 7 archivos: 3 de
+  combate + GOLDEN_RULES + GDD + DESIGN_DECISIONS + **el propio hook** (evita la
+  auto-edición silenciosa). `settings.json` NO se protege (lo necesita
+  `update-config`). Para una edición autorizada, comentá el hook en `settings.json`
   o editá a mano.
 - **Modos como comandos** — `.claude/commands/modo-*.md`. Invocás con
   `/modo-diseno`, etc.


### PR DESCRIPTION
Corrige `CLAUDE_WORKFLOW_GUIDE.md` §4: el bullet del hook decía "bloquea Edit/Write sobre los 6 archivos protegidos", desactualizado tras el hardening del hook (#113). Ahora describe las **2 superficies** (Edit/Write + matcher Bash del vector Unity-MCP) y los **7 protegidos** (+ el propio hook). El conteo de tools ("~70") se difiere al paquete docs (i)/SUB-PR 3 que ya lo tiene agendado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)