### PR TITLE
docs(numbers): refresca cifras + estado de specs (SUB-PR 5)

### DIFF
--- a/.claude/commands/cierre-sesion.md
+++ b/.claude/commands/cierre-sesion.md
@@ -24,6 +24,10 @@ Checklist (en orden; reportá qué se actualizó y qué no aplicaba):
    pidiendo construir algo que ya existía.)
 3. **Tech snapshot:** si hubo cambios estructurales (módulo/subsistema nuevo,
    refactor que mueve responsabilidades), actualizar `Docs/dev/_tech_snapshot.md`.
+3b. **Specs implementados:** si la sesión implementó un spec de
+   `Docs/dev/specs/`, marcar su header con
+   `> **ESTADO: IMPLEMENTADO — PR #N (YYYY-MM-DD)**` (evita que un spec viva como
+   "PROPUESTA" después de estar en código — origen: D14 de la auditoría 2026-06).
 4. **Memoria:** actualizar las memorias de proyecto afectadas (estado, próximo
    paso) y su línea en `MEMORY.md`. Editar archivos existentes — no crear
    duplicados.

--- a/Assets/Scripts/Gameplay/Combat/CLAUDE.md
+++ b/Assets/Scripts/Gameplay/Combat/CLAUDE.md
@@ -10,15 +10,17 @@
 
 ---
 
-## Estado actual (post-extracciones, abril 2026)
+## Estado actual (post-extracciones, actualizado 2026-06-16)
 
 ```
-CombatUIController.cs   → 980 loc  (era 1473) — orquesta BuildUI + HUD + lifecycle
-CombatFeedbackView.cs   → 357 loc  (Fase 1) — popups, shake, victory/defeat, flash
-CardHandView.cs         → 400 loc  (Fase 2) — mano de cartas, click, layout
-TurnManager.cs          → 735 loc  PROTEGIDO
-ActionQueue.cs          →  85 loc  PROTEGIDO
-PlayerCombatActor.cs    → 236 loc  PROTEGIDO
+CombatUIController.cs   →  752 loc (era 1473) — orquesta BuildUI + lifecycle
+CombatFeedbackView.cs   →  357 loc (Fase 1) — popups, shake, victory/defeat, flash
+CardHandView.cs         →  501 loc (Fase 2) — mano de cartas, click, layout, arte C7
+CombatHudView.cs        →  344 loc (Fase 3) — HUD: HP, energía, Estilo, intent, tipos
+CombatBackgroundView.cs →  182 loc (Fase 4) — fondos / parallax de combate
+TurnManager.cs          → 1098 loc PROTEGIDO
+ActionQueue.cs          →   85 loc PROTEGIDO
+PlayerCombatActor.cs    →  246 loc PROTEGIDO
 ```
 
 ---
@@ -34,10 +36,14 @@ PlayerCombatActor.cs    → 236 loc  PROTEGIDO
 Si una tarea requiere modificar estos archivos, **PARAR y pedir aprobación
 explícita a Sebastián antes de continuar.** Esto aplica a:
 
