### PR TITLE
docs(combat): docs paquete (i) — Momentum → Estilo (SUB-PR 3)

### DIFF
--- a/Docs/dev/CLAUDE_WORKFLOW_GUIDE.md
+++ b/Docs/dev/CLAUDE_WORKFLOW_GUIDE.md
@@ -127,10 +127,10 @@ Tu estilo de colaboración ya está definido: **vos diseñás, Claude implementa
 
 ## 4. Tooling de este repo (resumen)
 
-- **Unity MCP** (`ai-game-developer`, IvanMurzak, local): ~70 tools para leer
-  consola, escenas, GameObjects, correr tests NUnit, screenshots. Las de
-  solo-lectura están pre-aprobadas en `.claude/settings.json`; las que mutan
-  piden confirmación.
+- **Unity MCP** (`ai-game-developer`, IvanMurzak, local): ~75+ tools para leer
+  consola, escenas, GameObjects, correr tests NUnit, screenshots (usá
+  `unity-tool-list` para el listado actualizado). Las de solo-lectura están
+  pre-aprobadas en `.claude/settings.json`; las que mutan piden confirmación.
 - **Permisos** — `.claude/settings.json` (compartido, commiteado) +
   `.claude/settings.local.json` (personal, gitignored). Precedencia:
   `deny > ask > allow`.
@@ -144,7 +144,8 @@ Tu estilo de colaboración ya está definido: **vos diseñás, Claude implementa
   `update-config`). Para una edición autorizada, comentá el hook en `settings.json`
   o editá a mano.
 - **Modos como comandos** — `.claude/commands/modo-*.md`. Invocás con
-  `/modo-diseno`, etc.
+  `/modo-diseno`, etc. Incluye también `/cierre-sesion` (checklist de persistencia
+  al terminar un bloque de trabajo).
 
 ---
 

--- a/Docs/dev/COMBAT_ARCHITECTURE.md
+++ b/Docs/dev/COMBAT_ARCHITECTURE.md
@@ -1,116 +1,277 @@
 ## Combat Architecture
 
+> **Última actualización:** 2026-06-15 (SUB-PR 3 auditoría pre-M4 — paquete docs i).
+> Reescrito con Contador de Estilo (M2, reemplaza Momentum) + subsistemas M2/M3 +
+> pipeline fin-de-combate (Opción B, fix 2026-06-14).
+
+---
+
 ### Big picture
-- Combate 1v1 por turnos: el jugador juega cartas, se encolan acciones y se resuelven en orden.
-- Conceptos clave:
-  - World A/B (Change World): estado binario que afecta cartas duales; limitado a 1 cambio por combate (debug ilimitado opcional).
-  - ElementType (placeholder por color) + Effectiveness: modifica daño (SuperEficaz/PocoEficaz/Neutro).
-  - Momentum: free play al golpear debilidad (SuperEficaz); se consume en el siguiente uso de carta para no gastar energía.
-  - ActionQueue / IGameAction: cola determinista que resuelve acciones (daño, block, draw) secuencialmente.
+
+Combate 1v1 por turnos: el jugador juega cartas, las acciones se encolan y se
+resuelven en orden determinista.
+
+**Conceptos clave:**
+
+- **World A / B (Change World):** estado binario que afecta el lado activo de las
+  cartas duales y el tipo elemental del jugador. Limitado a 1 cambio por combate
+  (configurable; debug ilimitado opcional).
+- **ElementType** (placeholder por color: Rojo, Amarillo, Azul, Morado, Negro,
+  Blanco, None) + **Efectividad**: modifica daño (SuperEficaz ×1.5 / Neutro ×1.0 /
+  PocoEficaz ×0.75). **Bidireccional desde M2 (DD-018):** aplica al daño del jugador
+  sobre el enemigo Y al daño del enemigo sobre el jugador.
+- **Contador de Estilo:** +1 carga al hacer un golpe SuperEficaz (pre-block; el
+  bloqueo del enemigo no anula la carga); −1 al recibir SuperEficaz del enemigo.
+  5 cargas → 1 switch de mundo extra (no acumulable), reset de cargas. HUD: "Estilo: X/5".
+- **Cartas neutras:** daño al 90% del base (regla de balance, sin popup de efectividad).
+- **ActionQueue / IGameAction:** cola FIFO determinista que resuelve acciones
+  (daño, block, draw, heal) secuencialmente. `ProcessAll()` es síncrono.
+- **Retazos (M3):** items persistentes del run. `RelicHookDispatcher` invoca efectos
+  en 9 eventos clave del combate/nodo vía `RelicHookContext` (API limitada de 7
+  métodos). Los efectos no accedan directamente al `TurnManager`; lo hacen solo
+  a través de la API del contexto.
+
+---
+
+### Flujo de combate — detalle
+
+#### Inicialización
+
+```
+[BattleFlowController.Awake]
+    └─ TryConfigureCombat()
+          ├─ Lee RunSession + nodo actual (enemigo, IsElite, IsBoss)
+          └─ TurnManager.ConfigureCombat(deck, enemy, hp, maxHp)
+                ├─ Inyecta tipos por mundo del jugador
+                ├─ Inicializa _player / _enemy / _actionQueue
+                └─ Dispara OnCombatStart hook
+
+[CombatUIController.Start]
+    └─ BuildUI() — construye canvas en runtime (HUD, paneles, fondos)
+    └─ InitializeExtractedViews()
+          ├─ CombatFeedbackView — popups WEAK/RESIST/+ESTILO, shake, victory/defeat
+          ├─ CardHandView — mano, click → TryPrepareCardPlay/ResolvePreparedCardPlay
+          ├─ CombatHudView — textos: energía, Estilo, HP, bloqueo, intent, mundo, tipo
+          └─ CombatBackgroundView — fondos A/B, CoverFill
+```
+
+#### Loop de combate
+
+**Turno del jugador:**
+
+1. `TurnManager.BeginPlayerTurn()` — reset energía, draw cards, dispara `OnPlayerTurnStart` hook.
+2. `CardHandView` muestra la mano. Click → `TryPrepareCardPlay(entry, out prepared)`:
+   - Valida energía y que la carta esté en mano.
+   - Devuelve un `PreparedCardPlay` con la definición activa y el target.
+3. Animación de ataque (`PlayAttackOnce`). Al completar → `ResolvePreparedCardPlay(prepared)`:
+   - Determina efectividad (atacante vs tipo activo del enemigo).
+   - Actualiza Contador de Estilo (±1).
+   - Encola efectos en `ActionQueue`.
+   - `ActionQueue.ProcessAll()` resuelve daño/block/draw secuencialmente.
+   - Dispara hooks: `OnCardPlayed`, `OnDamageDealt`/`OnDamageTaken`.
+   - Descarta carta; verifica condición de fin de combate.
+4. `Player.EndTurn()` → paso al turno del enemigo.
+
+**Turno del enemigo:**
+
+1. `TurnManager.ExecuteEnemyTurn()` — limpia bloqueo enemigo, `SelectEnemyMove()` elige movimiento
+   según `AIPattern` (RandomWeighted / Sequence / PhaseBased por rango de HP).
+2. Encola efectos del movimiento → `ActionQueue.ProcessAll()`.
+3. `PlanNextEnemyMove()` para mostrar intent en el próximo turno.
+4. Verifica condición de fin de combate.
+
+#### Fin de combate
+
+```
+TurnManager.CheckCombatEndConditions()
+    └─ TurnManager.DispatchCombatEnd()
+          ├─ Sincroniza RunState.PlayerCurrentHP/MaxHP = _player.* (ANTES del dispatch)
+          │   → RunState autoritativo; Retazos OnCombatEnd leen/mutan HP fresco
+          └─ RelicHookDispatcher.Dispatch(OnCombatEnd, CombatEndHookData)
+
+BattleFlowController.Update() detecta cambio de fase (Victory/Defeat)
+    └─ ReportOutcome()
+          ├─ ApplyCombatResult(session, victory) — flags, ActoCompleted, drops de Retazos
+          │   SIN re-pisar HP (TurnManager ya sincronizó)
+          └─ RunScene → SceneTransitionManager
+```
+
+> **Regla de autoría para Retazos `OnCombatEnd`:** la mutación directa de
+> `RunState.PlayerCurrentHP` en OnCombatEnd ES CORRECTA bajo este diseño (Opción B,
+> fix 2026-06-14). `GrantHeal` sobre el actor no es viable en OnCombatEnd (no-op:
+> `IsCombatFinished` ya es `true`).
+
+---
 
 ### Diagramas (Mermaid)
 
 #### Turno del jugador (alto nivel)
