### PR TITLE
test(combat): red de tests pre-cirugía + cap de Estilo a 5 (SUB-PR 2)

### DIFF
--- a/Assets/Scripts/Gameplay/Combat/TurnManager.cs
+++ b/Assets/Scripts/Gameplay/Combat/TurnManager.cs
@@ -1004,6 +1004,15 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 _bonusWorldSwitches = 1;
                 _styleCharges = 0;
             }
+            else if (_styleCharges > 5)
+            {
+                // Cap a 5 (D-B). Si ya hay un switch bonus pendiente (_bonusWorldSwitches
+                // != 0), la rama de arriba no dispara y las cargas crecerían sin techo
+                // vía Retazos (RelicGrantStyleCharge). El Contador de Estilo nunca debe
+                // exceder 5 (golden rule §4); SetStyleChargesForTest ya clampaba, este
+                // es el path de producción.
+                _styleCharges = 5;
+            }
         }
 
         internal void RelicGrantBlock(ICombatActor actor, int amount)

--- a/Assets/Tests/EditMode/NeutralCardDamageTests.cs
+++ b/Assets/Tests/EditMode/NeutralCardDamageTests.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using RoguelikeCardBattler.Gameplay.Cards;
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Gameplay.Enemies;
+
+namespace RoguelikeCardBattler.Tests.EditMode
+{
+    /// <summary>
+    /// T9 (auditoría 2026-06, SUB-PR 2): una carta de tipo None aplica 90% del daño
+    /// base (DD-002) contra CUALQUIER tipo de enemigo, fuera de la tabla de efectividad
+    /// y sin otorgar cargas de Estilo.
+    ///
+    /// Nota sobre el 8º dispatch: las cartas neutras también disparan OnDamageDealt
+    /// (Sub-PR 3B, TurnManager.ApplyPlayerToEnemyEffectiveness ~líneas 611-620). Ese
+    /// dispatch depende de RunSession.RelicDispatcher, que se cablea en
+    /// RunSession.Awake — y Awake NO corre al AddComponent en EditMode (los callbacks
+    /// de MonoBehaviour solo corren en Play). Por eso esa rama se valida en Play /
+    /// por lectura de código; acá se congela la regla de balance del 90%.
+    /// </summary>
+    public class NeutralCardDamageTests : CombatTestBase
+    {
+        private TurnManager CreateManager(CardDefinition card, EnemyDefinition enemy)
+        {
+            var deck = new List<CardDeckEntry> { CreateSingleCardEntry(card) };
+            var go = CreateGameObject("TurnManager");
+            var manager = AddComponent<TurnManager>(go);
+            manager.SetTestConfig(maxHp: 30, energy: 3, startingHand: 1, cardsPerTurnCount: 1);
+            manager.SetTestData(deck, enemy);
+            return manager;
+        }
+
+        [TestCase(ElementType.Rojo)]
+        [TestCase(ElementType.Azul)]
+        [TestCase(ElementType.None)]
+        public void NeutralCard_Applies90PercentDamage(ElementType enemyType)
+        {
+            // Carta None, daño base 10 → round(10 * 0.9) = 9, sin importar el tipo enemigo.
+            CardDefinition card = CreateCardWithElement("neutral_strike", CardType.Attack, CardTarget.SingleEnemy,
+                cost: 0, ElementType.None, CreateEffect(EffectType.Damage, 10, EffectTarget.SingleEnemy));
+            EnemyDefinition enemy = CreateEnemyDefinition("enemy_" + enemyType, "Enemy", 50,
+                EnemyAIPattern.Sequence, new List<EnemyMove>(), enemyType);
+
+            TurnManager manager = CreateManager(card, enemy);
+            manager.InitializeCombat();
+            int hpBefore = manager.EnemyHP;
+
+            manager.PlayCard(manager.PlayerHand[0]);
+
+            Assert.AreEqual(hpBefore - 9, manager.EnemyHP,
+                "Carta neutra (None) aplica 90% del daño base (DD-002) contra cualquier tipo.");
+            Assert.AreEqual(0, manager.StyleCharges,
+                "Las cartas neutras no pasan por la tabla de efectividad → no otorgan cargas de Estilo.");
+        }
+    }
+}

--- a/Assets/Tests/EditMode/NeutralCardDamageTests.cs.meta
+++ b/Assets/Tests/EditMode/NeutralCardDamageTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 93f8f0a166145ad4d9cdd614d10da259

