### PR TITLE
docs(relics): verdad de Retazos OnCombatEnd + orden de hooks (SUB-PR 4)

### DIFF
--- a/Docs/design/RELICS.md
+++ b/Docs/design/RELICS.md
@@ -45,9 +45,10 @@ Effect            : IRelicEffect           ← clase concreta con campos seriali
 1. **Cartas neutras y `OnDamageDealt`** — Insight 5: hoy el dispatch de `OnDamageDealt` NO se dispara en el path `attackerType == ElementType.None`. Cualquier Retazo de "Modificador de daño ofensivo" basado en `OnDamageDealt` requiere agregar el 8º punto de inserción en `TurnManager` (ya marcado en roadmap 3B con `[REQUIERE APROBACIÓN]`). Decisión confirmada en Insight 5 = opción A (extender al path None). Sin ese cambio, los Retazos ofensivos serán contraintuitivos al jugar Strike neutro.
 2. **`EnqueueExtraDamage` no re-dispara `OnDamageDealt`** — daño "raw" sin efectividad ni cargas de Estilo. Si querés que el daño extra se beneficie de WEAK/RESIST, mutá `data.Amount` en `OnDamageDealt`; no uses `EnqueueExtraDamage`.
 3. **`GrantEnergy` solo aplica al player** ([IMPL 4] del spec 3A) — no-op silencioso para enemigos.
-4. **`OnCombatEnd` muta `RunState` directamente** ([CERRADO 3]) — para +oro, heal post-combate, etc. NO encolar acciones.
+4. **`OnCombatEnd` muta `RunState` directamente** ([CERRADO 3]) — para +oro, heal post-combate, etc. NO encolar acciones. **Regla de autoría (fijada por el fix de fin-de-combate, SUB-PR 1 / 2026-06-14, Opción B):** `TurnManager.DispatchCombatEnd` sincroniza `RunState.PlayerCurrentHP/MaxHP = _player.*` ANTES de disparar los hooks → en `OnCombatEnd` el `RunState` ya es autoritativo y la mutación directa de `PlayerCurrentHP` es la vía CORRECTA. Los `Grant*` del contexto (`GrantHeal`, `GrantBlock`, …) son **no-op** acá: `_phase` ya es Victory/Defeat → `IsCombatFinished == true` → cada `RelicGrant*` hace early-return. Para heal/escudo post-combate, escribí directo a `RunState`. (Esto INVIERTE la guía vieja D7/D8 que llamaba "patrón roto" a la mutación directa y "vía correcta" a `GrantHeal`.)
 5. **`Counters` los maneja el efecto** — el dispatcher no toca counters. Cada efecto resetea sus claves en el hook que tenga sentido (`OnPlayerTurnStart` para por-turno, `OnCombatEnd` para por-combate).
 6. **Orden por `AcquisitionOrder` ascendente** — relevante para Retazos que se encadenan (ej: "+5 daño" antes que "x2 daño" da resultado distinto al inverso). Sebastián puede usar esto como vector de build.
+7. **Orden de hooks en el arranque de combate** — `OnCombatStart` se dispara DESPUÉS del primer `BeginPlayerTurn` (para que `ClearBlock` no borre el bloque de apertura). Como `OnPlayerTurnStart` se dispara DENTRO de `BeginPlayerTurn`, en el turno 1 el orden real es **`OnPlayerTurnStart` → `OnCombatStart`** (contraintuitivo). Consecuencia para Retazos que resetean counters en `OnCombatStart` e incrementan en `OnPlayerTurnStart`: en el turno 1 el incremento ocurre ANTES del reset, y el reset de `OnCombatStart` los deja en 0 para el turno siguiente. Si un counter necesita estar limpio durante el primer `OnPlayerTurnStart`, inicializalo perezosamente (default 0) en vez de depender del reset de `OnCombatStart`.
 
 ---
 
@@ -214,8 +215,8 @@ Total: 23. Las 30 propuestas que siguen son un menú — Sebastián elige cuále
 
 ### Categoría 5 — Economía / fin de combate (`OnCombatEnd`)
 