+
 ```mermaid
 flowchart TD
-    A["Start Player Turn"] --> B["Draw cards and reset energy"]
-    B --> C["Player plays cards"]
-    C --> D["QueueEffects to ActionQueue"]
-    D --> E["ActionQueue ProcessAll"]
-    E --> F["Check end of combat"]
-    F -->|Combat ends| G["Victory or Defeat"]
-    F -->|Combat continues| H["Plan enemy move"]
-    H --> I["EndPlayerTurn then EnemyTurn"]
-    I --> J["Enemy actions via ActionQueue"]
-    J --> K["Check end of combat"]
-    K -->|Ends| G
-    K -->|Continues| L["Begin next Player Turn"]
+    A["BeginPlayerTurn\n(reset energía, draw, OnPlayerTurnStart hook)"] --> B["Player juega cartas\n(CardHandView)"]
+    B --> C["TryPrepareCardPlay\n(valida energía/mano)"]
+    C -->|ok| D["ResolvePreparedCardPlay\n(efectividad · Estilo · encola efectos)"]
+    D --> E["ActionQueue.ProcessAll\n(daño/block/draw/heal secuencial)"]
+    E --> F["CheckCombatEndConditions"]
+    F -->|fin| G["DispatchCombatEnd\n(sync RunState · hooks OnCombatEnd)"]
+    F -->|continúa| H["Plan enemy move"]
+    H --> I["ExecuteEnemyTurn"]
+    I --> J["ActionQueue.ProcessAll"]
+    J --> K["CheckCombatEndConditions"]
+    K -->|fin| G
+    K -->|continúa| A
 ```
 
-#### PlayCard (detalle)
+#### ResolvePreparedCardPlay (detalle)
+
 ```mermaid
 flowchart TD
-    A["PlayCard entry"] --> B["Get active CardDefinition using WorldSide"]
-    B --> C["Check card is in hand"]
-    C --> D["Check energy or Momentum"]
-    D -->|Momentum available| E["Consume Momentum free play"]
-    D -->|No Momentum| F["Spend energy cost"]
-    E --> G["Determine target"]
-    F --> G
-    G --> H["QueueEffects with source element type"]
-    H --> I["Damage: adjust by Effectiveness"]
-    I --> J["If SuperEficaz and damage > 0 then Momentum plus one"]
-    J --> K["Emit hit feedback event"]
-    K --> L["ActionQueue ProcessAll"]
-    L --> M["Discard card and check end"]
-    M --> N["UI updates"]
+    A["ResolvePreparedCardPlay"] --> B["Obtener CardDefinition activa\n(WorldSide A o B)"]
+    B --> C["Calcular efectividad\n(tipo carta vs tipo activo enemigo)"]
+    C --> D{Efectividad}
+    D -->|SuperEficaz| E["+1 carga Estilo\n(pre-block, siempre)"]
+    D -->|PocoEficaz| F["sin cambio de Estilo"]
+    D -->|Neutro/None| G["daño ×0.90 (90%)"]
+    E --> H["QueueEffects → ActionQueue"]
+    F --> H
+    G --> H
+    H --> I["ProcessAll"]
+    I --> J["Evento PlayerHitEffectiveness\n→ popup WEAK/+ESTILO o RESIST"]
+    J --> K["OnCardPlayed hook"]
+    K --> L["Descartar carta · CheckCombatEnd"]
 ```
+
+---
+
+### Subsistemas M2 / M3
+
+#### Contador de Estilo (M2, PR #89)
+
+- Reemplaza por completo a Momentum (eliminado en M2).
+- Variables: `_styleCharges` (0-5) y `_bonusWorldSwitches` (0-1, no acumulable).
+- `IncrementStyleCharges()` (método interno) es la única fuente de mutación del contador.
+- Al recibir SuperEficaz del enemigo: −1 carga (puede ir a negativo transitorio,
+  pero no acumula bonus).
+- La UI hardcodea "/5" porque `MaxStyleCharges` no está expuesto como propiedad
+  pública (gap conocido, ver Future work).
+
+#### Efectividad bidireccional (M2, DD-018)
+
+El daño del enemigo sobre el jugador aplica el mismo multiplicador (×1.5 SuperEficaz,
+×0.75 PocoEficaz) basado en el tipo del enemigo vs el **tipo activo del jugador**
+(que depende del mundo actual). Las cargas de Estilo se enlazan al lado defensivo:
+recibir SuperEficaz descuenta 1 carga.
+
+#### HealAction (M2 Sub-PR D)
+
+`EffectType.Heal` produce una `HealAction` que implementa `IGameAction`. Funciona
+en ambos actores (`PlayerCombatActor.Heal()` / `EnemyCombatActor.Heal()`). El intent
+`CalculateIntentValue` cubre `Defend + Heal` además de `Attack + Damage` y `Defend + Block`.
+
+#### PhaseBased AI (M2 Sub-PR D)
+
+`AIPattern.PhaseBased` en `EnemyDefinition`. `SelectEnemyMove()` filtra moves por
+`MinHpPercent`/`MaxHpPercent` del HP actual del enemigo; si ningún rango cubre,
+usa todos los moves como fallback.
+
+#### Sistema de Retazos (M3)
+
+`RelicHookDispatcher` — bus pub/sub instanciado en `RunSession.Awake` (persiste
+con el run). `TurnManager` lo invoca en 9 eventos:
+
+| Hook | Cuándo se dispara |
+|------|-------------------|
+| `OnCombatStart` | Tras `ConfigureCombat`, antes del primer turno |
+| `OnPlayerTurnStart` | Al inicio de cada turno del jugador |
+| `OnCardPlayed` | Dentro de `ResolvePreparedCardPlay`, tras `ProcessAll` |
+| `OnDamageDealt` | Daño jugador→enemigo (incluye cartas neutras: 8º dispatch) |
+| `OnDamageTaken` | Daño enemigo→jugador |
+| `OnWorldSwitch` | Al cambiar de mundo (incluye cambios por Contador de Estilo) |
+| `OnCombatEnd` | Tras sincronizar RunState, antes de pasar a BattleFlowController |
+| `OnCampfireOptionsBuilt` | Al abrir la Hoguera (payload con Options mutable) |
+| `OnShopStockBuilt` | Al armar el stock de la Tienda (payload con Stock mutable) |
+
+`RelicHookContext` expone 7 métodos seguros: `GrantBlock`, `GrantHeal`,
+`GrantDrawCards`, `GrantEnergy`, `GrantStyleCharge`, `GrantBonusWorldSwitch`,
+`EnqueueExtraDamage`. Guards de `IsCombatFinished` protegen los métodos que
+encolan acciones.
+
+> **Nota de orden:** `OnPlayerTurnStart` se dispara ANTES que `OnCombatStart`
+> cuando un Retazo reacciona al inicio del primer turno — footgun documentado
+> para autores de Retazos futuros.
+
+---
 
 ### Where to look (rutas)