-- Implementar `EffectType.Heal` (case nuevo en `CreateAction()`)
-- Implementar `PhaseBased` AI (case nuevo en `SelectEnemyMove()`)
-- Ampliar `CalculateIntentValue()` para combinaciones nuevas
+- Ampliar `CalculateIntentValue()` para combinaciones de intent nuevas (hoy ya
+  cubre Attack+Damage, Defend+Block y Defend+Heal — ver "Deuda técnica resuelta
+  en Sub-PR D" abajo)
 - Cualquier otro cambio estructural en estos archivos
+
+> **Nota:** `EffectType.Heal`/`HealAction` y la IA `PhaseBased` **ya están
+> implementados** (Sub-PR D, 2026-05-07). Ya NO son "futuros que requieren
+> aprobación" — el case de `CreateAction()` y el de `SelectEnemyMove()` existen.
 
 ---
 
@@ -82,8 +88,12 @@ Cada componente extraído sigue este patrón (ver `CombatFeedbackView` y
 
 ## Key Patterns
 
-- **Efectividad**: SOLO aplica a daño de carta del jugador vs tipo del enemigo.
-  NUNCA a daño del enemigo, bloqueo, robo de cartas ni ningún otro efecto.
+- **Efectividad**: aplica a daño tipado en **AMBAS direcciones** (DD-018, Sub-PR B).
+  Jugador→enemigo (`ApplyPlayerToEnemyEffectiveness`, defensor = tipo del enemigo)
+  Y enemigo→jugador (`ApplyEnemyToPlayerEffectiveness`, defensor = `PlayerActiveType`
+  según el mundo activo). NUNCA aplica a bloqueo, robo de cartas, otros efectos, ni
+  al daño RAW de Retazos (`EnqueueExtraDamage`). Cartas neutras (`None`) = 90% fijo
+  (DD-002), fuera de la tabla.
 - **Contador de Estilo**: +1 carga al hacer SuperEficaz con daño real; -1 al
   recibir SuperEficaz del enemigo. 5 cargas → 1 switch de mundo extra (no
   acumulable), reset de cargas. Se lee vía `TurnManager.StyleCharges`.

--- a/Docs/dev/_tech_snapshot.md
+++ b/Docs/dev/_tech_snapshot.md
@@ -7,7 +7,19 @@
 > En `modo:implementacion` se lee OBLIGATORIAMENTE antes de cualquier cambio que
 > afecte arquitectura o componentes críticos.
 >
-> **Última actualización:** 2026-06-14 — **SUB-PR 1 auditoría: fix de sincronización
+> **Última actualización:** 2026-06-16 — **SUB-PR 5 auditoría: números y estado**
+> (branch `docs/numbers-and-state`). Refresh mecánico de cifras desviadas, sin
+> cambios de código: **108** scripts C# en `Assets/Scripts` (no 53); `TurnManager.cs`
+> **~1098 LOC** (no 735/~960 contradictorios); LOC de vistas de combate corridos
+> (`CombatUIController` 752, `CardHandView` 501, `CombatHudView` 344,
+> `PlayerCombatActor` 246); suite EditMode **148/148** (18 archivos, +`CombatEndSyncTests`);
+> `gh` CLI **presente** (2.92.0) — PRs vía `gh pr create`; **CI parqueado** (GameCI
+> bloqueado por licencias Entitlement de Unity 6; `tests.yml` commiteado pero
+> DESACTIVADO, `workflow_dispatch`); purgada la sección "Restricciones conocidas"
+> de los 3 gaps de TurnManager (PhaseBased / EffectType.Heal / CalculateIntentValue)
+> **resueltos en M2 Sub-PR D**. HP base = 60 (D-C).
+>
+> **Última actualización previa:** 2026-06-14 — **SUB-PR 1 auditoría: fix de sincronización
 > fin-de-combate + retry/reset** (branch `feat/fix-combat-end-sync`, spec
 > `Docs/dev/specs/fix_combat_end_hp_sync_spec.md`, Opción B). Raíz del cluster H1-H4:
 > RunState tenía HP stale cuando corrían los hooks OnCombatEnd. **Fix:**
@@ -226,7 +238,7 @@
 
 ### Tests
 - **Unity Test Framework** (NUnit) en EditMode
-- 17 archivos de test en `Assets/Tests/EditMode/` (suite 142/142)
+- 18 archivos de test en `Assets/Tests/EditMode/` (suite 148/148)
 - Helper compartido: `CombatTestBase.cs`
 
 ---
@@ -320,7 +332,7 @@ Exclusivamente vía `RunSession.State` (= `RunState`). Flags principales:
 
 ## Estructura de archivos
 
-### Scripts (`Assets/Scripts/`) — 53 archivos C#
+### Scripts (`Assets/Scripts/`) — 108 archivos C#
 
 ```
 Core/
@@ -368,18 +380,18 @@ Gameplay/
     CardEnums.cs                 ← CardType, EffectType, EffectTarget
     EffectRef.cs                 ← referencia a efecto en SO
   Combat/
-    TurnManager.cs               ← 735 loc — PROTEGIDO
+    TurnManager.cs               ← ~1098 loc — PROTEGIDO
     ActionQueue.cs               ← 85 loc — PROTEGIDO
-    PlayerCombatActor.cs         ← 236 loc — PROTEGIDO
+    PlayerCombatActor.cs         ← 246 loc — PROTEGIDO
     EnemyCombatActor.cs
     ICombatActor.cs, IGameAction.cs, ActionContext.cs
     ElementTypes.cs              ← 7 tipos + matriz de efectividad
     ElementTypeColors.cs         ← C8: fuente única de verdad ElementType→Color (tinte UI)
     SpriteFrameAnimatorUI.cs
-    CombatUIController.cs        ← 710 loc (era 1473)
+    CombatUIController.cs        ← 752 loc (era 1473)
     CombatFeedbackView.cs        ← 357 loc (extraído en Fase 1)
-    CardHandView.cs              ← 400 loc (extraído en Fase 2)
-    CombatHudView.cs             ← 327 loc (extraído en Fase 3)
+    CardHandView.cs              ← 501 loc (extraído en Fase 2)
+    CombatHudView.cs             ← 344 loc (extraído en Fase 3)
     CombatBackgroundView.cs      ← 182 loc (extraído en Fase 4)
     CombatAmbientParticles.cs
     Actions/
@@ -435,7 +447,7 @@ RelicSoGenerator.cs                   ← MenuItem "Roguelike/Generate Relic Ass
                                         (idempotente — saltea archivos existentes)
 ```
 
-### Tests (`Assets/Tests/EditMode/`) — 17 archivos (suite EditMode 146/146)
+### Tests (`Assets/Tests/EditMode/`) — 18 archivos (suite EditMode 148/148)
 
 ```
 CombatTestBase.cs                ← helper compartido
@@ -464,6 +476,9 @@ CardArtTests.cs                  ← Auditoría de arte C7 (5 casos: campo Art d
                                    null, set/omit en SetDebugData, persistencia en el
                                    clon de upgrade, herencia dual por mundo, resolución
                                    vía CardDeckEntry)
+CombatEndSyncTests.cs            ← Auditoría SUB-PR 1 (T1: el seam ApplyCombatResult
+                                   no pisa el heal de Retazos OnCombatEnd; T2: el retry
+                                   tras derrota con 0 HP restaura HP jugable)
 ```
 
 ### ScriptableObjects (`Assets/ScriptableObjects/`)
@@ -493,7 +508,7 @@ aprobación explícita de Sebastián antes de proceder:
 
 | Archivo | LOC | Por qué está protegido |
 |---------|-----|------------------------|
-| `TurnManager.cs` | ~960 | Flujo de turnos, efectividad, energía, Contador de Estilo, IA enemiga, world switch, hooks de Retazos (3A) + API delegada |
+| `TurnManager.cs` | ~1098 | Flujo de turnos, efectividad, energía, Contador de Estilo, IA enemiga, world switch, hooks de Retazos (3A) + API delegada |
 | `ActionQueue.cs` | 85 | Orden determinista de ejecución (FIFO) |
 | `PlayerCombatActor.cs` | 236 | Mecánicas del jugador en combate |
 
@@ -550,15 +565,19 @@ de tocar.
 
 ## Restricciones conocidas
 
-- **No CI/CD** configurado. Tests se corren localmente vía Unity Test Runner.
-- **No gh CLI** instalado. PRs se crean manualmente desde la URL que devuelve `git push`.
+- **CI parqueado.** GameCI quedó bloqueado por el modelo de licencias Entitlement
+  de Unity 6. El workflow `tests.yml` está commiteado pero DESACTIVADO
+  (`workflow_dispatch` only); los tests se corren localmente vía Unity Test
+  Runner / Unity-MCP (`tests-run`). Detalle en `_roadmap.md` Future work.
+- **`gh` CLI presente** (2.92.0). Los PRs se crean con `gh pr create`.
 - **Comentarios mezclados español/inglés** sin criterio fijo (deuda menor, ver roadmap).
-- **CombatUIController** (710 loc post-Fase 4). Descomposición completa — es ahora
-  un orquestador puro de BuildUI y lifecycle. Listo para recibir features de M2.
-- **TurnManager tiene gaps conocidos** que requieren tocar el archivo protegido:
-  - PhaseBased AI declarado en enum pero sin implementación en `SelectEnemyMove()`
-  - `EffectType.Heal` no existe (BossAct1 Regenerate usa Block como workaround)
-  - `CalculateIntentValue()` solo maneja Attack+Damage y Defend+Block
+- **CombatUIController** (752 loc post-Fase 4). Descomposición completa — es ahora
+  un orquestador puro de BuildUI y lifecycle.
+
+> **Nota:** los 3 gaps de `TurnManager` que listaba esta sección (PhaseBased AI,
+> `EffectType.Heal`, `CalculateIntentValue`) **se resolvieron en M2 Sub-PR D
+> (2026-05-07)** — ya no son restricciones. Ver `Assets/Scripts/Gameplay/Combat/
+> CLAUDE.md §"Deuda técnica resuelta en Sub-PR D"`.
 
 ---
 

--- a/Docs/dev/audits/2026-06/PLAN_PRE_M4.md
+++ b/Docs/dev/audits/2026-06/PLAN_PRE_M4.md
@@ -155,15 +155,28 @@ aprueba la edición en el hilo principal.
   método (`IncrementStyleCharges`, `ClearBlock`, `RelicEnqueueExtraDamage`,
   `RelicGrantEnergy`).
 
-### SUB-PR 5 — Docs paquete (iii): números y estado `docs/numbers-and-state`
+### SUB-PR 5 — Docs paquete (iii): números y estado `docs/numbers-and-state` ✅ CERRADO 2026-06-16
 
 **Cierra:** D11, D12, D13, D14 + el arreglo de proceso T3 + HP (tras D-C).
 **Esfuerzo:** S (mecánico).
 
-- `_tech_snapshot.md`: 108 scripts, TurnManager 1088 LOC, purgar "Restricciones conocidas" (3 gaps resueltos), suite 146, gh CLI presente, CI parqueado, LOC corridos.
-- `Combat/CLAUDE.md`: LOC actuales, agregar CombatHudView/CombatBackgroundView, **corregir D13** (efectividad bidireccional — DD-018; es lo más peligroso del paquete), sacar Heal/PhaseBased de "futuros que requieren aprobación".
-- **D14 + T3 (proceso):** marcar los 4 specs (3E/3F/tint/C7) con header `> **ESTADO: IMPLEMENTADO — PR #N (fecha)**`; agregar campo Estado a la plantilla de Spec Técnico; agregar paso "marcar spec IMPLEMENTADO" a `/cierre-sesion`.
-- **HP (tras D-C):** si la verdad es 70 → subir `BattleScene.unity:434` + `TurnManager.cs:26`; si es 60 → corregir GOLDEN_RULES §9 (lo toca Sebastián) + nota de decisión.
+- [x] `_tech_snapshot.md`: **108** scripts (no 53), TurnManager **~1098** LOC (no
+  735/~960), purgada "Restricciones conocidas" (3 gaps PhaseBased/Heal/CalculateIntentValue
+  resueltos en M2-D), suite **148/148** (18 archivos, +CombatEndSyncTests), gh CLI
+  presente (2.92.0), CI parqueado (GameCI/Entitlement, tests.yml desactivado), LOC de
+  vistas corridos (CombatUIController 752, CardHandView 501, CombatHudView 344,
+  PlayerCombatActor 246).
+- [x] `Combat/CLAUDE.md`: LOC actuales, agregados CombatHudView/CombatBackgroundView al
+  bloque de estado, **corregido D13** (efectividad **bidireccional** — DD-018, verificado
+  en `ApplyEnemyToPlayerEffectiveness` líneas 595-597/655-681; era la negación más
+  peligrosa del paquete), sacados Heal/PhaseBased de "futuros que requieren aprobación"
+  (resueltos M2-D).
+- [x] **D14 + T3 (proceso):** los 4 specs (3E #97 / 3F #98 / tint #107 / C7 #105) llevan
+  header `> **ESTADO: IMPLEMENTADO — PR #N (fecha)**`; campo Estado agregado a la plantilla
+  de Spec Técnico (`_plantillas.md`); paso "Specs implementados" agregado a `/cierre-sesion`.
+- [x] **HP (tras D-C):** la verdad es **60** (`TurnManager.cs:26 playerMaxHP = 60`, verificado).
+  `_tech_snapshot` y `Combat/CLAUDE.md` NO contenían el número 70 (grep limpio) → sin cambios
+  ahí. GOLDEN_RULES §9 (70→60) lo edita Sebastián (fuera de este PR).
 
 ### SUB-PR 6 — Tooling: cerrar el bypass + limpieza `chore/tooling-hardening` ✅ CERRADO 2026-06-14
 

--- a/Docs/dev/modes/_plantillas.md
+++ b/Docs/dev/modes/_plantillas.md
@@ -74,6 +74,10 @@ qué prioridades sugiere]
 ```markdown
 # Spec — [Nombre de la feature]
 
+> **ESTADO: PROPUESTA.** (Al implementarse, cambiar a
+> `IMPLEMENTADO — PR #N (YYYY-MM-DD)`. Lo actualiza `/cierre-sesion` cuando el
+> spec se cierra en código — ver paso "Specs implementados" del ritual.)
+
 ## Origen
 - GDD section / DESIGN_DECISIONS / pedido directo de Sebastián / surgió en playtest
 

--- a/Docs/dev/specs/art_c7_card_art_spec.md
+++ b/Docs/dev/specs/art_c7_card_art_spec.md
@@ -1,5 +1,7 @@
 # Spec — C7: Cara de carta (arte de cartas) · habilitación de CÓDIGO
 
+> **ESTADO: IMPLEMENTADO — PR #105 (2026-06-05).** (Código + Fase 4 de integración de placeholders.)
+
 > **Generado en `modo:diseno`, 2026-06-05.** Es el spec de la pieza de CÓDIGO del
 > slot **C7** del plan de auditoría de arte (`Docs/design/ART_NEEDS.md`). C7 es
 > **mixto**: primero el código (este spec), DESPUÉS el prompt de IA.

--- a/Docs/dev/specs/m3_3e_newrun_spec.md
+++ b/Docs/dev/specs/m3_3e_newrun_spec.md
@@ -1,5 +1,7 @@
 # Spec — Sub-PR 3E: NewRunScene (selección de tipos + draft de carta dual + arranque de run)
 
+> **ESTADO: IMPLEMENTADO — PR #97 (2026-06-04).**
+
 > Generado en `modo:diseno` el 2026-06-04. Todas las decisiones cerradas — spec
 > implementable sin tocar archivos protegidos. El prompt de handoff para
 > `modo:implementacion` está al final.

--- a/Docs/dev/specs/m3_3f_horizontal_map_spec.md
+++ b/Docs/dev/specs/m3_3f_horizontal_map_spec.md
@@ -1,5 +1,7 @@
 # Spec — Sub-PR 3F: Mapa horizontal (refactor scroll lateral)
 
+> **ESTADO: IMPLEMENTADO — PR #98 (2026-06-05).** Cierra M3.
+
 > Estado: **CERRADO** (sin decisiones abiertas). Último sub-PR de M3 — su cierre
 > cierra el milestone. Diseñado 2026-06-05 en `modo:diseno`.
 

--- a/Docs/dev/specs/polish_type_tint_selectors_spec.md
+++ b/Docs/dev/specs/polish_type_tint_selectors_spec.md
@@ -1,5 +1,7 @@
 # Spec — Tinte por tipo elemental en selectores de Hoguera y Tienda (pulido pre-M4, #104)
 
+> **ESTADO: IMPLEMENTADO — PR #107 (2026-06-09).** (`#104` es el issue de backlog de origen.)
+
 ## Origen
 Backlog #104 / pedido directo de Sebastián. Pulido pre-M4. Continúa la línea de
 trabajo de la auditoría de arte C8 (tinte por tipo, `ElementTypeColors`) que ya


### PR DESCRIPTION
## SUB-PR 5 — Docs paquete (iii): números y estado

Cierra **D11, D12, D13, D14** + arreglo de proceso **T3** + **HP (D-C)** del plan pre-M4 (`Docs/dev/audits/2026-06/PLAN_PRE_M4.md §SUB-PR 5`). Docs puros, sin cambios de código.

### `_tech_snapshot.md` (D11/D12)
- **108** scripts C# (decía 53); `TurnManager` **~1098 LOC** (decía 735 en un lado, ~960 en otro — contradictorios); LOC de vistas corridos (`CombatUIController` 752, `CardHandView` 501, `CombatHudView` 344, `PlayerCombatActor` 246).
- Suite EditMode **148/148** (18 archivos, agregado `CombatEndSyncTests`).
- **`gh` CLI presente** (2.92.0); **CI parqueado** (GameCI bloqueado por Entitlement de Unity 6; `tests.yml` commiteado pero desactivado).
- Purgada "Restricciones conocidas": los 3 gaps de `TurnManager` (PhaseBased / `EffectType.Heal` / `CalculateIntentValue`) se resolvieron en **M2 Sub-PR D**.

### `Combat/CLAUDE.md` (D13 — lo más peligroso del paquete)
- **Efectividad corregida a BIDIRECCIONAL** (DD-018, Sub-PR B): aplica jugador→enemigo *y* enemigo→jugador. La redacción previa ("SOLO… NUNCA a daño del enemigo") era falsa — verificado en `ApplyEnemyToPlayerEffectiveness` (líneas 595-597, 655-681).
- LOC actuales + `CombatHudView`/`CombatBackgroundView` en el bloque de estado.
- `EffectType.Heal`/`HealAction` y `PhaseBased` fuera de "futuros que requieren aprobación" (resueltos M2-D).

### D14 + proceso (T3)
- Los 4 specs implementados llevan header `> **ESTADO: IMPLEMENTADO — PR #N (fecha)**`: 3E #97, 3F #98, tint #107, C7 #105.
- Campo **Estado** agregado a la plantilla de Spec Técnico (`_plantillas.md`).
- Paso **"Specs implementados"** agregado a `/cierre-sesion`.

### HP (D-C)
Código = **60** (`TurnManager.cs:26 playerMaxHP = 60`, verificado). Ni `_tech_snapshot` ni `Combat/CLAUDE.md` contenían el número 70 (grep limpio) → sin cambios ahí. GOLDEN_RULES §9 (70→60) lo edita Sebastián, fuera de este PR.

### Verificación
Cada cifra verificada con `wc -l` / `grep` contra el código actual. Sin impacto en tests ni en runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)