-> **Hook:** `OnCombatEnd`. **Payload:** `CombatEndHookData { bool Victory, EnemyDefinition Enemy }`.
-> **Acceso a `RunState` directo** ([CERRADO 3] del spec 3A). Mutación de `Gold`, `PlayerCurrentHP` permitida.
+> **Hook:** `OnCombatEnd`. **Payload:** `CombatEndHookData { bool Victory, EnemyDefinition Enemy, bool IsBoss, bool IsElite }`.
+> **Acceso a `RunState` directo** ([CERRADO 3] del spec 3A). **Mutación directa de `Gold` y `PlayerCurrentHP` es la vía CORRECTA** — bajo el fix Opción B (SUB-PR 1, 2026-06-14) `TurnManager.DispatchCombatEnd` sincroniza `RunState.PlayerCurrentHP/MaxHP = _player.*` ANTES del dispatch, así que `RunState` es autoritativo aquí. `ctx.GrantHeal(...)` y demás `Grant*` son **no-op** en este hook (`IsCombatFinished == true`): usá mutación directa de `RunState`, nunca la API de combate.
 
 **R-END-1 — "Botín extra"**
 - Mecánica: +N oro al ganar cada combate.
@@ -225,7 +226,7 @@ Total: 23. Las 30 propuestas que siguen son un menú — Sebastián elige cuále
 
 **R-END-2 — "Heal post-combate"**
 - Mecánica: heal N HP al ganar cada combate.
-- Implementación: en `OnCombatEnd`, si `data.Victory`, mutación directa `ctx.RunState.PlayerCurrentHP = Mathf.Min(maxHp, current + N)` o usar `ctx.GrantHeal(player, N)` (verificar que el actor siga referenciable post-Victory — `[ABIERTO]`; si no, mutación directa de RunState es la vía segura).
+- Implementación: en `OnCombatEnd`, si `data.Victory`, **mutación directa**: `ctx.RunState.PlayerCurrentHP = Mathf.Min(ctx.RunState.PlayerMaxHP, ctx.RunState.PlayerCurrentHP + N)`. **NO usar `ctx.GrantHeal(player, N)`**: en `OnCombatEnd` es no-op (`IsCombatFinished == true`). El `RunState` ya está sincronizado con el HP real del actor (fix Opción B, SUB-PR 1), así que `PlayerCurrentHP`/`PlayerMaxHP` son los valores correctos para el clamp. `[ABIERTO]` cerrado: la vía es mutación directa, sin ambigüedad.
 - Valor: `[PROPUESTA] N = 4`.
 - Rareza: Común. **Recomendado para pool inicial (slot 13).**
 
@@ -237,7 +238,7 @@ Total: 23. Las 30 propuestas que siguen son un menú — Sebastián elige cuále
 
 **R-END-4 — "Recompensa de purista"**
 - Mecánica: si terminaste el combate con HP completo, +N oro.
-- Implementación: en `OnCombatEnd`, si `data.Victory && ctx.RunState.PlayerCurrentHP == maxHp`, `ctx.RunState.Gold += N`.
+- Implementación: en `OnCombatEnd`, si `data.Victory && ctx.RunState.PlayerCurrentHP == ctx.RunState.PlayerMaxHP`, `ctx.RunState.Gold += N`. El chequeo de HP-lleno funciona porque el fix Opción B (SUB-PR 1) sincroniza `RunState.PlayerCurrentHP/MaxHP` con el actor ANTES del dispatch — sin ese sync, `RunState` tendría el HP pre-combate y el chequeo sería incorrecto.
 - Valor: `[PROPUESTA] N = 8`.
 - Rareza: Raro. Backlog candidato Elite.
 

--- a/Docs/dev/audits/2026-06/PLAN_PRE_M4.md
+++ b/Docs/dev/audits/2026-06/PLAN_PRE_M4.md
@@ -129,23 +129,31 @@ aprueba la edición en el hilo principal.
 - [x] `DEV_ONBOARDING.md`: HUD real (Estilo, no Momentum), popup real (WEAK/RESIST/+ESTILO), 5 slash commands (incl. /cierre-sesion), "Dónde mirar primero" con tabla Run layer post-M3 (T2). MCP a "~75+ tools".
 - [x] `CLAUDE_WORKFLOW_GUIDE.md §4`: conteo unificado a "~75+, ver unity-tool-list" (T6) + /cierre-sesion agregado a la lista de commands.
 
