### PR TITLE
chore(hooks): protect-files block → confirmación (ask)

### DIFF
--- a/.claude/hooks/protect-files.js
+++ b/.claude/hooks/protect-files.js
@@ -1,32 +1,30 @@
 #!/usr/bin/env node
 /**
- * PreToolUse hook — protege archivos criticos del proyecto.
+ * PreToolUse hook — precaucion sobre archivos criticos del proyecto.
  *
- * Bloquea las escrituras sobre archivos que, segun CLAUDE.md, NO se modifican
- * sin aprobacion explicita de Sebastian:
+ * Estos archivos, segun CLAUDE.md, no se tocan a la ligera:
  *   - 3 archivos de combate (arquitectura sensible)
- *   - 3 docs que solo Sebastian edita (GOLDEN_RULES, GDD, DESIGN_DECISIONS)
- *   - el propio hook (evita auto-desenganche silencioso; ver nota abajo)
+ *   - 3 docs de autoridad (GOLDEN_RULES, GDD, DESIGN_DECISIONS)
+ *   - el propio hook
+ *
+ * Modelo (cambiado 2026-06-16 a pedido de Sebastian): NO bloquea de forma dura.
+ * Devuelve la decision de permiso "ask" -> Claude Code muestra un prompt de
+ * confirmacion (allow/deny) en el momento. Si Sebastian aprueba, el agente edita;
+ * si no, se cancela. La idea es que el agente edite por Sebastian con una
+ * precaucion visible, no que Sebastian tenga que editar a mano. Antes el hook
+ * hacia `exit 2` (bloqueo duro); eso obligaba al baile de desenganche o a edicion
+ * manual, friccion que Sebastian decidio sacar.
  *
  * Cubre DOS superficies de escritura:
  *   1. Edit / Write / MultiEdit / NotebookEdit  -> via tool_input.file_path.
  *   2. Bash con comandos del plugin Unity-MCP (`script-update-or-create`,
  *      `script-delete`) que sobreescriben/borran .cs en disco SIN pasar por
- *      Edit/Write. Sin este matcher, `npx unity-mcp-cli run-tool
- *      script-update-or-create ... TurnManager.cs` editaba un protegido sin
- *      prompt ni hook (agujero T1 de la auditoria integral 2026-06).
+ *      Edit/Write (vector T1 de la auditoria integral 2026-06). Sigue cubierto:
+ *      tambien pide confirmacion.
  *
  * Mecanismo: lee el JSON del tool call por stdin; si el target apunta a un
- * archivo protegido, sale con codigo 2 (bloquea la herramienta y devuelve el
- * mensaje a Claude por stderr).
- *
- * Riesgo residual conocido: el agente podria editar .claude/settings.json para
- * desenganchar el hook y luego editar un protegido. Eso ya NO es silencioso —
- * es una accion deliberada, visible en el diff y revisable. settings.json NO se
- * protege a proposito (lo necesita el flujo update-config).
- *
- * Override puntual: si Sebastian autoriza editar uno de estos archivos, comenta
- * temporalmente el hook en .claude/settings.json o pidele que edite el a mano.
+ * archivo protegido, emite por stdout la decision "ask" y sale con codigo 0.
+ * Si no toca un protegido, sale 0 sin opinar (flujo de permisos normal).
  */
 
 const PROTECTED = [
@@ -40,14 +38,13 @@ const PROTECTED = [
 ];
 
 // Comandos del plugin Unity-MCP que escriben/borran .cs en disco SIN pasar por
-// Edit/Write. Si aparecen en un Bash junto a un archivo protegido, se bloquea.
+// Edit/Write. Si aparecen en un Bash junto a un archivo protegido, se confirma.
 const MCP_WRITE_TOOLS = ['script-update-or-create', 'script-delete'];
 
 // Anclado a la forma REAL de invocacion del CLI (`run-tool <write-tool>`). Asi
-// no se bloquean comandos que solo MENCIONAN el token en prosa (mensajes de
-// commit, echo, armar payloads de test) — over-block que mordia hasta el commit
-// de este propio cambio. El CLI siempre pasa por `run-tool <tool>`, asi que esto
-// sigue siendo agnostico al prefijo (npx / npx --yes ...@latest / binario pelado).
+// no se confirma por comandos que solo MENCIONAN el token en prosa (mensajes de
+// commit, echo, armar payloads de test). El CLI siempre pasa por `run-tool <tool>`,
+// asi que esto sigue siendo agnostico al prefijo (npx / npx --yes ...@latest / binario).
 const MCP_WRITE_RE = new RegExp(`run-tool\\s+(${MCP_WRITE_TOOLS.join('|')})\\b`);
 
 function norm(p) {
@@ -60,14 +57,20 @@ function basename(p) {
   return i >= 0 ? n.slice(i + 1) : n;
 }
 
-function blocked(hit) {
-  process.stderr.write(
-    `BLOQUEADO por hook protect-files: "${hit}" es un archivo protegido ` +
-      `(ver CLAUDE.md > Sobre archivos). NO lo edites sin aprobacion explicita ` +
-      `de Sebastian. Si ya la tenes, pedile que confirme y desactive el hook ` +
-      `temporalmente, o que aplique el cambio a mano.`
-  );
-  process.exit(2);
+function ask(hit) {
+  // Decision de permiso "ask": Claude Code pide confirmacion a Sebastian antes
+  // de ejecutar la herramienta. No bloquea de forma dura.
+  const out = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'ask',
+      permissionDecisionReason:
+        `"${hit}" es un archivo protegido (ver CLAUDE.md > Sobre archivos). ` +
+        `Confirma con Sebastian antes de editarlo.`,
+    },
+  };
+  process.stdout.write(JSON.stringify(out));
+  process.exit(0);
 }
 
 let raw = '';
@@ -79,14 +82,14 @@ process.stdin.on('end', () => {
     const data = JSON.parse(raw || '{}');
     ti = data.tool_input || {};
   } catch (_) {
-    process.exit(0); // si no se puede parsear, no bloquear
+    process.exit(0); // si no se puede parsear, no opinar
   }
 
   // Superficie 1: Edit/Write/MultiEdit/NotebookEdit -> path directo.
   const target = norm(ti.file_path || ti.notebook_path || ti.path || '');
   if (target) {
     const hit = PROTECTED.find((p) => target.endsWith(norm(p)));
-    if (hit) blocked(hit);
+    if (hit) ask(hit);
   }
 
   // Superficie 2: Bash -> comandos del plugin Unity-MCP que escriben/borran .cs.
@@ -95,7 +98,7 @@ process.stdin.on('end', () => {
     const hit = PROTECTED.find(
       (p) => command.includes(norm(p)) || command.includes(basename(p))
     );
-    if (hit) blocked(hit);
+    if (hit) ask(hit);
   }
 
   process.exit(0);


### PR DESCRIPTION
## Qué

A pedido de Sebastián: el hook `protect-files` deja de **bloquear de forma dura** (`exit 2`) y pasa a **pedir confirmación** — devuelve la decisión de permiso `"ask"`, así Claude Code muestra un prompt allow/deny en el momento. Claude edita el protegido tras el OK; Sebastián ya no tiene que editar a mano ni hacer el baile de desenganchar el hook.

## Por qué

El valor de tener al agente es que **edite por Sebastián**, con una precaución visible — no un muro. El modelo viejo (hard-block de SUB-PR 6) generaba fricción (edición manual / toggle del hook). `"ask"` mantiene la precaución (confirmación explícita, visible en diff) sin la fricción.

## Alcance

- Los 7 protegidos (3 de combate + GOLDEN_RULES/_gdd/DESIGN_DECISIONS + el propio hook) → ahora piden confirmación.
- El vector MCP (`run-tool script-update-or-create`/`script-delete` sobre un protegido) → también pide confirmación. Sigue cubierto y no silencioso (el agujero T1 que cerró SUB-PR 6 sigue cerrado, ahora con confirmación en vez de bloqueo).
- Sin falsos positivos: comandos que solo mencionan el token en prosa no disparan nada.

## Pendiente (fuera de este PR)

`CLAUDE.md` raíz (sección "Sobre archivos") y, si aplica, docs en `Docs/dev/modes/` todavía describen el modelo de bloqueo duro — los actualiza Sebastián (CLAUDE.md raíz es suyo por convención).

🤖 Generated with [Claude Code](https://claude.com/claude-code)