-- Turnos / cambio de mundo / momentum / efectividad:
-  - `Assets/Scripts/Gameplay/Combat/TurnManager.cs`
-- HUD, popups WEAK/RESIST/MOMENTUM, botón Change World:
-  - `Assets/Scripts/Gameplay/Combat/CombatUIController.cs`
-- Cola de acciones y tipos de acciones:
-  - `Assets/Scripts/Gameplay/Combat/ActionQueue.cs`
-  - `Assets/Scripts/Gameplay/Combat/Actions/*`
-- Tipos y tabla de efectividad:
-  - `Assets/Scripts/Gameplay/Combat/ElementTypes.cs`
-- Datos de cartas:
-  - `Assets/Scripts/Gameplay/Cards/CardDefinition.cs`
-  - `Assets/Scripts/Gameplay/Cards/DualCardDefinition.cs`
-  - `Assets/Scripts/Gameplay/Cards/CardDeckEntry.cs`
-- Datos de enemigos:
-  - `Assets/Scripts/Gameplay/Enemies/EnemyDefinition.cs`
-  - `Assets/Scripts/Gameplay/Enemies/EnemyMove.cs`
 
-### Notas de diseño
-- ElementType por color es placeholder; se renombrará a tipos finales más adelante.
-- “Momentum” es el nombre visible; internamente se usa contador de free plays (`FreePlays`).
-- Cambio de mundo: 1 uso por combate; flag de debug permite ilimitado.
-- UI se construye en runtime por `CombatUIController`; sprites de avatares se configuran vía inspector/captura inicial.
+| Qué necesitás | Dónde mirar |
+|---------------|-------------|
+| Turnos, cambio de mundo, Contador de Estilo, efectividad, IA | `Assets/Scripts/Gameplay/Combat/TurnManager.cs` |
+| HUD (energía, Estilo, HP, bloqueo, intent, tipo, mundo) | `Assets/Scripts/Gameplay/Combat/CombatHudView.cs` |
+| Popups WEAK/RESIST/+ESTILO, shake, victory/defeat | `Assets/Scripts/Gameplay/Combat/CombatFeedbackView.cs` |
+| Mano de cartas, click → jugar | `Assets/Scripts/Gameplay/Combat/CardHandView.cs` |
+| Fondos A/B por mundo, CoverFill | `Assets/Scripts/Gameplay/Combat/CombatBackgroundView.cs` |
+| Cola de acciones y tipos de acciones | `Assets/Scripts/Gameplay/Combat/ActionQueue.cs` |
+| | `Assets/Scripts/Gameplay/Combat/Actions/` |
+| Tipos y tabla de efectividad | `Assets/Scripts/Gameplay/Combat/ElementTypes.cs` |
+| Colores por tipo (tinte UI) | `Assets/Scripts/Gameplay/Combat/ElementTypeColors.cs` |
+| Datos de cartas | `Assets/Scripts/Gameplay/Cards/CardDefinition.cs` |
+| | `Assets/Scripts/Gameplay/Cards/DualCardDefinition.cs` |
+| | `Assets/Scripts/Gameplay/Cards/CardDeckEntry.cs` |
+| Datos de enemigos (SO, moves, AIPattern) | `Assets/Scripts/Gameplay/Enemies/EnemyDefinition.cs` |
+| | `Assets/Scripts/Gameplay/Enemies/EnemyMove.cs` |
+| Sistema de Retazos (hooks, dispatcher, contexto) | `Assets/Scripts/Gameplay/Relics/` |
+| Flujo del run, nodos, tienda, hoguera | `Assets/Scripts/Run/RunFlowController.cs` |
+| Estado del run (mazo, HP, gold, Retazos) | `Assets/Scripts/Run/RunState.cs` |
+| Flujo de BattleScene, drops, ReportOutcome | `Assets/Scripts/Run/BattleFlowController.cs` |
 
-### CombatUIController — Plan de descomposicion
+---
 
-`CombatUIController.cs` es un monolito de 1400+ lineas con 5 responsabilidades mezcladas.
-Se descompone incrementalmente en componentes independientes, cada uno un MonoBehaviour
-que se suscribe a eventos de TurnManager y recibe referencias de UI necesarias.
+### Componentes de UI de combate
 
-**Acoplamiento clave**: BattleFlowController NO referencia CombatUIController. Ambos
-se conectan a TurnManager de forma independiente. Esto permite extraer componentes
-sin tocar BattleFlowController.
+`CombatUIController` es el orquestador de BuildUI + lifecycle (~710 LOC). La
+presentación se distribuye en 4 componentes independientes extraídos:
 
-#### Componentes objetivo (en orden de extraccion)
+| Componente | Responsabilidad | Estado |
+|---|---|---|
+| `CombatFeedbackView` | Popups WEAK/RESIST/+ESTILO, shake de enemigo, texto victory/defeat, flash de panel, toast de mano llena | ✓ Fase 1 |
+| `CardHandView` | Botones de carta, click → TryPrepare/Resolve, animación de ataque, layout adaptivo, fade-in escalonado | ✓ Fase 2 |
+| `CombatHudView` | Textos de energía/Estilo/HP/bloqueo/intent/mundo/tipo, botones End Turn / Change World, highlight de avatares | ✓ Fase 3 |
+| `CombatBackgroundView` | Fondos sky/ground por mundo A/B, CoverFill, polling autónomo de `CurrentWorld` | ✓ Fase 4 |
 
-| Componente | Responsabilidad | Dependencias | Estado |
-|------------|----------------|--------------|--------|
-| `CombatFeedbackView` | Popups WEAK/RESIST/MOMENTUM, enemy shake, victory/defeat text, hand limit toast, panel flash | TurnManager events, UIAnimationHelper, AudioManager | **Fase 1** |
-| `CardHandView` | Mano de cartas, CardButtonBinding, sync, layout adaptivo, click → TurnManager | TurnManager (card play API), UI builders | Fase 2 |
-| `CombatHudView` | Paneles de HP, energia, momentum, mundo, block overlays, intents | TurnManager (read state), UI builders | Fase 3 |
-| `CombatBackgroundView` | Fondos sky/ground por mundo, CoverFill, sprites A/B | TurnManager.CurrentWorld | Fase 4 |
+**Patrón de integración:** cada componente vive como MonoBehaviour en el mismo
+GameObject que CombatUIController (o hijo directo). Recibe referencias de UI
+vía `Initialize()` después de `BuildUI()`. Se suscribe/desuscribe a eventos de
+TurnManager en `OnEnable`/`OnDisable`. Es solo presentación — nunca muta gameplay state.
 