-### SUB-PR 4 — Docs paquete (ii): verdad de Retazos `docs/relics-truth`
+### SUB-PR 4 — Docs paquete (ii): verdad de Retazos `docs/relics-truth` ✅ CERRADO 2026-06-16
 
 **Cierra:** D7, D8, D9, D10.
 **Esfuerzo:** S.
 **Coordina con:** SUB-PR 1 ✅ CERRADO — el fix YA fijó la regla de autoría real (ver abajo).
 **Depende de:** decisión D-A (D9 documenta las consecuencias de la semántica).
 
-- `RELICS.md`: corregir §217-218/228/240 con la regla de autoría **que el SUB-PR 1
-  fijó (Opción B, 2026-06-14)**: bajo este diseño la **mutación directa de
-  `PlayerCurrentHP` en OnCombatEnd ES CORRECTA** — `TurnManager.DispatchCombatEnd`
-  sincroniza `RunState.PlayerCurrentHP/MaxHP = _player.*` ANTES de disparar los hooks,
-  así RunState es autoritativo y `BattleFlowController` ya no pisa. `GrantHeal` sobre
-  el actor en OnCombatEnd **NO es viable** (sería no-op: `IsCombatFinished` ya es `true`).
-  Esto INVIERTE la guía vieja de D7/D8 ("mutación directa = patrón roto, GrantHeal =
-  vía correcta"), que el fix refutó. Agregar la regla de orden de hooks
-  (OnPlayerTurnStart/OnCombatStart).
-- `m3_hooks_spec.md`: corregir [CERRADO 3] y la inconsistencia con su tabla :436; registrar el cierre de [IMPL 1] (8º dispatch de cartas neutras); subsección "Consecuencias de la semántica" tras D-A; arreglar referencias de línea corridas (citar métodos).
+- [x] `RELICS.md`: corregido §Advertencias (punto 4 + nuevo punto 7 de orden de
+  hooks), §Categoría 5 (header `OnCombatEnd`), R-END-2 y R-END-4 con la regla de
+  autoría **que el SUB-PR 1 fijó (Opción B, 2026-06-14)**: bajo este diseño la
+  **mutación directa de `PlayerCurrentHP` en OnCombatEnd ES CORRECTA** —
+  `TurnManager.DispatchCombatEnd` sincroniza `RunState.PlayerCurrentHP/MaxHP =
+  _player.*` ANTES de disparar los hooks (verificado en `TurnManager.cs` líneas
+  746-755), así RunState es autoritativo y `BattleFlowController` ya no pisa.
+  `GrantHeal` sobre el actor en OnCombatEnd **NO es viable** (no-op: `_phase` ya
+  es Victory/Defeat → `IsCombatFinished == true` → `RelicGrantHeal` early-return,
+  verificado líneas 1015-1019). Invierte la guía vieja D7/D8. Agregada la regla de
+  orden de hooks (en turno 1: `OnPlayerTurnStart` → `OnCombatStart`).
+- [x] `m3_hooks_spec.md`: corregido [CERRADO 3] (aclaración Grant* no-op) y la
+  inconsistencia con su tabla :436 (heal por mutación directa, no `GrantHeal`);
+  registrado el cierre de [IMPL 1] (8º dispatch de cartas neutras, verificado
+  líneas 608-620); subsección "Consecuencias de la semántica del Contador de
+  Estilo" tras D-A; referencias de línea corridas reemplazadas por nombres de
+  método (`IncrementStyleCharges`, `ClearBlock`, `RelicEnqueueExtraDamage`,
+  `RelicGrantEnergy`).
 
 ### SUB-PR 5 — Docs paquete (iii): números y estado `docs/numbers-and-state`
 

--- a/Docs/dev/specs/m3_hooks_spec.md
+++ b/Docs/dev/specs/m3_hooks_spec.md
@@ -348,7 +348,7 @@ public class RelicHookDispatcher
 
 | Punto | Hook | Justificación |
 |-------|------|---------------|
-| `InitializeCombat()`, **después de** `BeginPlayerTurn(useStartingHand: true)` (último statement del método) | `OnCombatStart` | Crítico: se inserta DESPUÉS de `BeginPlayerTurn` para evitar que `ClearBlock(_player)` (línea 356 de `TurnManager`) borre el bloque que un Retazo "+4 bloque al iniciar combate" haya otorgado. En el primer turno `ClearBlock` es no-op (block = 0), así que invocar el hook después es semánticamente correcto: el combate ya está inicializado, el primer turno comenzó, y el GrantBlock del Retazo aplica sobre estado limpio. |
+| `InitializeCombat()`, **después de** `BeginPlayerTurn(useStartingHand: true)` (último statement del método) | `OnCombatStart` | Crítico: se inserta DESPUÉS de `BeginPlayerTurn` para evitar que `ClearBlock(_player)` (que corre dentro de `BeginPlayerTurn`) borre el bloque que un Retazo "+4 bloque al iniciar combate" haya otorgado. En el primer turno `ClearBlock` es no-op (block = 0), así que invocar el hook después es semánticamente correcto: el combate ya está inicializado, el primer turno comenzó, y el GrantBlock del Retazo aplica sobre estado limpio. |
 | `BeginPlayerTurn()`, después de `ClearBlock(_player)` y **antes de** `_player.DrawCards(...)` | `OnPlayerTurnStart` | Permite Retazos que modifican draw size, energía extra, etc. |
 | `ApplyPlayerToEnemyEffectiveness()`, después de calcular `finalAmount` y **antes de** `PlayerHitEffectiveness?.Invoke(...)` | `OnDamageDealt` | El daño post-efectividad es el que el jugador "siente", y los Retazos deben poder mutarlo antes de la cola. |
 | `ApplyEnemyToPlayerEffectiveness()`, después de calcular `finalAmount` y antes de `EnemyHitEffectiveness?.Invoke(...)` | `OnDamageTaken` | Permite Retazos defensivos ("daño recibido -1"). |
@@ -366,6 +366,18 @@ acciones post-combate. El efecto del Retazo escribe directo:
 `ctx.RunState.Gold += 5`, `ctx.RunState.PlayerCurrentHP = Mathf.Min(...)`. La
 `ActionQueue` ya no se procesa una vez detectado Victory/Defeat, por lo que
 encolar ahí sería frágil.
+
+**Aclaración (fix de fin-de-combate, SUB-PR 1 / 2026-06-14, Opción B).** Los
+métodos `Grant*` del contexto (`GrantHeal`, `GrantBlock`, `GrantStyleCharge`, …)
+son **no-op en `OnCombatEnd`**. `CheckCombatEndConditions` setea
+`_phase = Victory/Defeat` ANTES de llamar a `DispatchCombatEnd`, así que durante
+el dispatch `IsCombatFinished == true` y cada `RelicGrant*` hace early-return
+(el guard de §Guards comunes). Por eso heal/escudo post-combate van **sí o sí
+por mutación directa de `RunState`**, no por la API de combate. Y es seguro
+porque `DispatchCombatEnd` sincroniza `RunState.PlayerCurrentHP/MaxHP =
+_player.*` ANTES del dispatch → el `RunState` es autoritativo en este hook. Esto
+**invierte** la guía vieja D7/D8 (que trataba la mutación directa como "patrón
+roto" y `GrantHeal` como "vía correcta"): el fix demostró lo contrario.
 
 ### Eventos
 
@@ -433,7 +445,7 @@ Cobertura por categoría del Insight 3:
 | "Cada 3 cartas Skill → +1 energía siguiente turno" | counter en `OnCardPlayed` + `GrantEnergy` en `OnPlayerTurnStart` siguiente |
 | "+5 oro al final de combate" | `ctx.RunState.Gold += 5` (mutación directa, [CERRADO 3]) |
 | "Al cambiar de mundo, +5 bloque" | `GrantBlock(player, 5)` en `OnWorldSwitch` |
-| "Heal 3 al matar enemigo" | `GrantHeal(player, 3)` en `OnCombatEnd` (Victory) |
+| "Heal 3 al matar enemigo" | mutación directa `ctx.RunState.PlayerCurrentHP = Mathf.Min(RunState.PlayerMaxHP, RunState.PlayerCurrentHP + 3)` en `OnCombatEnd` (Victory). **NO** `GrantHeal`: es no-op tras Victory/Defeat ([CERRADO 3]) |
 | "+1 carga de Estilo al cambiar de mundo" | `GrantStyleCharge(1)` en `OnWorldSwitch` |
 | "Tu primer cambio de mundo encola 5 daño extra" | `EnqueueExtraDamage(enemy, 5, type)` en `OnWorldSwitch` |
 
@@ -442,8 +454,9 @@ Implementación en `TurnManager`: cada método del contexto delega a un método
 
 **Semántica precisa de cada método:**
 
-- **`GrantStyleCharge(amount)`** aplica la **misma lógica** que
-  `ApplyPlayerToEnemyEffectiveness` (líneas 583-593 de `TurnManager`):
+- **`GrantStyleCharge(amount)`** delega en el método `IncrementStyleCharges`
+  de `TurnManager` — la **misma fuente de verdad** que usa el path orgánico de
+  `ApplyPlayerToEnemyEffectiveness` cuando un SuperEficaz genera +1 carga:
   incrementa `_styleCharges`; si llega a 5 con `_bonusWorldSwitches == 0`,
   otorga el bonus switch y resetea las cargas a 0. Esto preserva la golden
   rule §4 (Contador de Estilo). NO basta con clampear a 5 — sin el reset +
@@ -604,14 +617,16 @@ Durante la implementación de Sub-PR 3A, el agente tomó 5 decisiones que no
 estaban explícitas en el spec original. Quedan registradas acá para
 trazabilidad y porque varias tienen impacto en sub-PRs futuras.
 
-**[IMPL 1] `OnDamageDealt` se dispara solo en el path tipado, no en el path
-de cartas neutras (`ElementType.None`).** En `ApplyPlayerToEnemyEffectiveness`
-(líneas 588-630), el branch de cartas None retorna temprano sin pasar por el
-hook. Razón: agregar el dispatch ahí hubiera sido un 8º punto en TurnManager
-fuera de los 7 aprobados. Consecuencia: Retazos de modificador de daño NO
-afectan cartas neutras hoy. **Reabrir en Sub-PR 3B** cuando se diseñen
-Retazos de esa categoría — ver Insight 5 para las dos opciones (extender el
-hook al path None con aprobación, o restringir Retazos a cartas tipadas).
+**[IMPL 1] `OnDamageDealt` en el path de cartas neutras (`ElementType.None`) —
+CERRADO en Sub-PR 3B.** En diseño 3A el branch de cartas None retornaba temprano
+sin disparar el hook (el 8º punto de dispatch quedaba fuera de los 7 aprobados).
+**3B cerró esto con aprobación explícita** (ver `RELICS.md §Decisiones cerradas`,
+ítem 1 — opción A del Insight 5): el branch `attackerType == ElementType.None`
+de `ApplyPlayerToEnemyEffectiveness` ahora dispara `OnDamageDealt` con el mismo
+contrato mutable que el path tipado (los Retazos mutan `data.Amount` sobre el
+daño neutro al 90% de DD-002). Consecuencia: los Retazos de modificador de daño
+**sí** afectan cartas neutras hoy. El `TurnManager` quedó con **8** puntos de
+dispatch, no 7.
 
 **[IMPL 2] Try/catch alrededor de `effect.OnHook(hook, data)` en el
 dispatcher.** No estaba en el spec; el agente lo agregó como defensa: un
@@ -627,15 +642,14 @@ implicaría duplicar la efectividad orgánica (el daño raw quedaría con
 multiplicador, lo cual contradice [CERRADO 3] de la doc de
 `EnqueueExtraDamage`). El parámetro se conserva en la signature como metadata
 para futuros usos (animaciones diferenciadas por tipo en UI de 3B, posibles
-Retazos en M5/M6 que sí lo lean). Comentario explícito en
-[TurnManager.cs:1018-1041](Assets/Scripts/Gameplay/Combat/TurnManager.cs#L1018).
+Retazos en M5/M6 que sí lo lean). Comentario explícito en el método
+`RelicEnqueueExtraDamage` de `TurnManager`.
 
 **[IMPL 4] `RelicGrantEnergy` es no-op silencioso para non-player actors.**
 Razón: la energía es concepto del jugador (`PlayerCombatActor.GainEnergy`);
 `ICombatActor` no expone `GainEnergy` y el enemigo no tiene pool de energía.
 Si un Retazo intenta `GrantEnergy(enemy, 1)`, el método valida y retorna sin
-loggear. Documentado en
-[TurnManager.cs:992-1000](Assets/Scripts/Gameplay/Combat/TurnManager.cs#L992).
+loggear. Documentado en el método `RelicGrantEnergy` de `TurnManager`.
 
 **[IMPL 5] Logger del dispatcher no spammea cuando hay 0 subscribers.**
 Aún con `LogDispatches = true`, si el filtrado del hook devuelve 0
@@ -647,6 +661,29 @@ no es prioridad ahora.
 
 Ninguna de estas decisiones rompe el spec ni reabre las 5 [CERRADO]s. Todas
 son refinamientos de implementación dentro del alcance acordado.
+
+## Consecuencias de la semántica del Contador de Estilo (D-A, 2026-06-12)
+
+Sebastián ratificó el Contador de Estilo como **PRE-block** (D-A, ver
+`Docs/dev/audits/2026-06/PLAN_PRE_M4.md §0`): un golpe SuperEficaz otorga +1
+carga aunque el enemigo lo bloquee al 100%. Esto = comportamiento actual del
+código y tiene dos consecuencias para los Retazos:
+
+1. **La carga se otorga ANTES del hook `OnDamageDealt`.** En
+   `ApplyPlayerToEnemyEffectiveness` el orden es: calcular `finalAmount`
+   post-efectividad → `IncrementStyleCharges(1)` si fue SuperEficaz con
+   `finalAmount > 0` → recién entonces `Dispatch(OnDamageDealt)`. La carga
+   depende del daño post-efectividad **pre-block** (el bloqueo del enemigo se
+   aplica más tarde, en `DamageAction.Execute`). Por lo tanto, un Retazo que en
+   `OnDamageDealt` baje `data.Amount` a 0 **no** revierte la carga ya otorgada
+   — la semántica pre-block es independiente del valor final encolado.
+
+2. **Retazos que leen/otorgan cargas operan sobre el conteo pre-block.**
+   `GrantStyleCharge` (R-SW-2 "Estilo Doble") y los Retazos que condicionan por
+   `StyleCharges` (R-DMG-4 "Combo de cargas") ven el contador tal cual lo dejó
+   el pre-block, sin descuento por bloqueos enemigos. Es intencional y es el
+   contrato que el test `StyleCharge_SuperEffectiveHitFullyBlocked_StillGrantsCharge`
+   (SUB-PR 2) congela.
 
 ## Alternativas consideradas
 


### PR DESCRIPTION
## SUB-PR 4 — Docs paquete (ii): verdad de Retazos

Cierra **D7, D8, D9, D10** del plan de remediación pre-M4 (`Docs/dev/audits/2026-06/PLAN_PRE_M4.md §SUB-PR 4`).

### Qué cambia
Sincroniza la documentación de Retazos con la **regla de autoría real** que fijó el fix de fin-de-combate (SUB-PR 1, Opción B, #111). La guía vieja D7/D8 quedó invertida por el fix y este PR la corrige.

**`RELICS.md`**
- §Advertencias punto 4, §Categoría 5 (header `OnCombatEnd`), R-END-2 y R-END-4: la **mutación directa de `RunState.PlayerCurrentHP` en `OnCombatEnd` ES la vía correcta** — `TurnManager.DispatchCombatEnd` sincroniza `RunState.PlayerCurrentHP/MaxHP = _player.*` ANTES del dispatch. `ctx.GrantHeal(...)` (y demás `Grant*`) son **no-op** en ese hook (`IsCombatFinished == true`).
- Nuevo punto 7 en §Advertencias: orden real de hooks en el arranque de combate (turno 1: `OnPlayerTurnStart` → `OnCombatStart`).

**`m3_hooks_spec.md`**
- `[CERRADO 3]`: aclaración de que los `Grant*` son no-op en `OnCombatEnd` + por qué la mutación directa es segura.
- Tabla de cobertura (`:436`): "Heal al matar enemigo" pasa a mutación directa de `RunState`, no `GrantHeal`.
- `[IMPL 1]`: marcado CERRADO en 3B (8º dispatch en path de cartas neutras).
- Nueva subsección "Consecuencias de la semántica del Contador de Estilo" (D-A pre-block).
- Referencias de línea corridas → nombres de método.

### Verificación
Cada afirmación verificada contra `TurnManager.cs` (líneas 608-620 del 8º dispatch, 717-757 de `CheckCombatEndConditions`/`DispatchCombatEnd`, 999-1041 de `IncrementStyleCharges`/`RelicGrant*`). Docs puros — sin cambios de código, sin impacto en tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)