--- a/Assets/Tests/EditMode/RelicAssetTests.cs
+++ b/Assets/Tests/EditMode/RelicAssetTests.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Gameplay.Relics;
+using RoguelikeCardBattler.Gameplay.Relics.Hooks;
+using RoguelikeCardBattler.Run;
+using RoguelikeCardBattler.Run.Campfire;
+using RoguelikeCardBattler.Run.Shop;
+
+namespace RoguelikeCardBattler.Tests.EditMode
+{
+    /// <summary>
+    /// T5 (auditoría 2026-06, SUB-PR 2): única validación datos↔código. Carga TODOS
+    /// los .asset reales de Retazos y verifica que cada hook que un asset DECLARA es
+    /// despachable por el RelicHookDispatcher real sin lanzar — es decir, el efecto
+    /// realmente maneja el hook que dice escuchar. Si un efecto tira al manejar un hook
+    /// declarado, el dispatcher loguea LogError y el Test Runner falla el test.
+    /// </summary>
+    public class RelicAssetTests
+    {
+        private const string RelicsFolder = "Assets/ScriptableObjects/Relics";
+
+        [Test]
+        public void RelicAssets_AllDeclaredHooksAreDispatchable()
+        {
+            string[] guids = AssetDatabase.FindAssets("t:RelicDefinition", new[] { RelicsFolder });
+            Assert.Greater(guids.Length, 0, $"No se encontraron RelicDefinition en {RelicsFolder}.");
+
+            foreach (string guid in guids)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(guid);
+                RelicDefinition def = AssetDatabase.LoadAssetAtPath<RelicDefinition>(path);
+                Assert.IsNotNull(def, $"No se pudo cargar {path}.");
+                Assert.IsNotNull(def.Effect, $"{def.name}: Effect sin asignar ([SerializeReference] nulo).");
+                Assert.IsNotNull(def.Hooks, $"{def.name}: Hooks sin asignar.");
+                Assert.Greater(def.Hooks.Length, 0, $"{def.name}: no declara ningún hook.");
+
+                // RunState + dispatcher dedicados por asset. Se despacha vía el dispatcher
+                // (no por OnHook directo) porque CurrentRelic tiene internal set y solo
+                // el dispatcher lo cablea antes de invocar al efecto.
+                RunState rs = new RunState();
+                RelicHookDispatcher disp = new RelicHookDispatcher(rs);
+                rs.Relics.Add(new RelicInstance(def, 0));
+
+                foreach (RelicHook hook in def.Hooks)
+                {
+                    RelicHookContext payload = BuildPayload(hook, rs, disp);
+                    // El dispatcher captura excepciones del efecto y las loguea como
+                    // LogError → NUnit falla el test (LogAssert). El DoesNotThrow cubre
+                    // además cualquier fallo en la construcción/recorrido del dispatch.
+                    Assert.DoesNotThrow(() => disp.Dispatch(hook, payload),
+                        $"{def.name}: el dispatch de {hook} lanzó una excepción no capturada.");
+                }
+            }
+        }
+
+        // Payload representativo por hook. TurnManager null: los Grant* hacen no-op por
+        // guard — lo que se valida es que el efecto maneje el hook declarado sin tirar.
+        private static RelicHookContext BuildPayload(RelicHook hook, RunState rs, RelicHookDispatcher disp)
+        {
+            switch (hook)
+            {
+                case RelicHook.OnCombatStart:
+                    return new CombatStartHookData(rs, null, disp, null);
+                case RelicHook.OnPlayerTurnStart:
+                    return new PlayerTurnStartHookData(rs, null, disp, TurnManager.WorldSide.A);
+                case RelicHook.OnDamageDealt:
+                    return new DamageDealtHookData(rs, null, disp, 10, Effectiveness.SuperEficaz, ElementType.Rojo, null);
+                case RelicHook.OnDamageTaken:
+                    return new DamageTakenHookData(rs, null, disp, 10, Effectiveness.SuperEficaz, ElementType.Rojo, null);
+                case RelicHook.OnWorldSwitch:
+                    return new WorldSwitchHookData(rs, null, disp, TurnManager.WorldSide.A, TurnManager.WorldSide.B);
+                case RelicHook.OnCombatEnd:
+                    return new CombatEndHookData(rs, null, disp, true, null, isBoss: true, isElite: true);
+                case RelicHook.OnCardPlayed:
+                    return new CardPlayedHookData(rs, null, disp, null, TurnManager.WorldSide.A, 0);
+                case RelicHook.OnCampfireOptionsBuilt:
+                    return new CampfireOptionsBuiltHookData(rs, disp, new List<CampfireOption>());
+                case RelicHook.OnShopStockBuilt:
+                    return new ShopStockBuiltHookData(rs, disp, new List<ShopItem>());
+                default:
+                    Assert.Fail($"Hook {hook} sin payload de prueba definido.");
+                    return null;
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/RelicAssetTests.cs.meta
+++ b/Assets/Tests/EditMode/RelicAssetTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2d1d45fef52eacc4a9490c7bb28f7b15

--- a/Assets/Tests/EditMode/RelicGrantEffectsOnTurnManagerTests.cs
+++ b/Assets/Tests/EditMode/RelicGrantEffectsOnTurnManagerTests.cs
@@ -1,0 +1,200 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using RoguelikeCardBattler.Gameplay.Cards;
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Gameplay.Enemies;
+using RoguelikeCardBattler.Gameplay.Relics;
+using RoguelikeCardBattler.Gameplay.Relics.Effects;
+using RoguelikeCardBattler.Gameplay.Relics.Hooks;
+using RoguelikeCardBattler.Run;
+
+namespace RoguelikeCardBattler.Tests.EditMode
+{
+    /// <summary>
+    /// T6 (auditoría 2026-06, SUB-PR 2): 10 casos de Retazos que usan la API Grant*
+    /// (GrantBlock / GrantStyleCharge / GrantHeal / GrantEnergy / GrantDrawCards)
+    /// disparados sobre un TurnManager REAL (no mock) y verificando que el estado de
+    /// combate muta como se espera. Cada hook se despacha a mano (no por el flujo de
+    /// combate completo): se construye el *HookData con el TurnManager real como
+    /// destinatario, de modo que ctx.GrantX delega en TurnManager.RelicGrantX y la
+    /// mutación real ocurre sobre el actor. Foco en la mutación de estado, no en la
+    /// animación.
+    ///
+    /// El dispatcher es uno dedicado por test (RunState propio): no se usa RunSession
+    /// porque su dispatcher se cablea en Awake, que no corre en EditMode. Lo único que
+    /// importa para Grant* es que el TurnManager del payload sea el real.
+    /// </summary>
+    public class RelicGrantEffectsOnTurnManagerTests : CombatTestBase
+    {
+        // ── Infra ──────────────────────────────────────────────────────────────
+
+        private EnemyDefinition DummyEnemy(int hp = 50)
+        {
+            return CreateEnemyDefinition("dummy", "Dummy", hp,
+                EnemyAIPattern.Sequence, new List<EnemyMove>(), ElementType.None);
+        }
+
+        private CardDefinition NoneCard(string id, int damage = 0, int cost = 0)
+        {
+            return CreateCardWithElement(id, CardType.Attack, CardTarget.SingleEnemy, cost,
+                ElementType.None, CreateEffect(EffectType.Damage, damage, EffectTarget.SingleEnemy));
+        }
+
+        private List<CardDeckEntry> Deck(int count)
+        {
+            var deck = new List<CardDeckEntry>();
+            for (int i = 0; i < count; i++)
+            {
+                deck.Add(CreateSingleCardEntry(NoneCard("card_" + i)));
+            }
+            return deck;
+        }
+
+        // TurnManager real e inicializado. ConfigureCombat permite override de HP
+        // (necesario para los casos de curación: arrancar por debajo del máximo).
+        private TurnManager CreateManager(List<CardDeckEntry> deck, EnemyDefinition enemy,
+            int maxHp = 30, int energy = 3, int startingHand = 1, int cardsPerTurn = 1, int? currentHp = null)
+        {
+            GameObject go = CreateGameObject("TurnManager");
+            TurnManager manager = AddComponent<TurnManager>(go);
+            manager.SetTestConfig(maxHp, energy, startingHand, cardsPerTurn);
+            manager.ConfigureCombat(deck, enemy,
+                playerCurrentHpOverride: currentHp,
+                playerMaxHpOverride: maxHp,
+                initializeImmediately: true);
+            return manager;
+        }
+
+        private static (RunState rs, RelicHookDispatcher disp) SetupRelic(IRelicEffect effect, params RelicHook[] hooks)
+        {
+            RelicDefinition def = ScriptableObject.CreateInstance<RelicDefinition>();
+            def.DisplayName = effect.GetType().Name;
+            def.Effect = effect;
+            def.Hooks = hooks;
+            RunState rs = new RunState();
+            RelicHookDispatcher disp = new RelicHookDispatcher(rs);
+            rs.Relics.Add(new RelicInstance(def, 0));
+            return (rs, disp);
+        }
+
+        // ── GrantBlock (×4) ──────────────────────────────────────────────────────
+
+        [Test] // R-OPEN-1
+        public void GrantBlock_OpenBlockOnCombatStart_GivesPlayerBlock()
+        {
+            TurnManager m = CreateManager(Deck(1), DummyEnemy());
+            Assert.AreEqual(0, m.PlayerBlock);
+            var (rs, disp) = SetupRelic(new RelicOpenBlockEffect { Amount = 4 }, RelicHook.OnCombatStart);
+            disp.Dispatch(RelicHook.OnCombatStart, new CombatStartHookData(rs, m, disp, null));
+            Assert.AreEqual(4, m.PlayerBlock);
+        }
+
+        [Test] // R-TURN-2
+        public void GrantBlock_TurnBlockOnPlayerTurnStart_GivesPlayerBlock()
+        {
+            TurnManager m = CreateManager(Deck(1), DummyEnemy());
+            var (rs, disp) = SetupRelic(new RelicTurnBlockEffect { Amount = 3 }, RelicHook.OnPlayerTurnStart);
+            disp.Dispatch(RelicHook.OnPlayerTurnStart, new PlayerTurnStartHookData(rs, m, disp, TurnManager.WorldSide.A));
+            Assert.AreEqual(3, m.PlayerBlock);
+        }
+
+        [Test] // R-SW-1
+        public void GrantBlock_SwitchBlockOnWorldSwitch_GivesPlayerBlock()
+        {
+            TurnManager m = CreateManager(Deck(1), DummyEnemy());
+            var (rs, disp) = SetupRelic(new RelicSwitchBlockEffect { Amount = 5 }, RelicHook.OnWorldSwitch);
+            disp.Dispatch(RelicHook.OnWorldSwitch, new WorldSwitchHookData(rs, m, disp, TurnManager.WorldSide.A, TurnManager.WorldSide.B));
+            Assert.AreEqual(5, m.PlayerBlock);
+        }
+
+        [Test] // R-BOSS-1
+        public void GrantBlock_BossLastStitchAfterVictory_GivesBlockOnNextCombatStart()
+        {
+            TurnManager m = CreateManager(Deck(1), DummyEnemy());
+            var (rs, disp) = SetupRelic(new RelicBossLastStitchEffect { EnergyBonus = 1, BlockBonus = 5 },
+                RelicHook.OnCombatEnd, RelicHook.OnCombatStart);
+            // Combate previo ganado → marca el flag interno (counter persiste en la instancia).
+            disp.Dispatch(RelicHook.OnCombatEnd, new CombatEndHookData(rs, m, disp, victory: true, null));
+            // Siguiente combate → consume el flag y otorga el bloqueo de remate.
+            disp.Dispatch(RelicHook.OnCombatStart, new CombatStartHookData(rs, m, disp, null));
+            Assert.AreEqual(5, m.PlayerBlock,
+                "Last-stitch otorga bloqueo al iniciar el combate siguiente tras una victoria.");
+        }
+
+        // ── GrantStyleCharge (×1) ─────────────────────────────────────────────────
+
+        [Test] // R-SW-2
+        public void GrantStyleCharge_SwitchStyleOnWorldSwitch_AddsCharge()
+        {
+            TurnManager m = CreateManager(Deck(1), DummyEnemy());
+            Assert.AreEqual(0, m.StyleCharges);
+            var (rs, disp) = SetupRelic(new RelicSwitchStyleChargeEffect { Amount = 1 }, RelicHook.OnWorldSwitch);
+            disp.Dispatch(RelicHook.OnWorldSwitch, new WorldSwitchHookData(rs, m, disp, TurnManager.WorldSide.A, TurnManager.WorldSide.B));
+            Assert.AreEqual(1, m.StyleCharges);
+        }
+
+        // ── GrantHeal (×2) ────────────────────────────────────────────────────────
+
+        [Test] // R-SW-3
+        public void GrantHeal_SwitchHealOnWorldSwitch_HealsPlayer()
+        {
+            TurnManager m = CreateManager(Deck(1), DummyEnemy(), maxHp: 30, currentHp: 10);
+            Assert.AreEqual(10, m.PlayerHP);
+            var (rs, disp) = SetupRelic(new RelicSwitchHealEffect { Amount = 2 }, RelicHook.OnWorldSwitch);
+            disp.Dispatch(RelicHook.OnWorldSwitch, new WorldSwitchHookData(rs, m, disp, TurnManager.WorldSide.A, TurnManager.WorldSide.B));
+            Assert.AreEqual(12, m.PlayerHP);
+        }
+
+        [Test] // R-ELITE-1
+        public void GrantHeal_VampiricOnSuperEffective_HealsPlayer()
+        {
+            TurnManager m = CreateManager(Deck(1), DummyEnemy(), maxHp: 30, currentHp: 10);
+            var (rs, disp) = SetupRelic(new RelicEliteVampiricEffect { Amount = 2 }, RelicHook.OnDamageDealt);
+            disp.Dispatch(RelicHook.OnDamageDealt,
+                new DamageDealtHookData(rs, m, disp, 10, Effectiveness.SuperEficaz, ElementType.Rojo, m.Enemy));
+            Assert.AreEqual(12, m.PlayerHP, "Vampírico cura al pegar un golpe SuperEficaz.");
+        }
+
+        // ── GrantEnergy (×1) ──────────────────────────────────────────────────────
+
+        [Test] // R-OPEN-3
+        public void GrantEnergy_OpenEnergyOnCombatStart_RestoresSpentEnergy()
+        {
+            // La energía arranca al máximo; se gasta 1 jugando una carta de costo 1
+            // (Update no corre en EditMode → no hay auto-end-turn que resetee energía).
+            var deck = new List<CardDeckEntry> { CreateSingleCardEntry(NoneCard("c", damage: 0, cost: 1)) };
+            TurnManager m = CreateManager(deck, DummyEnemy(), energy: 3, startingHand: 1);
+            m.PlayCard(m.PlayerHand[0]);
+            int energyBefore = m.PlayerEnergy; // 2
+
+            var (rs, disp) = SetupRelic(new RelicOpenEnergyEffect { Amount = 1 }, RelicHook.OnCombatStart);
+            disp.Dispatch(RelicHook.OnCombatStart, new CombatStartHookData(rs, m, disp, null));
+
+            Assert.AreEqual(energyBefore + 1, m.PlayerEnergy, "GrantEnergy restaura energía gastada.");
+        }
+
+        // ── GrantDrawCards (×2) ────────────────────────────────────────────────────
+
+        [Test] // R-OPEN-2
+        public void GrantDrawCards_OpenDrawOnCombatStart_AddsCardToHand()
+        {
+            // 3 cartas, mano inicial 1 → quedan 2 en el mazo para robar (mano < maxHandSize=7).
+            TurnManager m = CreateManager(Deck(3), DummyEnemy(), startingHand: 1, cardsPerTurn: 1);
+            int handBefore = m.PlayerHandCount; // 1
+            var (rs, disp) = SetupRelic(new RelicOpenDrawEffect { Amount = 1 }, RelicHook.OnCombatStart);
+            disp.Dispatch(RelicHook.OnCombatStart, new CombatStartHookData(rs, m, disp, null));
+            Assert.AreEqual(handBefore + 1, m.PlayerHandCount);
+        }
+
+        [Test] // R-TURN-1
+        public void GrantDrawCards_TurnDrawOnPlayerTurnStart_AddsCardToHand()
+        {
+            TurnManager m = CreateManager(Deck(3), DummyEnemy(), startingHand: 1, cardsPerTurn: 1);
+            int handBefore = m.PlayerHandCount; // 1
+            var (rs, disp) = SetupRelic(new RelicTurnDrawEffect { Amount = 1 }, RelicHook.OnPlayerTurnStart);
+            disp.Dispatch(RelicHook.OnPlayerTurnStart, new PlayerTurnStartHookData(rs, m, disp, TurnManager.WorldSide.A));
+            Assert.AreEqual(handBefore + 1, m.PlayerHandCount);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/RelicGrantEffectsOnTurnManagerTests.cs.meta
+++ b/Assets/Tests/EditMode/RelicGrantEffectsOnTurnManagerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2e24e5d4548c2844196a48888496ddf3

--- a/Assets/Tests/EditMode/StyleChargeTests.cs
+++ b/Assets/Tests/EditMode/StyleChargeTests.cs
@@ -1,0 +1,191 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using RoguelikeCardBattler.Gameplay.Cards;
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Gameplay.Enemies;
+using RoguelikeCardBattler.Gameplay.Relics;
+using RoguelikeCardBattler.Gameplay.Relics.Effects;
+using RoguelikeCardBattler.Gameplay.Relics.Hooks;
+using RoguelikeCardBattler.Run;
+
+namespace RoguelikeCardBattler.Tests.EditMode
+{
+    /// <summary>
+    /// Contrato del Contador de Estilo (golden rule §4) que la cirugía pre-M5 NO debe
+    /// romper (auditoría 2026-06, SUB-PR 2):
+    /// - T3: semántica PRE-block (D-A). Un golpe SuperEficaz otorga carga aunque el
+    ///   enemigo lo bloquee al 100% — el cargo se otorga en
+    ///   ApplyPlayerToEnemyEffectiveness cuando finalAmount &gt; 0, ANTES de que
+    ///   DamageAction aplique el bloqueo. Hoy PASA (congela comportamiento).
+    /// - T4: InitializeCombat resetea el estado de Estilo combat-local; los Counters
+    ///   de Retazos (RunState-level) NO se resetean → sangran (R-6, diferido al backlog).
+    /// - T7: invariante de cap a 5 (D-B). El fix vive en TurnManager.IncrementStyleCharges;
+    ///   T7-B FALLA sin el fix (las cargas crecen &gt;5 con un bonus pendiente).
+    /// </summary>
+    public class StyleChargeTests : CombatTestBase
+    {
+        // Assets SO creados localmente (los de la base se limpian en su propio TearDown).
+        private readonly List<UnityEngine.Object> _localAssets = new List<UnityEngine.Object>();
+
+        [TearDown]
+        public void CleanupLocalAssets()
+        {
+            foreach (UnityEngine.Object o in _localAssets)
+            {
+                if (o != null) UnityEngine.Object.DestroyImmediate(o);
+            }
+            _localAssets.Clear();
+        }
+
+        // ── Helpers ──────────────────────────────────────────────────────────
+
+        private TurnManager CreateManager(List<CardDeckEntry> deck, EnemyDefinition enemy,
+            int playerHp = 30, int energy = 3, int startingHand = 1, int cardsPerTurn = 1)
+        {
+            GameObject go = CreateGameObject("TurnManager");
+            TurnManager manager = AddComponent<TurnManager>(go);
+            manager.SetTestConfig(playerHp, energy, startingHand, cardsPerTurn);
+            manager.SetTestData(deck, enemy);
+            return manager;
+        }
+
+        private TurnManager CreateBareManager()
+        {
+            CardDefinition card = CreateCardWithElement("filler", CardType.Attack, CardTarget.SingleEnemy,
+                cost: 0, ElementType.None, CreateEffect(EffectType.Damage, 0, EffectTarget.SingleEnemy));
+            var deck = new List<CardDeckEntry> { CreateSingleCardEntry(card) };
+            EnemyDefinition enemy = CreateEnemyDefinition("dummy", "Dummy", 50,
+                EnemyAIPattern.Sequence, new List<EnemyMove>(), ElementType.None);
+            return CreateManager(deck, enemy);
+        }
+
+        // Enemigo con bloqueo inicial (BaseBlock) — necesario para el "bloqueo total" de T3.
+        // CombatTestBase.CreateEnemyDefinition hardcodea baseBlock=0, por eso el helper local.
+        private EnemyDefinition CreateBlockerEnemy(string id, int maxHp, int baseBlock, ElementType type)
+        {
+            EnemyDefinition enemy = ScriptableObject.CreateInstance<EnemyDefinition>();
+            enemy.SetDebugData(id, id, maxHp, baseBlock, EnemyAIPattern.Sequence,
+                null, null, 1f, null, type);
+            _localAssets.Add(enemy);
+            return enemy;
+        }
+
+        // Inscribe un efecto en un RunState dedicado con su dispatcher. El dispatcher
+        // setea CurrentRelic (internal set) → los hooks se despachan por él, no por
+        // OnHook directo. Espejo de RelicEffectsTests.Setup.
+        private static (RunState rs, RelicHookDispatcher disp) SetupRelic(IRelicEffect effect, params RelicHook[] hooks)
+        {
+            RelicDefinition def = ScriptableObject.CreateInstance<RelicDefinition>();
+            def.DisplayName = effect.GetType().Name;
+            def.Effect = effect;
+            def.Hooks = hooks;
+            RunState rs = new RunState();
+            RelicHookDispatcher disp = new RelicHookDispatcher(rs);
+            rs.Relics.Add(new RelicInstance(def, 0));
+            return (rs, disp);
+        }
+
+        // ── T3: PRE-block — un golpe SuperEficaz bloqueado al 100% igual da carga ──
+        [Test]
+        public void StyleCharge_SuperEffectiveHitFullyBlocked_StillGrantsCharge()
+        {
+            // Carta Rojo vs enemigo Azul = SuperEficaz. El enemigo arranca con 100 de
+            // bloqueo (BaseBlock) → absorbe el golpe entero (round(5*1.5)=8 ≤ 100).
+            // Bajo D-A (pre-block) el cargo se otorga igual: se aplica en
+            // ApplyPlayerToEnemyEffectiveness antes de que DamageAction aplique el bloqueo.
+            CardDefinition card = CreateCardWithElement("strike_rojo", CardType.Attack, CardTarget.SingleEnemy,
+                cost: 0, ElementType.Rojo, CreateEffect(EffectType.Damage, 5, EffectTarget.SingleEnemy));
+            var deck = new List<CardDeckEntry> { CreateSingleCardEntry(card) };
+            EnemyDefinition enemy = CreateBlockerEnemy("blocker_azul", maxHp: 20, baseBlock: 100, type: ElementType.Azul);
+
+            TurnManager manager = CreateManager(deck, enemy);
+            manager.InitializeCombat();
+            Assert.AreEqual(0, manager.StyleCharges);
+            int enemyHpBefore = manager.EnemyHP;
+
+            manager.PlayCard(manager.PlayerHand[0]);
+
+            Assert.AreEqual(1, manager.StyleCharges,
+                "Pre-block (D-A): el golpe SuperEficaz otorga carga aunque se bloquee al 100%.");
+            Assert.AreEqual(enemyHpBefore, manager.EnemyHP,
+                "El bloqueo de 100 absorbe el golpe entero (HP intacto) → confirma que fue bloqueo total.");
+        }
+
+        // ── T4: re-init resetea estado de Estilo; counters de Retazos sangran (R-6) ──
+        [Test]
+        public void InitializeCombat_SecondCall_ResetsStyleState_RelicCountersBleed()
+        {
+            TurnManager manager = CreateBareManager();
+            manager.InitializeCombat();
+            manager.SetStyleChargesForTest(4);
+            manager.SetBonusWorldSwitchesForTest(1);
+
+            // Segunda inicialización (nuevo combate de la misma run).
+            manager.InitializeCombat();
+
+            // El estado de Estilo (combat-local) SÍ se resetea (TurnManager.InitializeCombat).
+            Assert.AreEqual(0, manager.StyleCharges, "InitializeCombat resetea las cargas de Estilo.");
+            Assert.AreEqual(manager.MaxWorldSwitchesPerCombat, manager.TotalAvailableWorldSwitches,
+                "InitializeCombat resetea el switch bonus (no quedan switches extra del combate previo).");
+
+            // Los Counters de Retazos viven en RunState.Relics (run-level) y NADA en
+            // InitializeCombat los toca → sangran entre combates. R-6: conocido y
+            // diferido al backlog (plan pre-M4 §6). Este assert congela ese contrato.
+            var fx = new RelicTurnEnergyEveryNEffect { Period = 3, Amount = 1 };
+            var (rs, disp) = SetupRelic(fx, RelicHook.OnPlayerTurnStart);
+            RelicInstance inst = rs.Relics[0];
+            disp.Dispatch(RelicHook.OnPlayerTurnStart, new PlayerTurnStartHookData(rs, manager, disp, TurnManager.WorldSide.A));
+            disp.Dispatch(RelicHook.OnPlayerTurnStart, new PlayerTurnStartHookData(rs, manager, disp, TurnManager.WorldSide.A));
+            int counterBefore = inst.Counters["r-6:turns"]; // 2 (Period=3 aún no resetea)
+
+            manager.InitializeCombat();
+
+            Assert.AreEqual(counterBefore, inst.Counters["r-6:turns"],
+                "R-6: InitializeCombat NO resetea los Counters de Retazos (RunState-level) → sangran entre combates.");
+        }
+
+        // ── T7-A: overshoot desde estado limpio → 1 bonus + reset (sin leftover) ──
+        [Test]
+        public void GrantStyleCharge_OvershootFromCleanState_GrantsSingleBonusAndResets()
+        {
+            TurnManager manager = CreateBareManager();
+            manager.InitializeCombat();
+            manager.SetStyleChargesForTest(4);
+
+            // Un Retazo otorga +3 de una → 7, que supera 5 SIN bonus pendiente: se
+            // otorga 1 switch bonus y las cargas resetean a 0 (golden rule §4).
+            var (rs, disp) = SetupRelic(new RelicSwitchStyleChargeEffect { Amount = 3 }, RelicHook.OnWorldSwitch);
+            disp.Dispatch(RelicHook.OnWorldSwitch,
+                new WorldSwitchHookData(rs, manager, disp, TurnManager.WorldSide.A, TurnManager.WorldSide.B));
+
+            Assert.AreEqual(0, manager.StyleCharges, "Tras superar 5 sin bonus pendiente, las cargas resetean a 0.");
+            Assert.AreEqual(2, manager.TotalAvailableWorldSwitches, "Se otorga exactamente 1 switch bonus (base 1 + 1).");
+        }
+
+        // ── T7-B: overflow con bonus ya pendiente → cap a 5 (D-B). FALLA sin el fix ──
+        [Test]
+        public void GrantStyleCharge_OverflowWhileBonusPending_CapsAtFive()
+        {
+            TurnManager manager = CreateBareManager();
+            manager.InitializeCombat();
+            // Estado realista: el jugador ya llegó a 5 y tiene 1 switch bonus sin usar.
+            manager.SetBonusWorldSwitchesForTest(1);
+            manager.SetStyleChargesForTest(0);
+
+            // Con un bonus pendiente, la rama de reset de IncrementStyleCharges no dispara
+            // (_bonusWorldSwitches != 0). Sin el cap (D-B) las cargas crecerían sin techo
+            // vía Retazos. Otorgamos 6 → debe quedar topado en 5, nunca 6.
+            var (rs, disp) = SetupRelic(new RelicSwitchStyleChargeEffect { Amount = 1 }, RelicHook.OnWorldSwitch);
+            for (int i = 0; i < 6; i++)
+            {
+                disp.Dispatch(RelicHook.OnWorldSwitch,
+                    new WorldSwitchHookData(rs, manager, disp, TurnManager.WorldSide.A, TurnManager.WorldSide.B));
+            }
+
+            Assert.LessOrEqual(manager.StyleCharges, 5, "El Contador de Estilo nunca debe exceder 5 (D-B).");
+            Assert.AreEqual(5, manager.StyleCharges, "6 cargas con bonus pendiente quedan topadas en 5.");
+            Assert.AreEqual(2, manager.TotalAvailableWorldSwitches, "El bonus no se acumula (sigue 1, total 2).");
+        }
+    }
+}

--- a/Assets/Tests/EditMode/StyleChargeTests.cs.meta
+++ b/Assets/Tests/EditMode/StyleChargeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9ebce787cb34b5749ba46f56cf728bee

--- a/Docs/dev/GOLDEN_RULES.md
+++ b/Docs/dev/GOLDEN_RULES.md
@@ -116,9 +116,10 @@
 
 ### Reglas
 - El Contador de Estilo se reinicia a 0 al iniciar cada combate
-- **+1 carga** cuando un ataque del jugador hace dano SuperEficaz contra el enemigo
+- **+1 carga** cuando un ataque del jugador es SuperEficaz contra el enemigo. El bloqueo del enemigo NO anula la carga: se evalua sobre el dano calculado pre-bloqueo, asi que un SuperEficaz absorbido al 100% igual otorga carga (decision pre-block, 2026-06-14)
 - **-1 carga** cuando un ataque del enemigo hace dano SuperEficaz contra el tipo activo del jugador
 - El contador no baja de 0
+- El contador nunca supera **5**: si un efecto (p. ej. un Retazo) sumaria cargas por encima de 5, se dispara el bonus de las 5 una sola vez y el contador vuelve a 0 (nunca queda en 6+)
 - Al alcanzar **5 cargas**:
   - Se otorga 1 cambio de mundo adicional para ese combate
   - El contador se reinicia a 0
@@ -244,7 +245,7 @@
 
 ## 9. ACTOS Y DIFICULTAD (⏳ DD-011)
 
-- HP base del jugador: **70** al inicio de cada run. Sin maximo definido por diseno (lo limita la economia del run)
+- HP base del jugador: **60** al inicio de cada run. Sin maximo definido por diseno (lo limita la economia del run)
 - 3 actos. Cada acto incrementa HP enemigo, complejidad de patrones, mecanicas activas
 - **Acto 1**: enemigos con 1 tipo fijo, patrones simples (atacar, defender, cargar). Elites con 1 mecanica unica simple
 - **Acto 2**: enemigos con 2 tipos simultaneos, patrones con fases por umbral de HP. Aparecen enemigos transdimensionales. Elites combinan al menos 2 mecanicas
@@ -330,6 +331,6 @@
 
 ---
 
-> Ultima actualizacion: 2026-04-28 (post-GDD v2)
+> Ultima actualizacion: 2026-06-14 (DD pre-block + cap de Estilo a 5 + HP base 60; auditoria integral 2026-06)
 > Solo agregar reglas que esten cerradas por diseno o probadas en codigo.
 > Para decisiones de diseno abiertas, ver Docs/design/DESIGN_DECISIONS.md

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -10,15 +10,22 @@
 > **Fase actual:** M4 activo, reordenado 2026-06-10. Próximo paso: pulido pre-M4 (visor de mazo).
 > **Milestone activo:** M4 — Resto del Acto 1 (bloques: 4a integridad de cartas, 4b eventos+quests, 4c transdim+ancla)
 > **Próximo bloque:** M5 — Bosses con fases + Boss Acto 1 según GDD v2
-> **Última actualización:** 2026-06-16 (`modo:implementacion`: **SUB-PR 4 ✅ (#117) +
+> **Última actualización:** 2026-06-16 (`modo:implementacion`: **SUB-PR 2 ✅ (#120) CERRADO
+> → REMEDIACIÓN PRE-M4 COMPLETA**. Red de tests pre-cirugía + cap de Estilo a 5 (D-B). 4
+> archivos EditMode nuevos (T3 pre-block, T4 reset+sangrado R-6, T5 dispatchabilidad de los
+> 23 `.asset`, T6 ×10 Grant* sobre TurnManager real, T7 cap a 5, T9 carta None 90%): suite
+> **148 → 166**, archivos **18 → 22**. Fix D-B en el protegido `TurnManager.IncrementStyleCharges`
+> (clamp `> 5 → 5`; aprobado en hilo, hook toggleado y restaurado). **Los 6 sub-PRs de la
+> auditoría 2026-06 están cerrados.** Pendiente de Sebastián (hook bloquea): GOLDEN_RULES §4
+> (pre-block + cap a 5) y §9 (HP 70→60). Detalle en `audits/2026-06/PLAN_PRE_M4.md §SUB-PR 2`.)
+> **Previa:** 2026-06-16 (`modo:implementacion`: **SUB-PR 4 ✅ (#117) +
 > SUB-PR 5 ✅ (#118) CERRADOS** — paquetes docs (ii) verdad de Retazos y (iii) números/estado.
 > SUB-PR 4 (D7-D10): `RELICS.md` + `m3_hooks_spec.md` invierten la guía D7/D8 — mutación
 > directa de `PlayerCurrentHP` en OnCombatEnd es CORRECTA (sync Opción B), `Grant*` son
 > no-op ahí; + regla de orden de hooks + consecuencias D-A. SUB-PR 5 (D11-D14+D-C):
 > `_tech_snapshot` (108 scripts, TurnManager ~1098 LOC, suite 148, gh presente, CI parqueado,
 > gaps purgados) + `Combat/CLAUDE.md` (efectividad **bidireccional** DD-018) + 4 specs marcados
-> IMPLEMENTADO + campo Estado en plantilla + paso en /cierre-sesion. **Remediación pre-M4: solo
-> queda SUB-PR 2** (red de tests + cap Estilo a 5, requiere aprobación de edición de TurnManager).
+> IMPLEMENTADO + campo Estado en plantilla + paso en /cierre-sesion.
 > Detalle en `audits/2026-06/PLAN_PRE_M4.md §SUB-PR 4/5`.)
 > **Previa:** 2026-06-15 (`modo:implementacion`: **SUB-PR 3 CERRADO** —
 > docs paquete (i) Momentum → Estilo. Cierra D1/D2/D3/B11/T2/T6. `COMBAT_ARCHITECTURE.md`

--- a/Docs/dev/_tech_snapshot.md
+++ b/Docs/dev/_tech_snapshot.md
@@ -7,7 +7,19 @@
 > En `modo:implementacion` se lee OBLIGATORIAMENTE antes de cualquier cambio que
 > afecte arquitectura o componentes críticos.
 >
-> **Última actualización:** 2026-06-16 — **SUB-PR 5 auditoría: números y estado**
+> **Última actualización:** 2026-06-16 — **SUB-PR 2 auditoría: red de tests pre-cirugía
+> + cap de Estilo** (branch `feat/test-net-pre-surgery`). 4 archivos de test EditMode
+> nuevos (suite **148 → 166**, archivos **18 → 22**): `StyleChargeTests` (T3 pre-block /
+> T4 reset de estado + sangrado de counters R-6 / T7 cap a 5), `RelicAssetTests` (T5:
+> los 23 `.asset` de Retazos — cada hook declarado es despachable sin error),
+> `RelicGrantEffectsOnTurnManagerTests` (T6: 10 casos de Grant* sobre TurnManager real),
+> `NeutralCardDamageTests` (T9: carta None = 90% de daño, DD-002). **Fix D-B en el
+> protegido `TurnManager.IncrementStyleCharges`** (+8 líneas): clamp `else if
+> (_styleCharges > 5) _styleCharges = 5;` — antes solo `SetStyleChargesForTest`
+> clampaba; el path de producción acumulaba >5 vía Retazos con un switch bonus pendiente
+> (`TurnManager.cs` ahora **~1107 LOC**). Validado: compilación limpia, EditMode **166/166**.
+>
+> **Última actualización previa:** 2026-06-16 — **SUB-PR 5 auditoría: números y estado**
 > (branch `docs/numbers-and-state`). Refresh mecánico de cifras desviadas, sin
 > cambios de código: **108** scripts C# en `Assets/Scripts` (no 53); `TurnManager.cs`
 > **~1098 LOC** (no 735/~960 contradictorios); LOC de vistas de combate corridos
@@ -238,7 +250,7 @@
 
 ### Tests
 - **Unity Test Framework** (NUnit) en EditMode
-- 18 archivos de test en `Assets/Tests/EditMode/` (suite 148/148)
+- 22 archivos de test en `Assets/Tests/EditMode/` (suite 166/166)
 - Helper compartido: `CombatTestBase.cs`
 
 ---
@@ -380,7 +392,7 @@ Gameplay/
     CardEnums.cs                 ← CardType, EffectType, EffectTarget
     EffectRef.cs                 ← referencia a efecto en SO
   Combat/
-    TurnManager.cs               ← ~1098 loc — PROTEGIDO
+    TurnManager.cs               ← ~1107 loc — PROTEGIDO
     ActionQueue.cs               ← 85 loc — PROTEGIDO
     PlayerCombatActor.cs         ← 246 loc — PROTEGIDO
     EnemyCombatActor.cs
@@ -447,7 +459,7 @@ RelicSoGenerator.cs                   ← MenuItem "Roguelike/Generate Relic Ass
                                         (idempotente — saltea archivos existentes)
 ```
 
-### Tests (`Assets/Tests/EditMode/`) — 18 archivos (suite EditMode 148/148)
+### Tests (`Assets/Tests/EditMode/`) — 22 archivos (suite EditMode 166/166)
 
 ```
 CombatTestBase.cs                ← helper compartido
@@ -479,6 +491,17 @@ CardArtTests.cs                  ← Auditoría de arte C7 (5 casos: campo Art d
 CombatEndSyncTests.cs            ← Auditoría SUB-PR 1 (T1: el seam ApplyCombatResult
                                    no pisa el heal de Retazos OnCombatEnd; T2: el retry
                                    tras derrota con 0 HP restaura HP jugable)
+StyleChargeTests.cs              ← Auditoría SUB-PR 2 (T3 pre-block: golpe SuperEficaz
+                                   bloqueado al 100% igual da carga; T4 reset de estado
+                                   de Estilo en re-init + sangrado de counters R-6;
+                                   T7 cap a 5 / overshoot — D-B)
+RelicAssetTests.cs               ← Auditoría SUB-PR 2 (T5: carga los 23 .asset reales y
+                                   valida que cada hook declarado es despachable)
+RelicGrantEffectsOnTurnManagerTests.cs ← Auditoría SUB-PR 2 (T6: 10 casos de Grant*
+                                   —Block/StyleCharge/Heal/Energy/DrawCards— sobre un
+                                   TurnManager real, dispatch manual del hook)
+NeutralCardDamageTests.cs        ← Auditoría SUB-PR 2 (T9: carta None aplica 90% del
+                                   daño base, DD-002, contra cualquier tipo)
 ```
 
 ### ScriptableObjects (`Assets/ScriptableObjects/`)
@@ -508,7 +531,7 @@ aprobación explícita de Sebastián antes de proceder:
 
 | Archivo | LOC | Por qué está protegido |
 |---------|-----|------------------------|
-| `TurnManager.cs` | ~1098 | Flujo de turnos, efectividad, energía, Contador de Estilo, IA enemiga, world switch, hooks de Retazos (3A) + API delegada |
+| `TurnManager.cs` | ~1107 | Flujo de turnos, efectividad, energía, Contador de Estilo, IA enemiga, world switch, hooks de Retazos (3A) + API delegada |
 | `ActionQueue.cs` | 85 | Orden determinista de ejecución (FIFO) |
 | `PlayerCombatActor.cs` | 236 | Mecánicas del jugador en combate |
 

--- a/Docs/dev/audits/2026-06/PLAN_PRE_M4.md
+++ b/Docs/dev/audits/2026-06/PLAN_PRE_M4.md
@@ -100,24 +100,26 @@ H1). BattleFlowController y RunFlowController no son protegidos.
   OnCombatEnd es CORRECTA** (TurnManager sincroniza antes del dispatch), NO el patrón
   roto que asumía la "vía segura" vía `GrantHeal` (no-op por `IsCombatFinished`).
 
-### SUB-PR 2 — Red de tests pre-cirugía + cap de Estilo `feat/test-net-pre-surgery`
+### SUB-PR 2 — Red de tests pre-cirugía + cap de Estilo `feat/test-net-pre-surgery` ✅ CERRADO 2026-06-16
 
 **Cierra:** T3, T4, T5, T6, T7, T9 (los 6 tests pendientes del top 8) + el fix
-del cap a 5 (D-B) + suplentes opcionales.
+del cap a 5 (D-B).
 **Esfuerzo:** S-M (todos EditMode puros, verificados factibles uno a uno) + un
 fix chico en TurnManager.
 **Depende de:** D-A y D-B (ambas ya resueltas → desbloqueado).
-**Incluye 1 edición de archivo protegido** (cap a 5 en TurnManager) → Sebastián
-aprueba la edición en el hilo principal.
+**Incluyó 1 edición de archivo protegido** (cap a 5 en TurnManager) → aprobada por
+Sebastián en el hilo (hook protect-files toggleado temporalmente, restaurado al cerrar).
+**Validación:** compilación limpia, suite EditMode **166/166** (148 + 18 nuevos), corrida
+en vivo vía Unity-MCP.
 
-- `RelicAssets_AllDeclaredHooksAreDispatchable` (T5) — única validación datos↔código; carga los 23 `.asset` reales.
-- `RelicGrantEffects_OnRealTurnManager_MutateState` ×10 param. (T6) — media tabla de relics gana asserts de conducta.
-- `StyleCharge_SuperEffectiveHitFullyBlocked_StillGrantsCharge` (T3, **invertido por D-A**) — ratifica que el pre-block otorga carga aunque el golpe se bloquee al 100%. Hoy PASA (congela comportamiento).
-- `GrantStyleCharge_Overshoot_ResetsAndGrantsSingleBonus` (T7) — invariante de D-B (cap a 5). **Hoy FALLA** → documenta el bug; se arregla en este mismo PR con el cap en `TurnManager.cs:992-996`.
-- `InitializeCombat_SecondCall_ResetsStyleStateAndRelicCounters` (T4) — congela el contrato; documenta el counter que sangra (R-6).
-- `NeutralCard_Applies90PercentDamage` (T9) — regla de balance viva.
-- **Suplentes si hay apetito:** T8 (`InitializeDeck` ×2), T10 (round-trip de tipos).
-- **Propósito:** estos tests **congelan el comportamiento que la cirugía pre-M5 no debe romper.** Por eso van antes.
+- [x] `RelicAssets_AllDeclaredHooksAreDispatchable` (T5) — `RelicAssetTests.cs`. Carga los 23 `.asset` reales vía AssetDatabase y valida que cada hook declarado se despacha sin lanzar por el RelicHookDispatcher real (datos↔código).
+- [x] `RelicGrantEffects_OnRealTurnManager` ×10 (T6) — `RelicGrantEffectsOnTurnManagerTests.cs`. 10 casos de Grant* (Block ×4, StyleCharge ×1, Heal ×2, Energy ×1, DrawCards ×2) disparados con dispatch manual del hook sobre un TurnManager real; asserts sobre el estado de combate (bloque/cargas/HP/energía/mano).
+- [x] `StyleCharge_SuperEffectiveHitFullyBlocked_StillGrantsCharge` (T3, **D-A**) — `StyleChargeTests.cs`. Enemigo con BaseBlock=100 absorbe el golpe entero; el pre-block otorga carga igual. Pasa (congela comportamiento).
+- [x] `GrantStyleCharge_OverflowWhileBonusPending_CapsAtFive` (T7-B, **D-B**) — `StyleChargeTests.cs`. **Falló fail-first** (acumulaba 6) → arreglado con el clamp en `TurnManager.IncrementStyleCharges` (`else if (_styleCharges > 5) _styleCharges = 5;`). Acompañado de T7-A (`GrantStyleCharge_OvershootFromCleanState_GrantsSingleBonusAndResets`).
+- [x] `InitializeCombat_SecondCall_ResetsStyleState_RelicCountersBleed` (T4) — `StyleChargeTests.cs`. Congela el contrato: re-init resetea el estado de Estilo combat-local pero NO los Counters de Retazos (RunState-level) → documenta el sangrado R-6 (diferido).
+- [x] `NeutralCard_Applies90PercentDamage` (T9) — `NeutralCardDamageTests.cs` (×3 tipos enemigos). Regla de balance viva (DD-002). El 8º dispatch para cartas neutras depende de RunSession.RelicDispatcher (Awake, que no corre en EditMode) → verificado por código/Play.
+- **Nota:** suplentes T8/T10 NO se tomaron (alcance ya cubierto por los 6 del top 8).
+- **Propósito:** estos tests **congelan el comportamiento que la cirugía pre-M5 no debe romper.**
 
 ### SUB-PR 3 — Docs paquete (i): Momentum → Estilo `docs/momentum-to-style` ✅ CERRADO 2026-06-15
 


### PR DESCRIPTION
## Qué

SUB-PR 2 de la auditoría integral 2026-06 (`Docs/dev/audits/2026-06/PLAN_PRE_M4.md`): la **red de tests que congela el comportamiento de combate antes de la cirugía de TurnManager (pre-M5)** + el fix del cap de Estilo a 5 (decisión D-B).

Cierra los 6 tests pendientes del top 8 (**T3, T4, T5, T6, T7, T9**) y el bug D-B. Era el **único sub-PR pendiente** de la remediación pre-M4.

## Tests EditMode nuevos (suite **148 → 166**, archivos **18 → 22**)

| Archivo | Cubre |
|---|---|
| `StyleChargeTests.cs` | **T3** pre-block (D-A): un golpe SuperEficaz bloqueado al 100% igual otorga carga (enemigo con `BaseBlock=100` absorbe el golpe entero). **T4**: re-init resetea el estado de Estilo combat-local pero NO los Counters de Retazos (RunState-level) → documenta el sangrado **R-6** (diferido). **T7**: cap a 5 / overshoot (D-B). |
| `RelicAssetTests.cs` | **T5**: carga los **23 `.asset` reales** vía AssetDatabase y valida que cada hook declarado se despacha sin lanzar por el `RelicHookDispatcher` real (única validación datos↔código). |
| `RelicGrantEffectsOnTurnManagerTests.cs` | **T6**: 10 casos de la API `Grant*` (Block ×4, StyleCharge ×1, Heal ×2, Energy ×1, DrawCards ×2) disparados con **dispatch manual del hook sobre un TurnManager real**; asserts sobre el estado de combate. |
| `NeutralCardDamageTests.cs` | **T9**: carta `None` aplica **90%** del daño base (DD-002) contra cualquier tipo. |

## Fix D-B (archivo protegido)

`TurnManager.IncrementStyleCharges` ganó un clamp:

```csharp
else if (_styleCharges > 5)
{
    _styleCharges = 5;
}
```

Antes solo `SetStyleChargesForTest` clampaba; el **path de producción acumulaba >5** vía Retazos cuando ya había un switch bonus pendiente (la rama de reset no dispara con `_bonusWorldSwitches != 0`). `T7-B` documenta el bug (fail-first: acumulaba 6) y queda verde con el fix.

Edición del protegido **aprobada por Sebastián en el hilo** (hook `protect-files` toggleado temporalmente y restaurado al cerrar; `settings.json` sin cambio neto).

## Validación

- Compilación limpia.
- **EditMode 166/166** corrida en vivo vía Unity-MCP.

## Nota

El 8º dispatch (OnDamageDealt también para cartas neutras) depende de `RunSession.RelicDispatcher`, cableado en `Awake` — que NO corre al `AddComponent` en EditMode. Esa rama queda verificada por código (`TurnManager` ~611-620) / Play; T9 congela la regla del 90%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)