-#### Patron de integracion
-
-Cada componente extraido:
-1. Vive en el mismo GameObject que CombatUIController (o hijo directo).
-2. Se suscribe a TurnManager events en OnEnable/OnDisable.
-3. Recibe referencias de UI via campos internos (no SerializeField).
-4. CombatUIController le pasa las referencias despues de BuildUI() via metodo `Initialize()`.
-5. Es **solo presentacion** — nunca muta estado de gameplay.
-
-#### Reglas de extraccion
-
-- Cada fase es un commit/PR independiente.
-- Despues de cada fase: zero console errors + gameplay funcional = criterio de aceptacion.
-- CombatUIController se adelgaza pero sigue siendo el orquestador de BuildUI().
-- Los UI builder helpers (CreatePanel, CreateText, etc.) permanecen en CombatUIController
-  hasta que se extraigan todos los componentes; luego se mueven a un utility compartido.
+---
 
 ### Troubleshooting
-- No aparecen tests en Test Runner:
-  - Verifica asmdefs: runtime (`Assets/Scripts/RoguelikeCardBattler.asmdef`) y tests (`Assets/Tests/EditMode/EditModeTests.asmdef`). Usa pestaña EditMode en `Window > General > Test Runner`.
-- Sprites/avatares no se ven:
-  - `CombatUIController` reconstruye la UI; asigna sprites en inspector y se capturan al iniciar. Revisa que haya sprite asignado en PlayerAvatar/EnemyAvatar o en los campos del controller.
-- No sale WEAK/RESIST/MOMENTUM +1:
-  - Evento `PlayerHitEffectiveness` se emite en `TurnManager.AdjustDamageForEffectiveness`; asegúrate de tener tipos asignados en carta y enemigo, y que el golpe sea SuperEficaz/PocoEficaz.
 
+- **No aparecen tests en Test Runner:**
+  - Verificá asmdefs: runtime (`Assets/Scripts/RoguelikeCardBattler.asmdef`) y
+    tests (`Assets/Tests/EditMode/EditModeTests.asmdef`). Usá pestaña EditMode en
+    `Window > General > Test Runner`.
+- **Sprites/avatares no se ven:**
+  - `CombatUIController` reconstruye la UI; asigná sprites en el inspector y se
+    capturan al iniciar. Revisá campos `PlayerAvatar`/`EnemyAvatar`.
+- **No sale WEAK/RESIST/+ESTILO:**
+  - `PlayerHitEffectiveness` se emite en `TurnManager.AdjustDamageForEffectiveness`;
+    asegurate de tener tipos asignados en carta y enemigo, y que el golpe sea
+    SuperEficaz/PocoEficaz (None/None es Neutro, sin popup).
+- **Retazo de curación no aplica al final del combate:**
+  - Verificar que el Retazo mute `RunState.PlayerCurrentHP` directamente en
+    OnCombatEnd (patrón correcto). `GrantHeal` en OnCombatEnd es no-op porque
+    `IsCombatFinished == true` cuando dispara el hook.
+
+---
+
+### Notas de diseño
+
+- ElementType por color es placeholder; se renombrará a tipos finales más adelante.
+- **Contador de Estilo** es el nombre del sistema (HUD: "Estilo: X/5"). Momentum y
+  FreePlays fueron eliminados completamente en M2 (PR #89).
+- Cambio de mundo: 1 uso por combate (configurable, debug ilimitado); el Contador de
+  Estilo puede otorgar 1 uso extra al llegar a 5 cargas.
+- UI se construye en runtime por `CombatUIController`; no hay prefabs de Canvas.

--- a/Docs/dev/DEV_ONBOARDING.md
+++ b/Docs/dev/DEV_ONBOARDING.md
@@ -1,63 +1,127 @@
 ## Onboarding dev
 
+> **Última actualización:** 2026-06-15 (SUB-PR 3 auditoría pre-M4 — paquete docs i).
+> Actualizado con HUD real (Estilo, no Momentum), 5 slash commands, y Run layer post-M3.
+
+---
+
 ### Requisitos y setup
-- Ver versión de Unity: abre `ProjectSettings/ProjectVersion.txt` (línea `m_EditorVersion`).
-- Abrir el proyecto en Unity (hub o abrir carpeta raíz).
-- Paquetes: Test Framework ya está en `Packages/manifest.json` (com.unity.test-framework).
+
+- Ver versión de Unity: abrí `ProjectSettings/ProjectVersion.txt` (línea `m_EditorVersion`). Versión actual: **6000.2.14f1** (Unity 6.2).
+- Abrí el proyecto en Unity Hub o desde la carpeta raíz.
+- Paquetes: Test Framework ya está en `Packages/manifest.json` (`com.unity.test-framework`).
+
+---
 
 ### Correr el juego rápido
-- Escena: `Assets/Scenes/BattleScene.unity`.
-- En Play deberías ver HUD con Energy, Momentum, World y Switches; mano de cartas y un enemigo.
-- Prueba rápida de tipos:
-  - Carta: `Assets/ScriptableObjects/Cards/StrikeBasic.asset` → asigna `Element Type` (p. ej. Rojo).
-  - Enemigo: `Assets/ScriptableObjects/Enemies/WeakSlime.asset` → asigna `Element Type` (p. ej. Azul).
-  - En combate: Rojo vs Azul muestra “WEAK!” y “MOMENTUM +1”; Azul vs Rojo muestra “RESIST”.
+
+**Escena de combate:** `Assets/Scenes/BattleScene.unity`.
+
+En Play deberías ver:
+- HUD con **Energía: X**, **Estilo: X/5** (Contador de Estilo), **Mundo: A/B**, **Switches: X** (cambios disponibles).
+- Mano de cartas (hasta 5), botones **End Turn** y **Cambiar Mundo**.
+- Avatar y HP/bloqueo del jugador y del enemigo.
+- Intent del enemigo (qué va a hacer en el próximo turno).
+
+**Prueba rápida de tipos:**
+- Carta: `Assets/ScriptableObjects/Cards/StrikeBasic.asset` → asigná `Element Type` (p. ej. Rojo).
+- Enemigo: `Assets/ScriptableObjects/Enemies/WeakSlime.asset` → asigná `Element Type` (p. ej. Azul).
+- En combate: Rojo vs Azul → popup `WEAK!` (SuperEficaz, daño ×1.5) + si se ganó carga de Estilo: `WEAK!\n+ESTILO`. Azul vs Rojo → `RESIST` (PocoEficaz).
+- Cartas sin tipo (`None`) → daño al 90% sin popup.
+
+**Escena del run completo:** `Assets/Scenes/RunScene.unity`.
+
+La run completa va: `MainMenuScene` → `NewRunScene` (elegir 2 tipos, draftear carta dual) → `RunScene` (mapa horizontal con nodos: combate, hoguera, tienda, evento) → `BattleScene` → de vuelta a `RunScene`.
+
+---
 
 ### Correr tests
+
 - Unity: `Window > General > Test Runner` → pestaña `EditMode` → `Run All`.
 - CLI (opcional): `unity -runTests -projectPath . -testPlatform editmode -testResults results.xml`.
+- Suite actual: **148/148** (al 2026-06-14, 17 archivos de test en `Assets/Tests/EditMode/`).
 - Asmdefs:
   - Runtime: `Assets/Scripts/RoguelikeCardBattler.asmdef`.
   - Tests: `Assets/Tests/EditMode/EditModeTests.asmdef` (referencia al runtime).
-  - Separación para no arrastrar dependencias de tests al runtime.
+
+---
 
 ### Workflow Git
-- Ramas: `feat/*` para features, `docs/*` para documentación, `chore/*` para tareas misceláneas.
+
+- Ramas: `feat/*` (features), `docs/*` (documentación), `chore/*` (misc), `refactor/*` (refactor).
 - PRs: incluir `Closes #<issue>` para autocerrar el issue.
 
-### Dónde mirar primero (archivos clave)
-- `Assets/Scripts/Gameplay/Combat/TurnManager.cs`: orquesta turnos, jugar cartas, cambiar mundo, momentum.
-- `Assets/Scripts/Gameplay/Combat/CombatUIController.cs`: HUD, botones, popups WEAK/RESIST/MOMENTUM.
-- `Assets/Scripts/Gameplay/Combat/ActionQueue.cs`: cola FIFO de acciones.
-- `Assets/Scripts/Gameplay/Combat/ElementTypes.cs`: enum de tipos y matriz de efectividad.
-- `Assets/Scripts/Gameplay/Cards/CardDefinition.cs`: datos de cartas, tipo incluido.
-- `Assets/Scripts/Gameplay/Enemies/EnemyDefinition.cs`: datos de enemigo, tipo incluido.
+---
+
+### Dónde mirar primero
+
+#### Combate (BattleScene)
+
+| Qué | Dónde |
+|-----|-------|
+| Orquestación de turnos, Contador de Estilo, efectividad, IA | `Assets/Scripts/Gameplay/Combat/TurnManager.cs` |
+| Flujo de BattleScene (inicializa, detecta victoria/derrota, drops) | `Assets/Scripts/Run/BattleFlowController.cs` |
+| HUD: Estilo, HP, bloqueo, intent, tipo, mundo | `Assets/Scripts/Gameplay/Combat/CombatHudView.cs` |
+| Popups WEAK/RESIST/+ESTILO, shake, toast de mano llena | `Assets/Scripts/Gameplay/Combat/CombatFeedbackView.cs` |
+| Mano de cartas, click → jugar | `Assets/Scripts/Gameplay/Combat/CardHandView.cs` |
+| Cola FIFO de acciones (determinista) | `Assets/Scripts/Gameplay/Combat/ActionQueue.cs` |
+| Tipos elementales y tabla de efectividad | `Assets/Scripts/Gameplay/Combat/ElementTypes.cs` |
+
+#### Run layer (RunScene + estado entre escenas)
+
+| Qué | Dónde |
+|-----|-------|
+| Estado del run (mazo, HP, gold, Retazos, flags) | `Assets/Scripts/Run/RunState.cs` |
+| DontDestroyOnLoad de gameplay, owner del dispatcher de Retazos | `Assets/Scripts/Run/RunSession.cs` |
+| Mapa horizontal, nodos, tienda, hoguera, transiciones | `Assets/Scripts/Run/RunFlowController.cs` |
+| Pantalla de arranque de run (elegir tipos + draftear carta dual) | `Assets/Scripts/Run/NewRun/NewRunController.cs` |
+| Stock de la Tienda (lógica pura testeable) | `Assets/Scripts/Run/Shop/ShopNodeController.cs` |
+| Opciones de la Hoguera (heal/upgrade) | `Assets/Scripts/Run/Campfire/CampfireNodeController.cs` |
+| Generador de mapa del run | `Assets/Scripts/Run/Map/RunMapGenerator.cs` |
+
+#### Cartas y Retazos
+
+| Qué | Dónde |
+|-----|-------|
+| Datos de carta (coste, efectos, tipo, arte, upgrade) | `Assets/Scripts/Gameplay/Cards/CardDefinition.cs` |
+| Carta dual (cara A/B según mundo) | `Assets/Scripts/Gameplay/Cards/DualCardDefinition.cs` |
+| Sistema de Retazos (hooks, bus, contexto) | `Assets/Scripts/Gameplay/Relics/` |
+
+---
 
 ### Tooling Claude Code + Unity
 
 El proyecto está configurado para trabajar con Claude Code conectado a Unity.
-Esto es lo mínimo que necesitas saber para que funcione; los **hábitos** de uso
-(prompting, ahorro de tokens, memoria persistente) viven en
+Los **hábitos** de uso (prompting, ahorro de tokens, memoria persistente) viven en
 `Docs/dev/CLAUDE_WORKFLOW_GUIDE.md`.
 
 - **MCP de Unity** — servidor `ai-game-developer` (IvanMurzak), en modo **local**
-  (sin login ni token). Da ~73 tools para leer la consola, inspeccionar
+  (sin login ni token). Da ~75+ tools para leer la consola, inspeccionar
   escenas/GameObjects, correr tests NUnit y tomar screenshots desde el Editor.
+  Usá `unity-tool-list` para ver el listado completo actualizado.
   Requiere Unity abierto con el plugin conectado (Connected verde). Si al reabrir
-  Unity cambia el puerto, actualiza la URL en `.mcp.json` (por defecto
+  Unity cambia el puerto, actualizá la URL en `.mcp.json` (por defecto
   `http://localhost:24348`).
 - **Permisos** — `.claude/settings.json` es **compartido** (commiteado, lo lee el
   otro dev); `.claude/settings.local.json` es **personal** (gitignored, para tus
   rutas absolutas y reglas propias). Precedencia: `deny > ask > allow`.
-- **Hook protect-files** — `.claude/hooks/protect-files.js` bloquea Edit/Write
-  sobre los 6 archivos protegidos (los 3 de combate: `TurnManager.cs`,
-  `ActionQueue.cs`, `PlayerCombatActor.cs`, más `GOLDEN_RULES.md`, `_gdd.md` y
-  `DESIGN_DECISIONS.md`). Para una edición autorizada, comenta el hook en
-  `settings.json` o edita a mano.
-- **Slash commands `/modo-*`** — `.claude/commands/modo-*.md` activan los 4 modos
-  (`/modo-gdd`, `/modo-diseno`, `/modo-implementacion`, `/modo-revision`). Cada
-  uno carga solo el ritual de lectura de ese modo, no todo `Docs/`.
+- **Hook protect-files** — `.claude/hooks/protect-files.js` bloquea ediciones sobre
+  los archivos protegidos por dos superficies: (1) `Edit/Write/MultiEdit/NotebookEdit`
+  por `file_path`, y (2) `Bash` con los comandos del plugin Unity-MCP
+  (`script-update-or-create`/`script-delete`) que editan `.cs` en disco.
+  Protege 7 archivos: 3 de combate (`TurnManager.cs`, `ActionQueue.cs`,
+  `PlayerCombatActor.cs`) + `GOLDEN_RULES.md` + `_gdd.md` + `DESIGN_DECISIONS.md`
+  + el propio hook. Para una edición autorizada, comentá el hook en `settings.json`
+  o editá a mano.
+- **Slash commands** — invocados con `/nombre` en Claude Code:
+  - `/modo-gdd` — procesa el GDD, mapea gaps vs código, genera milestones.
+  - `/modo-diseno` — convierte una feature en spec técnico implementable.
+  - `/modo-implementacion` — escribe, modifica y debuggea código.
+  - `/modo-revision` — audita cambios contra spec, golden rules y arquitectura.
+  - `/cierre-sesion` — checklist completo de persistencia: checkboxes de sub-tareas,
+    anti-desfase de milestones futuros, tech_snapshot, memoria, higiene de milestone.
+    Invocarlo al terminar cualquier bloque de trabajo para que la próxima sesión
+    arranque con contexto fresco.
 
 **Para hábitos de prompting, ahorro de tokens y memoria persistente →
 `Docs/dev/CLAUDE_WORKFLOW_GUIDE.md`.**
-

--- a/Docs/dev/GLOSSARY.md
+++ b/Docs/dev/GLOSSARY.md
@@ -1,26 +1,77 @@
 ## Glossary (dev)
 
-Formato: término, definición breve, y si aplica “Dónde se ve” (UI) / “Dónde vive” (archivo).
+> **Última actualización:** 2026-06-15 (SUB-PR 3 auditoría pre-M4 — paquete docs i).
+> Purga de entradas de Momentum/FreePlays (eliminados en M2, PR #89).
+> Agregados términos M2/M3.
 
-- ActionQueue: cola FIFO que ejecuta acciones de combate en orden. Vive en `Assets/Scripts/Gameplay/Combat/ActionQueue.cs`.
-- asmdef (runtime): define el ensamblado de scripts del juego (`Assets/Scripts/RoguelikeCardBattler.asmdef`).
-- asmdef (tests): define el ensamblado de pruebas EditMode (`Assets/Tests/EditMode/EditModeTests.asmdef`); referencia al runtime.
-- CardDeckEntry: entrada de mazo/mano que puede contener carta simple o dual. Vive en `Assets/Scripts/Gameplay/Cards/CardDeckEntry.cs`.
-- CardDefinition: ScriptableObject con datos de una carta (coste, efectos, tipo elemental). Vive en `Assets/Scripts/Gameplay/Cards/CardDefinition.cs`. Se ve en UI de mano.
-- Change World: acción que alterna WorldSide A/B. Limitada a 1 por combate salvo debug ilimitado. Botón en HUD.
-- CombatUIController: construye HUD en runtime (energía, momentum, mundo, switches, popups WEAK/RESIST). Vive en `Assets/Scripts/Gameplay/Combat/CombatUIController.cs`.
-- DualCardDefinition: carta con dos lados (A/B) dependiente del WorldSide actual. Vive en `Assets/Scripts/Gameplay/Cards/DualCardDefinition.cs`.
-- Effectiveness: resultado de comparar ElementType atacante vs defensor (SuperEficaz, Neutro, PocoEficaz). Lógica en `Assets/Scripts/Gameplay/Combat/ElementTypes.cs`. UI muestra popups WEAK/RESIST.
-- ElementType: enum placeholder por color (Rojo, Amarillo, Azul, Morado, Negro, Blanco, None). Vive en `Assets/Scripts/Gameplay/Combat/ElementTypes.cs`.
-- EnemyDefinition: ScriptableObject de enemigo (HP, patrón AI, moves, tipo elemental). Vive en `Assets/Scripts/Gameplay/Enemies/EnemyDefinition.cs`.
-- EnemyMove: entrada de IA con efectos, peso/orden y tipo de intent. Vive en `Assets/Scripts/Gameplay/Enemies/EnemyMove.cs`. Se refleja en intent UI.
-- FreePlays: contador interno de Momentum; al consumirlo, la siguiente carta no gasta energía. Variable interna en `TurnManager`.
-- IGameAction: interfaz mínima para acciones en la ActionQueue (daño, block, draw). Vive en `Assets/Scripts/Gameplay/Combat/IGameAction.cs`.
-- Momentum: nombre visible del recurso de “free play” que se gana al golpear debilidad (SuperEficaz). HUD muestra “Momentum: X”; popup “MOMENTUM +1”.
-- Placeholder: marcadores temporales (p. ej. nombres de tipos por color) que se reemplazarán más adelante; se debe documentar cuando se use.
-- Test Runner / EditMode tests: ventana Unity `Window > General > Test Runner`, pestaña EditMode; pruebas viven en `Assets/Tests/EditMode/`.
-- TurnManager: orquesta el flujo de combate (turnos, jugar cartas, cambio de mundo, momentum, efectividad). Vive en `Assets/Scripts/Gameplay/Combat/TurnManager.cs`.
-- WEAK / RESIST: popups de feedback de efectividad; WEAK cuando es SuperEficaz, RESIST cuando es PocoEficaz. Mostrados por `CombatUIController` a partir del evento de hit.
-- World / WorldSide (A/B): estado binario del combate (mundo actual). Afecta cartas duales; cambio limitado según reglas. Guardado en `TurnManager`.
-- maxWorldSwitchesPerCombat / worldSwitchesUsed / debugUnlimitedWorldSwitches: config y contadores para Change World (límite por combate, usos actuales, flag de debug ilimitado). Viven en `TurnManager` y se muestran en HUD (Switches).
+Formato: término, definición breve, y si aplica "Dónde se ve" (UI) / "Dónde vive" (archivo).
 
+---
+
+- **ActionQueue:** cola FIFO que ejecuta acciones de combate en orden determinista. `ProcessAll()` es síncrono. Vive en `Assets/Scripts/Gameplay/Combat/ActionQueue.cs`.
+
+- **AIPattern:** enum de patrones de IA enemiga: `RandomWeighted` (peso aleatorio), `Sequence` (orden fijo), `PhaseBased` (filtra moves por rango de HP `MinHpPercent`/`MaxHpPercent`). Configurado en `EnemyDefinition`. Vive en `Assets/Scripts/Gameplay/Enemies/EnemyEnums.cs`.
+
+- **asmdef (runtime):** define el ensamblado de scripts del juego (`Assets/Scripts/RoguelikeCardBattler.asmdef`).
+
+- **asmdef (tests):** define el ensamblado de pruebas EditMode (`Assets/Tests/EditMode/EditModeTests.asmdef`); referencia al runtime.
+
+- **BattleFlowController:** orquesta el flujo de BattleScene: inicializa el combate desde `RunSession`, detecta victoria/derrota, aplica drops de Retazos y navega a RunScene. Vive en `Assets/Scripts/Run/BattleFlowController.cs`.
+
+- **CardDeckEntry:** entrada de mazo/mano que puede contener carta simple o dual. Expone `GetActiveCardDefinition(world)`. Vive en `Assets/Scripts/Gameplay/Cards/CardDeckEntry.cs`.
+
+- **CardDefinition:** ScriptableObject con datos de una carta (coste, efectos, tipo elemental, arte, upgrade). Vive en `Assets/Scripts/Gameplay/Cards/CardDefinition.cs`. Se ve en UI de mano.
+
+- **CardUpgradeDef:** struct embebido en `CardDefinition` con overrides de coste/efectos/nombre/descripción para la versión mejorada. `CanUpgrade()`/`ApplyUpgrade()` en `CardDeckEntry`; `CreateUpgradedClone()` produce un SO runtime. Vive embebido en `CardDefinition`.
+
+- **Change World:** acción que alterna WorldSide A/B. Limitada por combate (configurable, default 1; debug ilimitado). El Contador de Estilo puede otorgar 1 uso extra. Botón "Cambiar Mundo" en el HUD.
+
+- **CombatHudView:** componente UI extraído de `CombatUIController` (Fase 3). Muestra energía, Contador de Estilo, HP/bloqueo jugador+enemigo, intent del enemigo, tipo elemental, mundo, switches. No se suscribe a eventos — hace polling vía `Sync()` cada frame. Vive en `Assets/Scripts/Gameplay/Combat/CombatHudView.cs`.
+
+- **CombatUIController:** orquesta BuildUI + lifecycle del canvas de combate en runtime. Wirear las 4 views extraídas vía `InitializeExtractedViews()`. ~710 LOC. Vive en `Assets/Scripts/Gameplay/Combat/CombatUIController.cs`.
+
+- **Contador de Estilo:** sistema que reemplaza a Momentum (eliminado en M2, PR #89). +1 carga al hacer un golpe SuperEficaz (pre-block); −1 al recibir SuperEficaz del enemigo. 5 cargas → 1 switch de mundo extra (no acumulable), reset de cargas. UI muestra "Estilo: X/5". Popup "+ESTILO" en `CombatFeedbackView`. Variable `_styleCharges` en `TurnManager`.
+
+- **DualCardDefinition:** ScriptableObject con dos `CardDefinition` (sideA/sideB) correspondientes a los mundos A y B. La cara activa depende del WorldSide actual; `GetActiveCardDefinition(world)` via `CardDeckEntry`. Vive en `Assets/Scripts/Gameplay/Cards/DualCardDefinition.cs`.
+
+- **Efectividad (Effectiveness):** resultado de comparar ElementType atacante vs tipo activo del defensor. Tres valores: `SuperEficaz` (×1.5), `Neutro` (×1.0), `PocoEficaz` (×0.75). **Bidireccional desde M2 (DD-018):** aplica al daño del jugador sobre el enemigo Y al daño del enemigo sobre el jugador. Cartas sin tipo (`None`) aplican 90% del daño base sin popup. Lógica en `Assets/Scripts/Gameplay/Combat/ElementTypes.cs`. UI: popups WEAK/RESIST/+ESTILO.
+
+- **ElementType:** enum placeholder por color (Rojo, Amarillo, Azul, Morado, Negro, Blanco, None). Vive en `Assets/Scripts/Gameplay/Combat/ElementTypes.cs`.
+
+- **ElementTypeColors:** clase estática con la fuente única de verdad `ElementType→Color`. API: `For(type)`, `ReadableOnDark(type)`, `ReadableTextOn(bg)`, `Dim(color,factor)`, `TypePrefix(type)` (token rich-text `[Tipo]` para UI). Vive en `Assets/Scripts/Gameplay/Combat/ElementTypeColors.cs`.
+
+- **EnemyDefinition:** ScriptableObject de enemigo (HP, AIPattern, moves, tipo elemental, avatar sprite). Vive en `Assets/Scripts/Gameplay/Enemies/EnemyDefinition.cs`.
+
+- **EnemyMove:** entrada de IA con efectos, peso/orden, tipo de intent y rango de HP (para PhaseBased). Vive en `Assets/Scripts/Gameplay/Enemies/EnemyMove.cs`. Se refleja en el intent UI.
+
+- **HealAction:** acción (`IGameAction`) que cura a un actor. Producida por `EffectType.Heal` en `TurnManager.CreateAction()`. Funciona en jugador y enemigo. Implementada en M2 Sub-PR D. Vive en `Assets/Scripts/Gameplay/Combat/Actions/`.
+
+- **IGameAction:** interfaz mínima para acciones en la ActionQueue (DamageAction, BlockAction, DrawCardsAction, HealAction). Vive en `Assets/Scripts/Gameplay/Combat/IGameAction.cs`.
+
+- **OnCombatEnd / OnCombatStart / OnDamageDealt / … :** hooks del `RelicHook` enum. Invocan a los `IRelicEffect` de los Retazos activos a través del `RelicHookDispatcher`. Ver tabla completa en `COMBAT_ARCHITECTURE.md §Sistema de Retazos`.
+
+- **Placeholder:** marcadores temporales (p. ej. nombres de tipos por color, sprites de arte) que se reemplazarán más adelante; documentar cuando se use.
+
+- **RelicHookDispatcher:** bus pub/sub que `TurnManager` invoca en 9 eventos clave. Instanciado en `RunSession.Awake`, persiste con la run. Vive en `Assets/Scripts/Gameplay/Relics/RelicHookDispatcher.cs`.
+
+- **RelicHookContext:** payload de contexto para cada dispatch. Expone 7 métodos seguros: `GrantBlock`, `GrantHeal`, `GrantDrawCards`, `GrantEnergy`, `GrantStyleCharge`, `GrantBonusWorldSwitch`, `EnqueueExtraDamage`. Guards de `IsCombatFinished` protegen los que encolan acciones. Vive en `Assets/Scripts/Gameplay/Relics/Hooks/RelicHookContext.cs`.
+
+- **RelicInstance:** wrapper runtime de un Retazo (AcquisitionOrder + Counters). No es el SO — es la instancia viva durante el run. Vive en `Assets/Scripts/Gameplay/Relics/RelicInstance.cs`.
+
+- **Retazo / Retazos:** items persistentes del run (equiv. a Relics en Slay the Spire). Adquiridos en combates Elite/Boss o en la Tienda. Efectos cableados a hooks del combate y nodos. Inventario visible en HUD de combate y mapa. `RunState.Relics: List<RelicInstance>`.
+
+- **RunFlowController:** orquesta RunScene: mapa, nodos, transiciones (Hoguera/Tienda/Combate/Evento), instancia `RelicInventoryView` en el HUD del mapa. 885 LOC (god-object pendiente de desguace antes de M4-4b). Vive en `Assets/Scripts/Run/RunFlowController.cs`.
+
+- **RunSession:** único DontDestroyOnLoad de gameplay. Owner del `RelicHookDispatcher` (instanciado en Awake; persiste con la run, sobrevive a `State.Reset`). Comunica datos entre escenas vía `RunState`. Vive en `Assets/Scripts/Run/RunSession.cs`.
+
+- **RunState:** datos del run (mazo, HP, gold, Retazos, nodos, flags de flujo). Fuente única de verdad entre escenas. Vive en `Assets/Scripts/Run/RunState.cs`.
+
+- **Test Runner / EditMode tests:** ventana Unity `Window > General > Test Runner`, pestaña EditMode. Tests en `Assets/Tests/EditMode/`. Suite: 148/148 (al 2026-06-14).
+
+- **TurnManager:** orquesta el flujo de combate (turnos, jugar cartas, cambio de mundo, Contador de Estilo, efectividad, IA enemiga, hooks de Retazos). Archivo protegido. Vive en `Assets/Scripts/Gameplay/Combat/TurnManager.cs`.
+
+- **WEAK / RESIST / +ESTILO:** popups de feedback de efectividad y Estilo. WEAK = golpe SuperEficaz; RESIST = golpe PocoEficaz; +ESTILO = carga de Estilo ganada (se combina con WEAK: "WEAK!\n+ESTILO"). Mostrados por `CombatFeedbackView` a partir del evento `PlayerHitEffectiveness`.
+
+- **World / WorldSide (A/B):** estado binario del combate (mundo actual). Afecta cartas duales y el tipo elemental activo del jugador. Cambio limitado por combate según reglas. Guardado en `TurnManager.currentWorld`.
+
+- **WorldSwitch count / Estilo bonus:** `_worldSwitchesUsed` (usos totales) y `_bonusWorldSwitches` (extra por Contador de Estilo, máx 1 sin acumular). Ambos en `TurnManager`. HUD muestra los switches restantes.

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -10,7 +10,13 @@
 > **Fase actual:** M4 activo, reordenado 2026-06-10. Próximo paso: pulido pre-M4 (visor de mazo).
 > **Milestone activo:** M4 — Resto del Acto 1 (bloques: 4a integridad de cartas, 4b eventos+quests, 4c transdim+ancla)
 > **Próximo bloque:** M5 — Bosses con fases + Boss Acto 1 según GDD v2
-> **Última actualización:** 2026-06-15 (`modo:implementacion` + follow-up revisión:
+> **Última actualización:** 2026-06-15 (`modo:implementacion`: **SUB-PR 3 CERRADO** —
+> docs paquete (i) Momentum → Estilo. Cierra D1/D2/D3/B11/T2/T6. `COMBAT_ARCHITECTURE.md`
+> reescrito con Contador de Estilo + subsistemas M2/M3 + pipeline fin-de-combate.
+> `GLOSSARY.md` purgado y ampliado con términos M2/M3. `DEV_ONBOARDING.md` con HUD
+> real, 5 commands y tabla Run layer. `CLAUDE_WORKFLOW_GUIDE.md §4` conteo tools + /cierre-sesion.
+> Detalle en `audits/2026-06/PLAN_PRE_M4.md §SUB-PR 3`.)
+> **Previa:** 2026-06-15 (`modo:implementacion` + follow-up revisión:
 > **SUB-PR 6 CERRADO** — tooling hardening T1/T4/T10 (PR #113) + WORKFLOW_GUIDE §4
 > (PR #114) + over-block precision (PR #115). Hook `protect-files.js` con 2 superficies
 > + regex anclada a `run-tool`; `settings.json` consolidado + deny aliases PowerShell

--- a/Docs/dev/audits/2026-06/PLAN_PRE_M4.md
+++ b/Docs/dev/audits/2026-06/PLAN_PRE_M4.md
@@ -119,15 +119,15 @@ aprueba la edición en el hilo principal.
 - **Suplentes si hay apetito:** T8 (`InitializeDeck` ×2), T10 (round-trip de tipos).
 - **Propósito:** estos tests **congelan el comportamiento que la cirugía pre-M5 no debe romper.** Por eso van antes.
 
-### SUB-PR 3 — Docs paquete (i): Momentum → Estilo `docs/momentum-to-style`
+### SUB-PR 3 — Docs paquete (i): Momentum → Estilo `docs/momentum-to-style` ✅ CERRADO 2026-06-15
 
 **Cierra:** D1, D2, D3, B11 + **T2 y T6 de F4** (mismo PR, todos son docs de onboarding/arquitectura).
 **Esfuerzo:** M (reescritura de COMBAT_ARCHITECTURE; S para los demás).
 
-- `COMBAT_ARCHITECTURE.md`: reescribir con Estilo + flujo Prepare/Resolve + subsistemas M2/M3 (hooks, HealAction, PhaseBased, pipeline fin-de-combate).
-- `GLOSSARY.md`: purgar entradas muertas, agregar términos M2/M3.
-- `DEV_ONBOARDING.md`: HUD real, popup real, 5 commands, "Dónde mirar primero" con el Run layer (T2).
-- Unificar conteo de skills a "~75+, ver `unity-tool-list`" (T6); agregar `/cierre-sesion` a WORKFLOW_GUIDE §4.
+- [x] `COMBAT_ARCHITECTURE.md`: reescrito con Contador de Estilo + flujo TryPrepareCardPlay/ResolvePreparedCardPlay + subsistemas M2/M3 (hooks, HealAction, PhaseBased, pipeline fin-de-combate incl. sync Opción B). Diagramas Mermaid actualizados. Where to look ampliado con Run layer y Retazos.
+- [x] `GLOSSARY.md`: purgadas entradas Momentum/FreePlays (sistema muerto), agregados términos M2/M3 (Contador de Estilo, Retazos, RelicHookDispatcher, RelicHookContext, RelicInstance, HealAction, AIPattern, BattleFlowController, RunFlowController, RunSession, RunState, ElementTypeColors, etc.).
+- [x] `DEV_ONBOARDING.md`: HUD real (Estilo, no Momentum), popup real (WEAK/RESIST/+ESTILO), 5 slash commands (incl. /cierre-sesion), "Dónde mirar primero" con tabla Run layer post-M3 (T2). MCP a "~75+ tools".
+- [x] `CLAUDE_WORKFLOW_GUIDE.md §4`: conteo unificado a "~75+, ver unity-tool-list" (T6) + /cierre-sesion agregado a la lista de commands.
 
 ### SUB-PR 4 — Docs paquete (ii): verdad de Retazos `docs/relics-truth`
 


### PR DESCRIPTION
## Summary

Cierra D1, D2, D3, B11, T2, T6 de la auditoría pre-M4 (`PLAN_PRE_M4.md §SUB-PR 3`).
PR de docs puro — no toca código ni archivos protegidos.

- **COMBAT_ARCHITECTURE.md**: reescritura completa. Contador de Estilo (reemplaza Momentum), flujo TryPrepareCardPlay/ResolvePreparedCardPlay, subsistemas M2/M3 (hooks Retazos, HealAction, PhaseBased AI, pipeline fin-de-combate con sync Opción B). Diagramas Mermaid actualizados. Tabla de componentes UI extraídos. Where to look con Run layer y Retazos.
- **GLOSSARY.md**: purgadas entradas Momentum/FreePlays (eliminadas en M2 PR #89). Agregados ~15 términos M2/M3: Contador de Estilo, Retazos, RelicHookDispatcher, RelicHookContext, HealAction, AIPattern, BattleFlowController, RunFlowController, RunSession, RunState, ElementTypeColors, etc.
- **DEV_ONBOARDING.md**: HUD real (Estilo/5), popups reales (WEAK/RESIST/+ESTILO), 5 slash commands incl. `/cierre-sesion`, tabla Run layer post-M3 en "Dónde mirar primero", MCP a ~75+.
- **CLAUDE_WORKFLOW_GUIDE.md §4**: conteo de tools a "~75+, ver unity-tool-list"; `/cierre-sesion` en la lista de commands. Bullet protect-files intacto (ya corregido en PR #114).

## Verificación

- Todas las afirmaciones verificadas contra código real antes de redactarse (regla dura del task).
- Popup `+ESTILO` verificado en `CombatFeedbackView.cs:139`.
- HUD fields `_styleChargesText` verificado en `CombatHudView.cs`.
- TryPrepareCardPlay/ResolvePreparedCardPlay verificado en `TurnManager.cs` y `CardHandView.cs`.
- 5 slash commands verificados en `.claude/commands/`.

## Test plan

- [ ] Leer COMBAT_ARCHITECTURE.md y verificar que no menciona Momentum/FreePlays.
- [ ] Leer GLOSSARY.md y verificar que las entradas Momentum/FreePlays están eliminadas.
- [ ] Leer DEV_ONBOARDING.md y verificar que el HUD dice "Estilo: X/5" y los 5 commands están listados.
- [ ] Leer CLAUDE_WORKFLOW_GUIDE.md §4 y verificar "~75+" y "/cierre-sesion".

🤖 Generated with [Claude Code](https://claude.com/claude-code)