### PR TITLE
feat(ui): visor de mazo — DeckViewerView (pulido pre-M4)

### DIFF
--- a/Assets/Scripts/Gameplay/Cards/CardDisplay.cs
+++ b/Assets/Scripts/Gameplay/Cards/CardDisplay.cs
@@ -1,0 +1,76 @@
+using RoguelikeCardBattler.Gameplay.Combat;
+
+namespace RoguelikeCardBattler.Gameplay.Cards
+{
+    /// <summary>
+    /// Hogar canónico de los helpers de presentación de cartas en texto (token de
+    /// tipo coloreado, carta representante de una entry, criterio de label dual).
+    /// Esta lógica vivía duplicada como `private static` en ShopNodeController y
+    /// CampfireNodeController (BuildCardSelectLabel / CardToken / RepresentativeCard);
+    /// el visor de mazo la extrae acá para NO crear una tercera copia que arrastre
+    /// el drift (decisión del spec del visor, §Reuso).
+    ///
+    /// Migrar ShopNodeController/CampfireNodeController a consumir estos métodos es
+    /// follow-up FUERA de scope del visor (anotado en `_roadmap.md` Future work):
+    /// tocaría sus tests y no aporta al visor. Por ahora este es el único consumidor.
+    /// </summary>
+    public static class CardDisplay
+    {
+        /// <summary>
+        /// Carta representante de una entry, usada para orden/coste/tipo. Single →
+        /// la propia carta; dual → SideA con fallback a SideB (tolera SideA null).
+        /// Devuelve null si la entry no tiene ninguna carta resoluble.
+        /// </summary>
+        public static CardDefinition RepresentativeCard(CardDeckEntry entry)
+        {
+            if (entry == null) return null;
+            if (entry.SingleCard != null) return entry.SingleCard;
+            if (entry.DualCard != null) return entry.DualCard.SideA ?? entry.DualCard.SideB;
+            return null;
+        }
+
+        /// <summary>
+        /// Token rich-text "[Tipo] Nombre" de un lado (color del tipo vía
+        /// ElementTypeColors.TypePrefix). Tipo None ⇒ solo el nombre (sin token de
+        /// color). Lado null ⇒ "?" (nunca lanza NRE).
+        /// </summary>
+        public static string CardToken(CardDefinition card)
+        {
+            if (card == null) return "?";
+            string prefix = ElementTypeColors.TypePrefix(card.ElementType);
+            return string.IsNullOrEmpty(prefix) ? card.CardName : $"{prefix} {card.CardName}";
+        }
+
+        /// <summary>Tipo elemental de un lado, null-safe (null ⇒ None).</summary>
+        public static ElementType SideType(CardDefinition card) =>
+            card != null ? card.ElementType : ElementType.None;
+
+        /// <summary>
+        /// Token combinado de una entry sin coste ni marcadores. Single ⇒ su token;
+        /// dual ⇒ "[TipoA] NombreA / [TipoB] NombreB", que colapsa a un solo token
+        /// SOLO si nombre Y tipo coinciden en ambos lados no-null (mismo criterio que
+        /// ShopNodeController.BuildCardSelectLabel). Lados null se renderizan "?" y
+        /// nunca colapsan. Nunca lanza NRE.
+        /// </summary>
+        public static string EntryToken(CardDeckEntry entry)
+        {
+            if (entry == null || !entry.IsValid) return "";
+            if (entry.DualCard != null)
+            {
+                CardDefinition a = entry.DualCard.SideA;
+                CardDefinition b = entry.DualCard.SideB;
+                string tokenA = CardToken(a);
+                string tokenB = CardToken(b);
+                bool sameName = NameOf(a) == NameOf(b);
+                bool sameType = SideType(a) == SideType(b);
+                bool bothNonNull = a != null && b != null;
+                return (sameName && sameType && bothNonNull) ? tokenA : $"{tokenA} / {tokenB}";
+            }
+            return entry.SingleCard != null ? CardToken(entry.SingleCard) : "";
+        }
+
+        // Nombre de un lado, null-safe (null ⇒ "?"), usado por el criterio de colapso.
+        private static string NameOf(CardDefinition card) =>
+            card != null ? card.CardName : "?";
+    }
+}

--- a/Assets/Scripts/Gameplay/Cards/CardDisplay.cs.meta
+++ b/Assets/Scripts/Gameplay/Cards/CardDisplay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d57ac46ed29ce3c428ad0394ad417a7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Gameplay/Cards/UI.meta
+++ b/Assets/Scripts/Gameplay/Cards/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ebf2aadd94a519546afe1b4f45a3a401
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Cards/UI/DeckViewerView.cs
+++ b/Assets/Scripts/Gameplay/Cards/UI/DeckViewerView.cs
@@ -1,0 +1,638 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+using RoguelikeCardBattler.Core.UI;
+using RoguelikeCardBattler.Gameplay.Combat;
+
+namespace RoguelikeCardBattler.Gameplay.Cards.UI
+{
+    /// <summary>
+    /// Vista de solo lectura del mazo completo del run. Clase de presentación pura
+    /// (no MonoBehaviour) — molde de RelicInventoryView. Crea un sub-Canvas overlay
+    /// propio (sortingOrder=100) que flota sobre cualquier panel opaco (Tienda,
+    /// Hoguera) en RunScene y sobre el HUD de combate en BattleScene.
+    /// Montada por RunFlowController (RunScene) y CombatUIController (BattleScene).
+    /// Helpers static puros (SortForDisplay/BuildRowLabel/BuildTooltip/BuildUpgradePreview)
+    /// son testeables sin UI, siguiendo el patrón de ShopNodeController.BuildStock.
+    /// </summary>
+    public class DeckViewerView
+    {
+        private static readonly Color DimmerColor      = new Color(0f,    0f,    0f,    0.78f);
+        private static readonly Color PanelBg          = new Color(0.07f, 0.07f, 0.11f, 0.97f);
+        private static readonly Color BadgeBg          = new Color(0.12f, 0.12f, 0.20f, 0.92f);
+        private static readonly Color RowEven          = new Color(0.10f, 0.10f, 0.15f, 0.88f);
+        private static readonly Color RowOdd           = new Color(0.07f, 0.07f, 0.11f, 0.88f);
+        private static readonly Color TooltipBg        = new Color(0.04f, 0.04f, 0.06f, 0.97f);
+        private static readonly Color TextColor        = new Color(1f,    0.95f, 0.85f, 1f);
+
+        private readonly Font  _font;
+        private readonly Canvas _subCanvas;
+
+        private Button _badgeButton;
+        private Text   _badgeLabel;
+
+        private RectTransform      _modalOverlay;
+        private Text               _modalTitle;
+        private RectTransform      _scrollContent;
+        private readonly List<GameObject> _rowGos = new List<GameObject>();
+
+        private GameObject  _tooltipGo;
+        private CanvasGroup _tooltipGroup;
+        private Text        _tooltipText;
+        private RectTransform _tooltipRect;
+
+        private IReadOnlyList<CardDeckEntry> _cachedDeck;
+        private bool _isOpen;
+
+        private static Sprite _whiteSprite;
+
+        // ────────────────────────────────────────
+        // Construcción
+        // ────────────────────────────────────────
+
+        public DeckViewerView(Canvas hostCanvas, Font font)
+        {
+            _font = font;
+
+            // Sub-Canvas overlay independiente: flota sobre paneles opacos de la
+            // escena sin necesitar coordinación con cada controller de nodo.
+            GameObject canvasGo = new GameObject("DeckViewerCanvas",
+                typeof(RectTransform), typeof(Canvas), typeof(GraphicRaycaster));
+            canvasGo.transform.SetParent(hostCanvas.transform, false);
+
+            RectTransform canvasRt = canvasGo.GetComponent<RectTransform>();
+            canvasRt.anchorMin = Vector2.zero;
+            canvasRt.anchorMax = Vector2.one;
+            canvasRt.offsetMin = Vector2.zero;
+            canvasRt.offsetMax = Vector2.zero;
+
+            _subCanvas = canvasGo.GetComponent<Canvas>();
+            _subCanvas.overrideSorting = true;
+            _subCanvas.sortingOrder   = 100;
+
+            RectTransform subRect = (RectTransform)_subCanvas.transform;
+            BuildBadge(subRect);
+            BuildModal(subRect);
+            BuildTooltipGo(subRect);
+        }
+
+        // ────────────────────────────────────────
+        // API pública de instancia
+        // ────────────────────────────────────────
+
+        /// <summary>
+        /// Actualiza el badge y, si el modal está abierto, reconstruye la lista.
+        /// Null-safe: deck == null → badge "Mazo (0)", lista vacía, sin excepción.
+        /// </summary>
+        public void Refresh(IReadOnlyList<CardDeckEntry> deck)
+        {
+            _cachedDeck = deck;
+            UpdateBadgeText();
+            if (_isOpen) RebuildList();
+        }
+
+        public void Open()
+        {
+            _isOpen = true;
+            if (_modalOverlay != null) _modalOverlay.gameObject.SetActive(true);
+            UpdateBadgeText();
+            RebuildList();
+        }
+
+        public void Close()
+        {
+            _isOpen = false;
+            if (_modalOverlay != null) _modalOverlay.gameObject.SetActive(false);
+            HideTooltip();
+            UpdateBadgeText();
+        }
+
+        public void Toggle()
+        {
+            if (_isOpen) Close(); else Open();
+        }
+
+        /// <summary>
+        /// Destruye los GameObjects del overlay (llamado por los owners en transiciones
+        /// de escena, espejo de RelicInventoryView.Cleanup).
+        /// </summary>
+        public void Cleanup()
+        {
+            if (_subCanvas != null)
+                UnityEngine.Object.Destroy(_subCanvas.gameObject);
+        }
+
+        // ────────────────────────────────────────
+        // Helpers static puros — testeables sin UI
+        // ────────────────────────────────────────
+
+        /// <summary>
+        /// Devuelve una lista NUEVA ordenada por CardType→coste→nombre→id.
+        /// No muta la entrada. Orden estable (LINQ OrderBy/ThenBy).
+        /// Filtra entradas inválidas y duales con ambos lados null.
+        /// </summary>
+        public static List<CardDeckEntry> SortForDisplay(IReadOnlyList<CardDeckEntry> deck)
+        {
+            if (deck == null) return new List<CardDeckEntry>();
+
+            return deck
+                .Where(e => e != null && e.IsValid && RepresentativeCard(e) != null)
+                .OrderBy(e =>  (int)RepresentativeCard(e).Type)
+                .ThenBy(e =>  RepresentativeCard(e).Cost)
+                .ThenBy(e =>  RepresentativeCard(e).CardName)
+                .ThenBy(e =>  RepresentativeCard(e).Id)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Línea de fila con rich-text: [Tipo] Nombre · coste⚡ + marcador ★/+.
+        /// Duales: ambos lados; colapsa a un token solo si nombre Y tipo coinciden
+        /// en ambos lados no-null. Lados null → "?". Nunca lanza NRE.
+        /// </summary>
+        public static string BuildRowLabel(CardDeckEntry entry)
+        {
+            if (entry == null || !entry.IsValid) return "";
+
+            string body;
+            if (entry.DualCard != null)
+            {
+                CardDefinition a   = entry.DualCard.SideA;
+                CardDefinition b   = entry.DualCard.SideB;
+                string tokenA      = CardToken(a);
+                string tokenB      = CardToken(b);
+                bool sameName      = NameOf(a) == NameOf(b);
+                bool sameType      = SideType(a) == SideType(b);
+                bool bothNonNull   = a != null && b != null;
+                string display     = (sameName && sameType && bothNonNull) ? tokenA : $"{tokenA} / {tokenB}";
+
+                CardDefinition rep = RepresentativeCard(entry);
+                body = rep != null ? $"{display} · {rep.Cost}⚡" : display;
+            }
+            else
+            {
+                CardDefinition c = entry.SingleCard;
+                body = c != null ? $"{CardToken(c)} · {c.Cost}⚡" : "";
+            }
+
+            string marker = entry.IsUpgraded    ? " ★"
+                          : entry.CanUpgrade()  ? " +"
+                          :                       "";
+            return body + marker;
+        }
+
+        /// <summary>
+        /// Cuerpo del tooltip: por lado tipo/nombre/coste/descripción + bloque de
+        /// preview de mejora al final. Nunca lanza NRE.
+        /// </summary>
+        public static string BuildTooltip(CardDeckEntry entry)
+        {
+            if (entry == null || !entry.IsValid) return "";
+
+            var sb = new StringBuilder();
+            if (entry.DualCard != null)
+            {
+                AppendSideTooltip(sb, entry.DualCard.SideA, "A");
+                sb.AppendLine();
+                AppendSideTooltip(sb, entry.DualCard.SideB, "B");
+            }
+            else
+            {
+                AppendSideTooltip(sb, entry.SingleCard, null);
+            }
+
+            string preview = BuildUpgradePreview(entry);
+            if (!string.IsNullOrEmpty(preview))
+            {
+                sb.AppendLine();
+                sb.Append(preview);
+            }
+            return sb.ToString().TrimEnd();
+        }
+
+        /// <summary>
+        /// Bloque de preview de mejora.
+        /// ""              → no hay mejora configurada.
+        /// "★ Mejorada"    → ya se aplicó la mejora.
+        /// "Mejora ▸ ..."  → muestra en qué se convertiría la carta.
+        ///                   En duales: PER-LADO — coincide con CreateUpgradedClone()
+        ///                   (solo mejora el lado con HasUpgrade; el otro sin cambios).
+        /// Lee CardUpgradeDef directo, nunca llama CreateUpgradedClone.
+        /// </summary>
+        public static string BuildUpgradePreview(CardDeckEntry entry)
+        {
+            if (entry == null || !entry.IsValid) return "";
+            if (entry.IsUpgraded) return "★ Mejorada";
+
+            if (entry.DualCard != null)
+            {
+                CardDefinition a  = entry.DualCard.SideA;
+                CardDefinition b  = entry.DualCard.SideB;
+                bool aHas = a != null && a.Upgrade != null && a.Upgrade.HasUpgrade;
+                bool bHas = b != null && b.Upgrade != null && b.Upgrade.HasUpgrade;
+                if (!aHas && !bHas) return "";
+
+                var sb = new StringBuilder("Mejora ▸\n");
+                sb.AppendLine(BuildSideUpgradeSnippet(a, aHas));
+                sb.Append(BuildSideUpgradeSnippet(b, bHas));
+                return sb.ToString().TrimEnd();
+            }
+            else
+            {
+                CardDefinition c = entry.SingleCard;
+                if (c == null || c.Upgrade == null || !c.Upgrade.HasUpgrade) return "";
+                return "Mejora ▸\n" + BuildSideUpgradeSnippet(c, true);
+            }
+        }
+
+        // ────────────────────────────────────────
+        // Helpers estáticos internos
+        // ────────────────────────────────────────
+
+        /// <summary>
+        /// Carta representante para orden/coste/tipo. Espejo de ShopNodeController.
+        /// Fallback SideA → SideB para duales con SideA null.
+        /// </summary>
+        private static CardDefinition RepresentativeCard(CardDeckEntry entry)
+        {
+            if (entry == null) return null;
+            if (entry.SingleCard != null) return entry.SingleCard;
+            if (entry.DualCard   != null) return entry.DualCard.SideA ?? entry.DualCard.SideB;
+            return null;
+        }
+
+        // Token rich-text "[Tipo] Nombre" para un lado. null → "?".
+        private static string CardToken(CardDefinition c)
+        {
+            if (c == null) return "?";
+            string prefix = ElementTypeColors.TypePrefix(c.ElementType);
+            return string.IsNullOrEmpty(prefix) ? c.CardName : $"{prefix} {c.CardName}";
+        }
+
+        private static ElementType SideType(CardDefinition c) =>
+            c != null ? c.ElementType : ElementType.None;
+
+        private static string NameOf(CardDefinition c) =>
+            c != null ? c.CardName : "?";
+
+        private static void AppendSideTooltip(StringBuilder sb, CardDefinition c, string sideLabel)
+        {
+            if (c == null)
+            {
+                if (sideLabel != null) sb.AppendLine($"[{sideLabel}] ?");
+                return;
+            }
+            string prefix = sideLabel != null ? $"[{sideLabel}] " : "";
+            string typeToken = ElementTypeColors.TypePrefix(c.ElementType);
+            string header = string.IsNullOrEmpty(typeToken)
+                ? $"{prefix}{c.CardName} · {c.Cost}⚡"
+                : $"{prefix}{typeToken} {c.CardName} · {c.Cost}⚡";
+            sb.AppendLine($"<b>{header}</b>");
+            if (!string.IsNullOrEmpty(c.Description))
+                sb.AppendLine(c.Description);
+        }
+
+        // Snippet de un lado en el bloque "Mejora ▸".
+        // hasUpgrade=true  → valores mejorados.
+        // hasUpgrade=false → lado sin cambios (mostrar igual que un "upgraded" pero con valores base).
+        private static string BuildSideUpgradeSnippet(CardDefinition c, bool hasUpgrade)
+        {
+            if (c == null) return "?";
+            if (!hasUpgrade)
+            {
+                // Lado no afectado por el upgrade; se muestra sin cambios.
+                string p = ElementTypeColors.TypePrefix(c.ElementType);
+                string h = string.IsNullOrEmpty(p) ? $"{c.CardName} · {c.Cost}⚡" : $"{p} {c.CardName} · {c.Cost}⚡";
+                return string.IsNullOrEmpty(c.Description) ? h : $"{h}\n{c.Description}";
+            }
+            CardUpgradeDef u    = c.Upgrade;
+            string name         = !string.IsNullOrEmpty(u.UpgradedName)        ? u.UpgradedName        : c.CardName + "+";
+            string desc         = !string.IsNullOrEmpty(u.UpgradedDescription) ? u.UpgradedDescription : c.Description;
+            int    cost         = u.OverrideCost ? u.UpgradedCost : c.Cost;
+            string p2           = ElementTypeColors.TypePrefix(c.ElementType);
+            string header       = string.IsNullOrEmpty(p2) ? $"{name} · {cost}⚡" : $"{p2} {name} · {cost}⚡";
+            return string.IsNullOrEmpty(desc) ? header : $"{header}\n{desc}";
+        }
+
+        // ────────────────────────────────────────
+        // Instancia — lógica interna de UI
+        // ────────────────────────────────────────
+
+        private void UpdateBadgeText()
+        {
+            int count = _cachedDeck != null ? _cachedDeck.Count : 0;
+            if (_badgeLabel  != null) _badgeLabel.text  = $"Mazo ({count})";
+            if (_modalTitle  != null) _modalTitle.text  = $"Mazo ({count})";
+        }
+
+        private void RebuildList()
+        {
+            foreach (GameObject go in _rowGos)
+                if (go != null) UnityEngine.Object.Destroy(go);
+            _rowGos.Clear();
+
+            List<CardDeckEntry> sorted = SortForDisplay(_cachedDeck);
+            for (int i = 0; i < sorted.Count; i++)
+                AddRow(sorted[i], i);
+        }
+
+        private void AddRow(CardDeckEntry entry, int index)
+        {
+            GameObject rowGo = new GameObject($"Row_{index}",
+                typeof(RectTransform), typeof(Image), typeof(LayoutElement), typeof(EventTrigger));
+            rowGo.transform.SetParent(_scrollContent, false);
+
+            LayoutElement le    = rowGo.GetComponent<LayoutElement>();
+            le.preferredHeight  = 50f;
+            le.minHeight        = 40f;
+            le.flexibleWidth    = 1f;
+
+            Image bg    = rowGo.GetComponent<Image>();
+            bg.sprite   = GetWhiteSprite();
+            bg.color    = index % 2 == 0 ? RowEven : RowOdd;
+
+            GameObject textGo = new GameObject("Label", typeof(RectTransform), typeof(Text));
+            textGo.transform.SetParent(rowGo.transform, false);
+            RectTransform textRt    = (RectTransform)textGo.transform;
+            textRt.anchorMin        = Vector2.zero;
+            textRt.anchorMax        = Vector2.one;
+            textRt.offsetMin        = new Vector2(8f, 4f);
+            textRt.offsetMax        = new Vector2(-8f, -4f);
+
+            Text label                  = textGo.GetComponent<Text>();
+            label.font                  = _font;
+            label.fontSize              = 20;
+            label.color                 = TextColor;
+            label.alignment             = TextAnchor.MiddleLeft;
+            label.supportRichText       = true;
+            label.horizontalOverflow    = HorizontalWrapMode.Overflow;
+            label.verticalOverflow      = VerticalWrapMode.Overflow;
+            label.text                  = BuildRowLabel(entry);
+
+            // Tooltip por fila — usa la posición del GO en pantalla (ScreenSpaceOverlay).
+            string tooltipText = BuildTooltip(entry);
+            EventTrigger trigger = rowGo.GetComponent<EventTrigger>();
+
+            EventTrigger.Entry enter = new EventTrigger.Entry { eventID = EventTriggerType.PointerEnter };
+            enter.callback.AddListener(_ => ShowTooltip(tooltipText, rowGo.transform.position));
+            trigger.triggers.Add(enter);
+
+            EventTrigger.Entry exit = new EventTrigger.Entry { eventID = EventTriggerType.PointerExit };
+            exit.callback.AddListener(_ => HideTooltip());
+            trigger.triggers.Add(exit);
+
+            _rowGos.Add(rowGo);
+        }
+
+        // ────────────────────────────────────────
+        // Build de componentes UI
+        // ────────────────────────────────────────
+
+        private void BuildBadge(RectTransform parent)
+        {
+            // Esquina superior: zona entre el WorldPanel (38-62%) y el borde derecho,
+            // por encima de la RelicBar → el badge no colisiona con ningún HUD existente.
+            GameObject badgeGo = new GameObject("DeckViewerBadge",
+                typeof(RectTransform), typeof(Image), typeof(Button));
+            badgeGo.transform.SetParent(parent, false);
+
+            RectTransform rt = (RectTransform)badgeGo.transform;
+            rt.anchorMin = new Vector2(0.72f, 0.93f);
+            rt.anchorMax = new Vector2(0.88f, 0.99f);
+            rt.offsetMin = Vector2.zero;
+            rt.offsetMax = Vector2.zero;
+
+            Image bg   = badgeGo.GetComponent<Image>();
+            bg.sprite  = GetWhiteSprite();
+            bg.color   = BadgeBg;
+
+            GameObject labelGo = new GameObject("Label", typeof(RectTransform), typeof(Text));
+            labelGo.transform.SetParent(badgeGo.transform, false);
+            RectTransform labelRt = (RectTransform)labelGo.transform;
+            labelRt.anchorMin = Vector2.zero;
+            labelRt.anchorMax = Vector2.one;
+            labelRt.offsetMin = new Vector2(6f, 2f);
+            labelRt.offsetMax = new Vector2(-6f, -2f);
+
+            _badgeLabel                 = labelGo.GetComponent<Text>();
+            _badgeLabel.font            = _font;
+            _badgeLabel.fontSize        = 20;
+            _badgeLabel.color           = Color.white;
+            _badgeLabel.alignment       = TextAnchor.MiddleCenter;
+            _badgeLabel.supportRichText = false;
+            _badgeLabel.text            = "Mazo (0)";
+
+            _badgeButton = badgeGo.GetComponent<Button>();
+            _badgeButton.onClick.AddListener(Toggle);
+        }
+
+        private void BuildModal(RectTransform parent)
+        {
+            // Dimmer de pantalla completa — bloquea raycasts para impedir clicks
+            // en la mano durante combate (el combate es por turnos: no hace falta pausar).
+            GameObject overlayGo = new GameObject("DeckViewerModal",
+                typeof(RectTransform), typeof(Image));
+            overlayGo.transform.SetParent(parent, false);
+            _modalOverlay              = (RectTransform)overlayGo.transform;
+            _modalOverlay.anchorMin    = Vector2.zero;
+            _modalOverlay.anchorMax    = Vector2.one;
+            _modalOverlay.offsetMin    = Vector2.zero;
+            _modalOverlay.offsetMax    = Vector2.zero;
+
+            Image dimmer          = overlayGo.GetComponent<Image>();
+            dimmer.sprite         = GetWhiteSprite();
+            dimmer.color          = DimmerColor;
+            dimmer.raycastTarget  = true;
+
+            // Título centrado en la franja superior del modal.
+            GameObject titleGo = new GameObject("Title", typeof(RectTransform), typeof(Text));
+            titleGo.transform.SetParent(_modalOverlay, false);
+            RectTransform titleRt = (RectTransform)titleGo.transform;
+            titleRt.anchorMin = new Vector2(0.2f, 0.88f);
+            titleRt.anchorMax = new Vector2(0.8f, 0.95f);
+            titleRt.offsetMin = Vector2.zero;
+            titleRt.offsetMax = Vector2.zero;
+
+            _modalTitle                  = titleGo.GetComponent<Text>();
+            _modalTitle.font             = _font;
+            _modalTitle.fontSize         = 28;
+            _modalTitle.color            = Color.white;
+            _modalTitle.alignment        = TextAnchor.MiddleCenter;
+            _modalTitle.text             = "Mazo (0)";
+
+            BuildScrollView(_modalOverlay);
+
+            // Botón Cerrar en la franja inferior del modal.
+            GameObject closeGo = new GameObject("CloseButton",
+                typeof(RectTransform), typeof(Image), typeof(Button));
+            closeGo.transform.SetParent(_modalOverlay, false);
+            RectTransform closeRt = (RectTransform)closeGo.transform;
+            closeRt.anchorMin = new Vector2(0.38f, 0.02f);
+            closeRt.anchorMax = new Vector2(0.62f, 0.08f);
+            closeRt.offsetMin = Vector2.zero;
+            closeRt.offsetMax = Vector2.zero;
+
+            Image closeBg  = closeGo.GetComponent<Image>();
+            closeBg.sprite = GetWhiteSprite();
+            closeBg.color  = new Color(0.2f, 0.2f, 0.3f, 0.9f);
+
+            GameObject closeLabelGo = new GameObject("Label", typeof(RectTransform), typeof(Text));
+            closeLabelGo.transform.SetParent(closeGo.transform, false);
+            RectTransform closeLabelRt = (RectTransform)closeLabelGo.transform;
+            closeLabelRt.anchorMin = Vector2.zero;
+            closeLabelRt.anchorMax = Vector2.one;
+            closeLabelRt.offsetMin = Vector2.zero;
+            closeLabelRt.offsetMax = Vector2.zero;
+
+            Text closeText           = closeLabelGo.GetComponent<Text>();
+            closeText.font           = _font;
+            closeText.fontSize       = 22;
+            closeText.color          = Color.white;
+            closeText.alignment      = TextAnchor.MiddleCenter;
+            closeText.text           = "Cerrar";
+
+            Button closeBtn = closeGo.GetComponent<Button>();
+            closeBtn.onClick.AddListener(Close);
+
+            _modalOverlay.gameObject.SetActive(false);
+        }
+
+        private void BuildScrollView(RectTransform modalOverlay)
+        {
+            // ScrollRect estándar vertical: Viewport(Mask) → Content(VLG+CSF).
+            GameObject scrollGo = new GameObject("ScrollView",
+                typeof(RectTransform), typeof(Image), typeof(ScrollRect));
+            scrollGo.transform.SetParent(modalOverlay, false);
+            RectTransform scrollRt = (RectTransform)scrollGo.transform;
+            scrollRt.anchorMin = new Vector2(0.1f, 0.09f);
+            scrollRt.anchorMax = new Vector2(0.9f, 0.87f);
+            scrollRt.offsetMin = Vector2.zero;
+            scrollRt.offsetMax = Vector2.zero;
+
+            Image scrollBg  = scrollGo.GetComponent<Image>();
+            scrollBg.sprite = GetWhiteSprite();
+            scrollBg.color  = PanelBg;
+
+            // Viewport (necesita Image para que Mask funcione).
+            GameObject vpGo = new GameObject("Viewport",
+                typeof(RectTransform), typeof(Image), typeof(Mask));
+            vpGo.transform.SetParent(scrollGo.transform, false);
+            RectTransform vpRt = (RectTransform)vpGo.transform;
+            vpRt.anchorMin = Vector2.zero;
+            vpRt.anchorMax = Vector2.one;
+            vpRt.offsetMin = Vector2.zero;
+            vpRt.offsetMax = Vector2.zero;
+
+            Image vpImg        = vpGo.GetComponent<Image>();
+            vpImg.sprite       = GetWhiteSprite();
+            vpImg.color        = new Color(0f, 0f, 0f, 0.01f); // casi invisible, necesario para la Mask
+            Mask mask          = vpGo.GetComponent<Mask>();
+            mask.showMaskGraphic = false;
+
+            // Content: crece hacia abajo desde el techo del viewport.
+            GameObject contentGo = new GameObject("Content",
+                typeof(RectTransform), typeof(VerticalLayoutGroup), typeof(ContentSizeFitter));
+            contentGo.transform.SetParent(vpGo.transform, false);
+            _scrollContent             = (RectTransform)contentGo.transform;
+            _scrollContent.anchorMin   = new Vector2(0f, 1f);
+            _scrollContent.anchorMax   = new Vector2(1f, 1f);
+            _scrollContent.pivot       = new Vector2(0.5f, 1f);
+            _scrollContent.offsetMin   = Vector2.zero;
+            _scrollContent.offsetMax   = Vector2.zero;
+
+            VerticalLayoutGroup vlg   = contentGo.GetComponent<VerticalLayoutGroup>();
+            vlg.spacing               = 2f;
+            vlg.childForceExpandWidth  = true;
+            vlg.childForceExpandHeight = false;
+            vlg.childControlWidth      = true;
+            vlg.childControlHeight     = true;
+            vlg.padding                = new RectOffset(4, 4, 4, 4);
+
+            ContentSizeFitter csf = contentGo.GetComponent<ContentSizeFitter>();
+            csf.verticalFit       = ContentSizeFitter.FitMode.PreferredSize;
+            csf.horizontalFit     = ContentSizeFitter.FitMode.Unconstrained;
+
+            ScrollRect sr         = scrollGo.GetComponent<ScrollRect>();
+            sr.viewport           = vpRt;
+            sr.content            = _scrollContent;
+            sr.horizontal         = false;
+            sr.vertical           = true;
+            sr.scrollSensitivity  = 25f;
+            sr.movementType       = ScrollRect.MovementType.Clamped;
+        }
+
+        private void BuildTooltipGo(RectTransform parent)
+        {
+            // Tooltip bajo el sub-Canvas (no bajo relicBar como en RelicInventoryView).
+            // Se posiciona en espacio de pantalla al hacer hover sobre una fila.
+            _tooltipGo = new GameObject("DeckViewerTooltip",
+                typeof(RectTransform), typeof(Image), typeof(CanvasGroup),
+                typeof(VerticalLayoutGroup), typeof(ContentSizeFitter));
+            _tooltipGo.transform.SetParent(parent, false);
+            _tooltipRect           = (RectTransform)_tooltipGo.transform;
+            _tooltipRect.sizeDelta = new Vector2(440f, 0f);
+            _tooltipRect.pivot     = new Vector2(0f, 1f);
+            _tooltipRect.anchorMin = Vector2.zero;
+            _tooltipRect.anchorMax = Vector2.zero;
+
+            Image bg    = _tooltipGo.GetComponent<Image>();
+            bg.sprite   = GetWhiteSprite();
+            bg.color    = TooltipBg;
+
+            VerticalLayoutGroup vlg   = _tooltipGo.GetComponent<VerticalLayoutGroup>();
+            vlg.padding               = new RectOffset(12, 12, 10, 10);
+            vlg.spacing               = 4;
+            vlg.childForceExpandWidth  = true;
+            vlg.childForceExpandHeight = false;
+            vlg.childControlWidth      = true;
+            vlg.childControlHeight     = true;
+
+            ContentSizeFitter csf = _tooltipGo.GetComponent<ContentSizeFitter>();
+            csf.verticalFit       = ContentSizeFitter.FitMode.PreferredSize;
+            csf.horizontalFit     = ContentSizeFitter.FitMode.Unconstrained;
+
+            _tooltipGroup                  = _tooltipGo.GetComponent<CanvasGroup>();
+            _tooltipGroup.alpha            = 0f;
+            _tooltipGroup.blocksRaycasts   = false;
+            _tooltipGroup.interactable     = false;
+
+            GameObject textGo = new GameObject("TooltipText", typeof(RectTransform), typeof(Text));
+            textGo.transform.SetParent(_tooltipGo.transform, false);
+
+            _tooltipText                      = textGo.GetComponent<Text>();
+            _tooltipText.font                 = _font;
+            _tooltipText.fontSize             = 18;
+            _tooltipText.color                = new Color(1f, 0.95f, 0.85f, 1f);
+            _tooltipText.alignment            = TextAnchor.UpperLeft;
+            _tooltipText.supportRichText      = true;
+            _tooltipText.horizontalOverflow   = HorizontalWrapMode.Wrap;
+            _tooltipText.verticalOverflow     = VerticalWrapMode.Overflow;
+        }
+
+        private void ShowTooltip(string text, Vector3 rowWorldPos)
+        {
+            if (_tooltipGo == null) return;
+            _tooltipText.text     = text;
+            _tooltipRect.position = rowWorldPos + new Vector3(8f, 8f, 0f);
+            UIAnimationHelper.FadeIn(_tooltipGroup, 0.15f);
+        }
+
+        private void HideTooltip()
+        {
+            if (_tooltipGo == null) return;
+            UIAnimationHelper.FadeOut(_tooltipGroup, 0.1f);
+        }
+
+        private static Sprite GetWhiteSprite()
+        {
+            if (_whiteSprite != null) return _whiteSprite;
+            _whiteSprite = Sprite.Create(
+                Texture2D.whiteTexture,
+                new Rect(0, 0, 1, 1),
+                new Vector2(0.5f, 0.5f));
+            return _whiteSprite;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Cards/UI/DeckViewerView.cs
+++ b/Assets/Scripts/Gameplay/Cards/UI/DeckViewerView.cs
@@ -138,12 +138,17 @@ namespace RoguelikeCardBattler.Gameplay.Cards.UI
         {
             if (deck == null) return new List<CardDeckEntry>();
 
+            // Resuelve el representante UNA sola vez por entry (en el Select) en vez
+            // de recalcularlo en cada cláusula de orden; luego ordena sobre el par.
             return deck
-                .Where(e => e != null && e.IsValid && RepresentativeCard(e) != null)
-                .OrderBy(e =>  (int)RepresentativeCard(e).Type)
-                .ThenBy(e =>  RepresentativeCard(e).Cost)
-                .ThenBy(e =>  RepresentativeCard(e).CardName)
-                .ThenBy(e =>  RepresentativeCard(e).Id)
+                .Where(e => e != null && e.IsValid)
+                .Select(e => (entry: e, rep: CardDisplay.RepresentativeCard(e)))
+                .Where(x => x.rep != null)
+                .OrderBy(x => (int)x.rep.Type)
+                .ThenBy(x => x.rep.Cost)
+                .ThenBy(x => x.rep.CardName)
+                .ThenBy(x => x.rep.Id)
+                .Select(x => x.entry)
                 .ToList();
         }
 
@@ -156,26 +161,11 @@ namespace RoguelikeCardBattler.Gameplay.Cards.UI
         {
             if (entry == null || !entry.IsValid) return "";
 
-            string body;
-            if (entry.DualCard != null)
-            {
-                CardDefinition a   = entry.DualCard.SideA;
-                CardDefinition b   = entry.DualCard.SideB;
-                string tokenA      = CardToken(a);
-                string tokenB      = CardToken(b);
-                bool sameName      = NameOf(a) == NameOf(b);
-                bool sameType      = SideType(a) == SideType(b);
-                bool bothNonNull   = a != null && b != null;
-                string display     = (sameName && sameType && bothNonNull) ? tokenA : $"{tokenA} / {tokenB}";
-
-                CardDefinition rep = RepresentativeCard(entry);
-                body = rep != null ? $"{display} · {rep.Cost}⚡" : display;
-            }
-            else
-            {
-                CardDefinition c = entry.SingleCard;
-                body = c != null ? $"{CardToken(c)} · {c.Cost}⚡" : "";
-            }
+            // Token (single o dual con colapso) canónico en CardDisplay; el coste se
+            // toma del representante (las duales no exponen un Cost propio).
+            string token = CardDisplay.EntryToken(entry);
+            CardDefinition rep = CardDisplay.RepresentativeCard(entry);
+            string body = rep != null ? $"{token} · {rep.Cost}⚡" : token;
 
             string marker = entry.IsUpgraded    ? " ★"
                           : entry.CanUpgrade()  ? " +"
@@ -250,32 +240,10 @@ namespace RoguelikeCardBattler.Gameplay.Cards.UI
         // ────────────────────────────────────────
         // Helpers estáticos internos
         // ────────────────────────────────────────
-
-        /// <summary>
-        /// Carta representante para orden/coste/tipo. Espejo de ShopNodeController.
-        /// Fallback SideA → SideB para duales con SideA null.
-        /// </summary>
-        private static CardDefinition RepresentativeCard(CardDeckEntry entry)
-        {
-            if (entry == null) return null;
-            if (entry.SingleCard != null) return entry.SingleCard;
-            if (entry.DualCard   != null) return entry.DualCard.SideA ?? entry.DualCard.SideB;
-            return null;
-        }
-
-        // Token rich-text "[Tipo] Nombre" para un lado. null → "?".
-        private static string CardToken(CardDefinition c)
-        {
-            if (c == null) return "?";
-            string prefix = ElementTypeColors.TypePrefix(c.ElementType);
-            return string.IsNullOrEmpty(prefix) ? c.CardName : $"{prefix} {c.CardName}";
-        }
-
-        private static ElementType SideType(CardDefinition c) =>
-            c != null ? c.ElementType : ElementType.None;
-
-        private static string NameOf(CardDefinition c) =>
-            c != null ? c.CardName : "?";
+        // Los helpers de label/representante (RepresentativeCard / CardToken /
+        // SideType / criterio de colapso dual) viven en CardDisplay (módulo Cards),
+        // hogar canónico compartido. Acá solo quedan los helpers exclusivos del
+        // tooltip y del preview de mejora.
 
         private static void AppendSideTooltip(StringBuilder sb, CardDefinition c, string sideLabel)
         {
@@ -392,15 +360,20 @@ namespace RoguelikeCardBattler.Gameplay.Cards.UI
 
         private void BuildBadge(RectTransform parent)
         {
-            // Esquina superior: zona entre el WorldPanel (38-62%) y el borde derecho,
-            // por encima de la RelicBar → el badge no colisiona con ningún HUD existente.
+            // Esquina superior IZQUIERDA. Es la zona libre en ambas escenas:
+            // - Combate: el topBar tiene WorldPanel (x 0.38–0.62) y ChangeWorldButton
+            //   (x 0.74–0.98); la franja izquierda x 0.02–0.17 está vacía. (La esquina
+            //   derecha NO sirve: con sortingOrder=100 el badge taparía el botón Change
+            //   World y bloquearía sus clics.)
+            // - Mapa: el título y el status van centrados (texto en x 0.1–0.9), así que
+            //   el extremo izquierdo queda visualmente libre.
             GameObject badgeGo = new GameObject("DeckViewerBadge",
                 typeof(RectTransform), typeof(Image), typeof(Button));
             badgeGo.transform.SetParent(parent, false);
 
             RectTransform rt = (RectTransform)badgeGo.transform;
-            rt.anchorMin = new Vector2(0.72f, 0.93f);
-            rt.anchorMax = new Vector2(0.88f, 0.99f);
+            rt.anchorMin = new Vector2(0.02f, 0.93f);
+            rt.anchorMax = new Vector2(0.17f, 0.99f);
             rt.offsetMin = Vector2.zero;
             rt.offsetMax = Vector2.zero;
 

--- a/Assets/Scripts/Gameplay/Cards/UI/DeckViewerView.cs.meta
+++ b/Assets/Scripts/Gameplay/Cards/UI/DeckViewerView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4ecd2c0299ba71e4480f3022ccc6cdb4

--- a/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatUIController.cs
@@ -4,6 +4,7 @@ using UnityEngine.EventSystems;
 using UnityEngine.UI;
 using RoguelikeCardBattler.Gameplay.Enemies;
 using RoguelikeCardBattler.Gameplay.Relics;
+using RoguelikeCardBattler.Gameplay.Cards.UI;
 using RoguelikeCardBattler.Gameplay.Relics.UI;
 using RoguelikeCardBattler.Run;
 
@@ -57,6 +58,8 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         // copia equivalente en RunMapView.
         private RelicInventoryView _relicView;
         private int _lastRelicCount;
+        // Visor de mazo: sub-Canvas overlay propio, montado en BuildUI junto al _relicView.
+        private DeckViewerView _deckViewer;
 
         // Layout/estilo del HUD: constantes para mantener jerarquía visual y escalado.
         private const float TopBarMinY = 0.92f;
@@ -434,6 +437,11 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 new Vector2(1f, TopBarMinY),
                 new Color(0f, 0f, 0f, 0f));
             _relicView = new RelicInventoryView(relicBar, uiFont);
+
+            // Visor de mazo: overlay propio sobre el canvas de combate.
+            // RunSession puede ser null en standalone BattleScene sin run → Refresh(null) es null-safe.
+            _deckViewer = new DeckViewerView(_canvas, uiFont);
+            _deckViewer.Refresh(RunSession.Instance?.State?.GetDeckSnapshot());
 
             InitializePlayerAnimator();
             InitializeExtractedViews(

--- a/Assets/Scripts/Run/RunFlowController.cs
+++ b/Assets/Scripts/Run/RunFlowController.cs
@@ -7,6 +7,7 @@ using RoguelikeCardBattler.Core;
 using RoguelikeCardBattler.Gameplay.Cards;
 using RoguelikeCardBattler.Gameplay.Combat;
 using RoguelikeCardBattler.Gameplay.Relics;
+using RoguelikeCardBattler.Gameplay.Cards.UI;
 using RoguelikeCardBattler.Gameplay.Relics.UI;
 using RoguelikeCardBattler.Run.Campfire;
 using RoguelikeCardBattler.Run.Shop;
@@ -41,6 +42,7 @@ namespace RoguelikeCardBattler.Run
         private Text _titleText;
         private RunMapView _mapView;
         private RelicInventoryView _relicView;
+        private DeckViewerView _deckViewer;
         private Text _resolveTitleText;
         private Text _resolveBodyText;
         private Button _resolveCompleteButton;
@@ -154,6 +156,10 @@ namespace RoguelikeCardBattler.Run
             BuildActoCompletedPanel();
             BuildCampfireController();
             BuildShopController();
+
+            // Visor de mazo: sub-Canvas overlay, flota sobre paneles opacos (Tienda/Hoguera).
+            _deckViewer = new DeckViewerView(_canvas, uiFont);
+            _deckViewer.Refresh(_state.GetDeckSnapshot());
         }
 
         private void BuildCampfireController()
@@ -257,6 +263,8 @@ namespace RoguelikeCardBattler.Run
             // Suficiente refrescar acá: los Retazos sólo cambian fuera del mapa
             // (combate/elite/boss/tienda) y todo retorno al mapa pasa por ShowMap.
             _relicView?.Refresh(_state.Relics);
+            // El mazo puede cambiar al volver de combate (recompensa) o de Tienda/Hoguera.
+            _deckViewer?.Refresh(_state.GetDeckSnapshot());
         }
 
         private void EnterNode(int index)
@@ -372,6 +380,7 @@ namespace RoguelikeCardBattler.Run
             }
             _mapView?.Cleanup();
             _relicView?.Cleanup();
+            _deckViewer?.Cleanup();
             SceneTransitionManager.LoadScene(BattleSceneName);
         }
 
@@ -656,6 +665,7 @@ namespace RoguelikeCardBattler.Run
                 _state.PrepareForRetry();
                 _mapView?.Cleanup();
                 _relicView?.Cleanup();
+                _deckViewer?.Cleanup();
                 SceneTransitionManager.LoadScene(BattleSceneName);
             });
 
@@ -685,6 +695,7 @@ namespace RoguelikeCardBattler.Run
             }
             _mapView?.Cleanup();
             _relicView?.Cleanup();
+            _deckViewer?.Cleanup();
             SceneTransitionManager.LoadScene(MainMenuSceneName);
         }
 

--- a/Assets/Tests/EditMode/DeckViewerTests.cs
+++ b/Assets/Tests/EditMode/DeckViewerTests.cs
@@ -42,6 +42,19 @@ public class DeckViewerTests
         return e;
     }
 
+    // Cuenta ocurrencias (no solapadas) de una subcadena. Usado para verificar que
+    // un nombre colapsado aparece exactamente una vez en el label.
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0, idx = 0;
+        while ((idx = haystack.IndexOf(needle, idx, System.StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            idx += needle.Length;
+        }
+        return count;
+    }
+
     // ────────────────────────────────────────
     // TEST 1 — Orden tipo → coste → nombre
     // ────────────────────────────────────────
@@ -53,19 +66,25 @@ public class DeckViewerTests
         var cB = MakeCard("b", "Alpha",  1, CardType.Skill);
         var cC = MakeCard("c", "Mend",   2, CardType.Attack);   // mismo tipo/coste que cA, nombre menor
         var cD = MakeCard("d", "Heal",   1, CardType.Power);
+        var cE = MakeCard("e", "Hex",    1, CardType.Curse);    // cubre el resto del enum
+        var cF = MakeCard("f", "Burn",   1, CardType.Status);
 
         var deck = new List<CardDeckEntry>
         {
-            SingleEntry(cA), SingleEntry(cB), SingleEntry(cC), SingleEntry(cD)
+            // Orden de entrada deliberadamente mezclado para que el sort tenga que trabajar.
+            SingleEntry(cF), SingleEntry(cA), SingleEntry(cE),
+            SingleEntry(cB), SingleEntry(cC), SingleEntry(cD)
         };
 
         List<CardDeckEntry> sorted = DeckViewerView.SortForDisplay(deck);
 
-        // Attack (0) < Skill (1) < Power (2) → Attack primero, luego coste asc dentro del tipo.
+        // Cadena completa del enum: Attack(0) < Skill(1) < Power(2) < Curse(3) < Status(4).
         Assert.AreEqual(CardType.Attack, sorted[0].SingleCard.Type);
         Assert.AreEqual(CardType.Attack, sorted[1].SingleCard.Type);
         Assert.AreEqual(CardType.Skill,  sorted[2].SingleCard.Type);
         Assert.AreEqual(CardType.Power,  sorted[3].SingleCard.Type);
+        Assert.AreEqual(CardType.Curse,  sorted[4].SingleCard.Type);
+        Assert.AreEqual(CardType.Status, sorted[5].SingleCard.Type);
 
         // Dentro de Attack (coste 2 ambas): Mend < Zephyr por nombre.
         Assert.AreEqual("Mend",   sorted[0].SingleCard.CardName);
@@ -190,20 +209,24 @@ public class DeckViewerTests
 
         string label = DeckViewerView.BuildRowLabel(entry);
 
-        // Nombre y tipo distintos → NO colapsa; ambos lados presentes.
+        // Nombre y tipo distintos → NO colapsa: ambos lados presentes + separador " / ".
         StringAssert.Contains("BladeA", label);
         StringAssert.Contains("BladeB", label);
-        StringAssert.Contains("/",      label);
+        StringAssert.Contains(" / ",    label);
 
-        // Caso colapso: mismo nombre Y mismo tipo en ambos lados.
+        // Caso colapso: mismo nombre Y mismo tipo en ambos lados no-null.
         var sameA = MakeCard("sa", "Twin", 1, CardType.Skill, ElementType.Azul);
         var sameB = MakeCard("sb", "Twin", 1, CardType.Skill, ElementType.Azul);
         var sameEntry = DualEntry(sameA, sameB);
 
         string collapsed = DeckViewerView.BuildRowLabel(sameEntry);
-        // Colapsa: aparece "Twin" una sola vez (sin "/").
-        StringAssert.Contains("Twin", collapsed);
-        Assert.IsFalse(collapsed.Contains("Twin / Twin"), "No debe mostrar ambos tokens cuando colapsa");
+        // Al colapsar, el separador " / " desaparece y el nombre aparece UNA sola vez.
+        // (Si una regresión rompiera el colapso, el resultado sería "<tokenA> / <tokenB>"
+        // — con separador y "Twin" dos veces — y ambos asserts fallarían. La aserción
+        // anterior `!Contains("Twin / Twin")` era tautológica: los tags de color entre
+        // medio hacían que esa subcadena literal nunca apareciera ni sin colapso.)
+        Assert.IsFalse(collapsed.Contains(" / "), "No debe quedar el separador cuando colapsa");
+        Assert.AreEqual(1, CountOccurrences(collapsed, "Twin"), "El nombre colapsado debe aparecer una sola vez");
     }
 
     // ────────────────────────────────────────
@@ -331,5 +354,69 @@ public class DeckViewerTests
         // El label lleva el marcador ★ (no "+").
         StringAssert.Contains("★", label);
         Assert.IsFalse(label.Contains(" +"), "Una carta ya mejorada no debe mostrar el marcador '+'");
+    }
+
+    // ────────────────────────────────────────
+    // TEST 13 — BuildTooltip dual: ambos lados con nombre/descripción + preview anexado
+    // ────────────────────────────────────────
+
+    [Test]
+    public void BuildTooltip_Dual_ContainsBothSidesAndAppendedPreview()
+    {
+        var sideA = MakeCard("a", "BladeA", 2, CardType.Attack, ElementType.Azul);
+        sideA.Upgrade.SetTestData(false, 0, null, "BladeA+", "A más filosa.");
+        var sideB = MakeCard("b", "BladeB", 1, CardType.Skill, ElementType.Morado);
+        var entry = DualEntry(sideA, sideB);
+
+        string tooltip = DeckViewerView.BuildTooltip(entry);
+
+        // Ambos lados presentes con sus nombres y descripciones base.
+        StringAssert.Contains("BladeA", tooltip);
+        StringAssert.Contains("BladeB", tooltip);
+        StringAssert.Contains("Desc BladeA", tooltip);
+        StringAssert.Contains("Desc BladeB", tooltip);
+        // Etiquetas de lado A/B.
+        StringAssert.Contains("[A]", tooltip);
+        StringAssert.Contains("[B]", tooltip);
+        // El bloque de preview de mejora queda anexado al final (per-lado: A mejora, B no).
+        StringAssert.Contains("Mejora", tooltip);
+        StringAssert.Contains("BladeA+", tooltip);
+    }
+
+    // ────────────────────────────────────────
+    // TEST 14 — BuildTooltip con un lado null no crashea y rinde "[A] ?"
+    // ────────────────────────────────────────
+
+    [Test]
+    public void BuildTooltip_NullSide_DoesNotThrowAndRendersPlaceholder()
+    {
+        var sideB = MakeCard("b", "SoloB", 1, CardType.Skill);
+        var entry = DualEntry(null, sideB);
+
+        string tooltip = null;
+        Assert.DoesNotThrow(() => tooltip = DeckViewerView.BuildTooltip(entry));
+
+        // El lado A null se renderiza como "[A] ?"; el B válido muestra su nombre.
+        StringAssert.Contains("[A] ?", tooltip);
+        StringAssert.Contains("SoloB", tooltip);
+    }
+
+    // ────────────────────────────────────────
+    // TEST 15 — BuildTooltip de carta ya mejorada contiene "Mejorada"
+    // ────────────────────────────────────────
+
+    [Test]
+    public void BuildTooltip_AlreadyUpgraded_ContainsMejorada()
+    {
+        var c = MakeCard("m", "Enhanced", 1, CardType.Attack);
+        c.Upgrade.SetTestData(false, 0, null, "Enhanced+", "Mucho mejor.");
+        var entry = SingleEntry(c);
+        entry.ApplyUpgrade();
+
+        string tooltip = DeckViewerView.BuildTooltip(entry);
+
+        // No muestra el "se convertiría en…", solo la marca de ya-mejorada.
+        StringAssert.Contains("Mejorada", tooltip);
+        StringAssert.Contains("Enhanced", tooltip);
     }
 }

--- a/Assets/Tests/EditMode/DeckViewerTests.cs
+++ b/Assets/Tests/EditMode/DeckViewerTests.cs
@@ -1,0 +1,335 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using RoguelikeCardBattler.Gameplay.Cards;
+using RoguelikeCardBattler.Gameplay.Cards.UI;
+using RoguelikeCardBattler.Gameplay.Combat;
+
+/// <summary>
+/// Tests EditMode para los helpers static puros de DeckViewerView.
+/// No instancia UI. Sigue el patrón de fixtures de NewRunTests/ShopTests/CampfireTests:
+/// CardDefinition vía ScriptableObject.CreateInstance + SetDebugData;
+/// CardUpgradeDef.SetTestData está bajo UNITY_INCLUDE_TESTS (disponible en EditMode).
+/// </summary>
+[TestFixture]
+public class DeckViewerTests
+{
+    // ────────────────────────────────────────
+    // Helpers de fixture
+    // ────────────────────────────────────────
+
+    private static CardDefinition MakeCard(string id, string name, int cost, CardType type, ElementType elem = ElementType.None)
+    {
+        var c = ScriptableObject.CreateInstance<CardDefinition>();
+        c.SetDebugData(id, name, $"Desc {name}", cost, type, CardRarity.Common, CardTarget.SingleEnemy,
+                       new List<string>(), new List<EffectRef>(), elem);
+        return c;
+    }
+
+    private static CardDeckEntry SingleEntry(CardDefinition c)
+    {
+        var e = new CardDeckEntry();
+        e.SetSingleCard(c);
+        return e;
+    }
+
+    private static CardDeckEntry DualEntry(CardDefinition sideA, CardDefinition sideB)
+    {
+        var dual = ScriptableObject.CreateInstance<DualCardDefinition>();
+        dual.InitRuntimeSides("dual_id", "Dual", sideA, sideB);
+        var e = new CardDeckEntry();
+        e.SetDualCard(dual);
+        return e;
+    }
+
+    // ────────────────────────────────────────
+    // TEST 1 — Orden tipo → coste → nombre
+    // ────────────────────────────────────────
+
+    [Test]
+    public void SortForDisplay_OrdersByTypeCostName()
+    {
+        var cA = MakeCard("a", "Zephyr", 2, CardType.Attack);
+        var cB = MakeCard("b", "Alpha",  1, CardType.Skill);
+        var cC = MakeCard("c", "Mend",   2, CardType.Attack);   // mismo tipo/coste que cA, nombre menor
+        var cD = MakeCard("d", "Heal",   1, CardType.Power);
+
+        var deck = new List<CardDeckEntry>
+        {
+            SingleEntry(cA), SingleEntry(cB), SingleEntry(cC), SingleEntry(cD)
+        };
+
+        List<CardDeckEntry> sorted = DeckViewerView.SortForDisplay(deck);
+
+        // Attack (0) < Skill (1) < Power (2) → Attack primero, luego coste asc dentro del tipo.
+        Assert.AreEqual(CardType.Attack, sorted[0].SingleCard.Type);
+        Assert.AreEqual(CardType.Attack, sorted[1].SingleCard.Type);
+        Assert.AreEqual(CardType.Skill,  sorted[2].SingleCard.Type);
+        Assert.AreEqual(CardType.Power,  sorted[3].SingleCard.Type);
+
+        // Dentro de Attack (coste 2 ambas): Mend < Zephyr por nombre.
+        Assert.AreEqual("Mend",   sorted[0].SingleCard.CardName);
+        Assert.AreEqual("Zephyr", sorted[1].SingleCard.CardName);
+    }
+
+    // ────────────────────────────────────────
+    // TEST 2 — Estabilidad en claves iguales
+    // ────────────────────────────────────────
+
+    [Test]
+    public void SortForDisplay_IsStableOnEqualKeys()
+    {
+        // Dos cartas con mismo tipo/coste/nombre — difieren solo en Id.
+        var c1 = MakeCard("id_1", "Strike", 1, CardType.Attack);
+        var c2 = MakeCard("id_2", "Strike", 1, CardType.Attack);
+        var e1 = SingleEntry(c1);
+        var e2 = SingleEntry(c2);
+
+        var deck = new List<CardDeckEntry> { e1, e2 };
+        List<CardDeckEntry> sorted = DeckViewerView.SortForDisplay(deck);
+
+        // El tie-break por Id garantiza orden determinista.
+        Assert.AreEqual("id_1", sorted[0].SingleCard.Id);
+        Assert.AreEqual("id_2", sorted[1].SingleCard.Id);
+    }
+
+    // ────────────────────────────────────────
+    // TEST 3 — Sort no muta la entrada
+    // ────────────────────────────────────────
+
+    [Test]
+    public void SortForDisplay_DoesNotMutateInput()
+    {
+        var cA = MakeCard("a", "Zorro", 3, CardType.Skill);
+        var cB = MakeCard("b", "Alfa",  1, CardType.Attack);
+        var original = new List<CardDeckEntry> { SingleEntry(cA), SingleEntry(cB) };
+
+        List<CardDeckEntry> sorted = DeckViewerView.SortForDisplay(original);
+
+        // La lista original conserva su orden y conteo.
+        Assert.AreEqual(2, original.Count);
+        Assert.AreEqual("Zorro", original[0].SingleCard.CardName);
+        Assert.AreEqual("Alfa",  original[1].SingleCard.CardName);
+        // La sortida es una lista nueva.
+        Assert.AreNotSame(original, sorted);
+        Assert.AreEqual(2, sorted.Count);
+    }
+
+    // ────────────────────────────────────────
+    // TEST 4 — Null / vacío → lista vacía, sin excepción
+    // ────────────────────────────────────────
+
+    [Test]
+    public void SortForDisplay_NullOrEmpty_ReturnsEmptyList()
+    {
+        List<CardDeckEntry> fromNull  = DeckViewerView.SortForDisplay(null);
+        List<CardDeckEntry> fromEmpty = DeckViewerView.SortForDisplay(new List<CardDeckEntry>());
+
+        Assert.IsNotNull(fromNull);
+        Assert.AreEqual(0, fromNull.Count);
+        Assert.IsNotNull(fromEmpty);
+        Assert.AreEqual(0, fromEmpty.Count);
+    }
+
+    // ────────────────────────────────────────
+    // TEST 5 — Dual con SideA null no crashea
+    // ────────────────────────────────────────
+
+    [Test]
+    public void SortForDisplay_DualWithNullSideA_DoesNotThrow()
+    {
+        // SideA null, SideB válido → IsValid = true (DualCard != null), pero SideA es null.
+        var sideB = MakeCard("b", "SideB", 2, CardType.Skill);
+        var entry = DualEntry(null, sideB);
+
+        Assert.IsTrue(entry.IsValid, "Entrada dual con SideA null debe ser IsValid");
+
+        // SortForDisplay ni BuildRowLabel deben lanzar NRE.
+        List<CardDeckEntry> sorted = null;
+        Assert.DoesNotThrow(() => sorted = DeckViewerView.SortForDisplay(new List<CardDeckEntry> { entry }));
+
+        string label = null;
+        Assert.DoesNotThrow(() => label = DeckViewerView.BuildRowLabel(entry));
+
+        // El fallback usa SideB → el entry aparece en la lista.
+        Assert.AreEqual(1, sorted.Count);
+        // El label del lado null se renderiza como "?" sin crashear.
+        StringAssert.Contains("?",      label);
+        StringAssert.Contains("SideB",  label);
+    }
+
+    // ────────────────────────────────────────
+    // TEST 6 — Label simple incluye prefijo tipo + nombre + coste
+    // ────────────────────────────────────────
+
+    [Test]
+    public void BuildRowLabel_Single_HasTypePrefixNameCost()
+    {
+        var c = MakeCard("x", "Strike", 1, CardType.Attack, ElementType.Rojo);
+        var entry = SingleEntry(c);
+
+        string label = DeckViewerView.BuildRowLabel(entry);
+
+        // El prefijo de tipo Rojo produce "[Rojo]" coloreado.
+        StringAssert.Contains("[Rojo]", label);
+        StringAssert.Contains("Strike", label);
+        StringAssert.Contains("1",      label);
+        StringAssert.Contains("⚡",     label);
+    }
+
+    // ────────────────────────────────────────
+    // TEST 7 — Label dual muestra AMBOS lados; colapsa cuando coinciden
+    // ────────────────────────────────────────
+
+    [Test]
+    public void BuildRowLabel_Dual_ShowsBothSides_CollapsesWhenSameNameAndType()
+    {
+        var sideA = MakeCard("a", "BladeA", 2, CardType.Attack, ElementType.Azul);
+        var sideB = MakeCard("b", "BladeB", 2, CardType.Attack, ElementType.Morado);
+        var entry = DualEntry(sideA, sideB);
+
+        string label = DeckViewerView.BuildRowLabel(entry);
+
+        // Nombre y tipo distintos → NO colapsa; ambos lados presentes.
+        StringAssert.Contains("BladeA", label);
+        StringAssert.Contains("BladeB", label);
+        StringAssert.Contains("/",      label);
+
+        // Caso colapso: mismo nombre Y mismo tipo en ambos lados.
+        var sameA = MakeCard("sa", "Twin", 1, CardType.Skill, ElementType.Azul);
+        var sameB = MakeCard("sb", "Twin", 1, CardType.Skill, ElementType.Azul);
+        var sameEntry = DualEntry(sameA, sameB);
+
+        string collapsed = DeckViewerView.BuildRowLabel(sameEntry);
+        // Colapsa: aparece "Twin" una sola vez (sin "/").
+        StringAssert.Contains("Twin", collapsed);
+        Assert.IsFalse(collapsed.Contains("Twin / Twin"), "No debe mostrar ambos tokens cuando colapsa");
+    }
+
+    // ────────────────────────────────────────
+    // TEST 8 — Tipo None no inserta token de color
+    // ────────────────────────────────────────
+
+    [Test]
+    public void BuildRowLabel_TypeNone_NoColorToken()
+    {
+        var c = MakeCard("n", "Neutral", 0, CardType.Status, ElementType.None);
+        var entry = SingleEntry(c);
+
+        string label = DeckViewerView.BuildRowLabel(entry);
+
+        // TypePrefix(None) = ""; la fila no empieza con "[".
+        StringAssert.Contains("Neutral", label);
+        Assert.IsFalse(label.TrimStart().StartsWith("["), "Carta None no debe tener token de color al inicio");
+    }
+
+    // ────────────────────────────────────────
+    // TEST 9 — Preview de mejora disponible (single)
+    // ────────────────────────────────────────
+
+    [Test]
+    public void BuildUpgradePreview_Available_Single_ShowsUpgradedValues()
+    {
+        var c = MakeCard("s", "Strike", 1, CardType.Attack);
+        c.Upgrade.SetTestData(
+            overrideCost:         true,
+            upgradedCost:         0,
+            upgradedEffects:      null,
+            upgradedName:         "Strike+",
+            upgradedDescription:  "Inflige más daño.");
+        var entry = SingleEntry(c);
+
+        string preview = DeckViewerView.BuildUpgradePreview(entry);
+
+        Assert.IsFalse(string.IsNullOrEmpty(preview), "Preview no debe estar vacío para carta con upgrade");
+        StringAssert.Contains("Mejora",   preview);
+        StringAssert.Contains("Strike+",  preview);
+        StringAssert.Contains("0",        preview);   // coste mejorado (OverrideCost = true)
+        StringAssert.Contains("Inflige",  preview);
+
+        // El label de fila tiene el marcador "+".
+        string label = DeckViewerView.BuildRowLabel(entry);
+        StringAssert.EndsWith("+", label.TrimEnd());
+    }
+
+    // ────────────────────────────────────────
+    // TEST 10 — Preview de mejora dual PER-LADO
+    // ────────────────────────────────────────
+
+    [Test]
+    public void BuildUpgradePreview_Dual_PerSide_SideAUpgradedSideBUnchanged()
+    {
+        var sideA = MakeCard("a", "BladeSA", 2, CardType.Attack);
+        sideA.Upgrade.SetTestData(
+            overrideCost:         false,
+            upgradedCost:         0,
+            upgradedEffects:      null,
+            upgradedName:         "BladeSA+",
+            upgradedDescription:  "Más filosa.");
+
+        var sideB = MakeCard("b", "BladeSB", 1, CardType.Skill);
+        // SideB NO tiene upgrade configurado.
+
+        var entry = DualEntry(sideA, sideB);
+
+        // CanUpgrade() debe ser true (aHas=true aunque bHas=false).
+        Assert.IsTrue(entry.CanUpgrade());
+
+        // El label termina en "+".
+        string label = DeckViewerView.BuildRowLabel(entry);
+        StringAssert.EndsWith("+", label.TrimEnd());
+
+        // El preview contiene los valores nuevos de A Y los valores base de B (sin cambios).
+        string preview = DeckViewerView.BuildUpgradePreview(entry);
+        StringAssert.Contains("BladeSA+", preview, "Debe mostrar nombre mejorado de A");
+        StringAssert.Contains("Más filosa", preview, "Debe mostrar descripción mejorada de A");
+        StringAssert.Contains("BladeSB",  preview, "Debe mostrar nombre base de B (sin cambios)");
+    }
+
+    // ────────────────────────────────────────
+    // TEST 11 — Sin mejora → preview vacío, sin marcador
+    // ────────────────────────────────────────
+
+    [Test]
+    public void BuildUpgradePreview_NoUpgrade_EmptyAndNoMarker()
+    {
+        var c = MakeCard("u", "Plain", 1, CardType.Attack);
+        // No se configura ningún upgrade → HasUpgrade == false.
+        var entry = SingleEntry(c);
+
+        string preview = DeckViewerView.BuildUpgradePreview(entry);
+        string label   = DeckViewerView.BuildRowLabel(entry);
+
+        Assert.IsEmpty(preview, "Sin upgrade definido el preview debe ser vacío");
+        Assert.IsFalse(label.Contains("★") || label.Contains("+"),
+            "Sin upgrade no debe haber marcador en el label");
+    }
+
+    // ────────────────────────────────────────
+    // TEST 12 — Ya mejorada → marcador ★, tooltip "Mejorada"
+    // ────────────────────────────────────────
+
+    [Test]
+    public void BuildUpgradePreview_AlreadyUpgraded_StarMarkerAndMejoradaText()
+    {
+        var c = MakeCard("m", "Enhanced", 1, CardType.Attack);
+        c.Upgrade.SetTestData(
+            overrideCost:        false,
+            upgradedCost:        0,
+            upgradedEffects:     null,
+            upgradedName:        "Enhanced+",
+            upgradedDescription: "Mucho mejor.");
+
+        var entry = SingleEntry(c);
+        entry.ApplyUpgrade(); // Aplica la mejora → IsUpgraded = true
+
+        string preview = DeckViewerView.BuildUpgradePreview(entry);
+        string label   = DeckViewerView.BuildRowLabel(entry);
+
+        StringAssert.Contains("★",       preview);
+        StringAssert.Contains("Mejorada", preview);
+        // El label lleva el marcador ★ (no "+").
+        StringAssert.Contains("★", label);
+        Assert.IsFalse(label.Contains(" +"), "Una carta ya mejorada no debe mostrar el marcador '+'");
+    }
+}

--- a/Assets/Tests/EditMode/DeckViewerTests.cs.meta
+++ b/Assets/Tests/EditMode/DeckViewerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c1483b2dcd8d2cd49a7a69a6cdde835e

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -10,12 +10,14 @@
 > **Fase actual:** M4 activo. Pre-M4 visor de mazo: ✅ CERRADO (2026-06-16).
 > **Milestone activo:** M4 — Resto del Acto 1 (bloques: 4a integridad de cartas, 4b eventos+quests, 4c transdim+ancla)
 > **Próximo bloque:** M4 bloque 4a — Integridad del sistema de cartas (spec pendiente)
-> **Última actualización:** 2026-06-16 (`modo:implementacion`: **Visor de mazo ✅ CERRADO** —
-> `DeckViewerView.cs` (sub-Canvas overlay, badge `Mazo (N)`, modal scrolleable, tooltip FadeIn/Out,
-> helpers static puros `SortForDisplay`/`BuildRowLabel`/`BuildTooltip`/`BuildUpgradePreview`).
-> `DeckViewerTests.cs` (12 casos). Montado en `RunFlowController` (RunScene) y `CombatUIController`
-> (BattleScene). Suite EditMode **166 → 178** (12 nuevos), compilación limpia. Branch
-> `feat/deck-viewer`. E2E visual pendiente de confirmación manual por Sebastián en Unity.)
+> **Última actualización:** 2026-06-16 (`modo:implementacion`: **Visor de mazo ✅ CERRADO + fixes
+> de revisión aplicados**. `DeckViewerView.cs` (sub-Canvas overlay, badge `Mazo (N)` en esquina sup.
+> izquierda, modal scrolleable, tooltip FadeIn/Out, helpers static puros). Post-revisión: nuevo
+> `CardDisplay.cs` (hogar canónico `public static` de helpers de label — corrige la 3ª copia
+> privada que marcó la revisión, M1), Test 7 des-tautologizado (M3), +3 tests de `BuildTooltip`
+> (M2), Test 1 cubre los 5 `CardType`, badge reubicado para no tapar Change World en combate.
+> `DeckViewerTests.cs` **15 casos**. Suite EditMode **166 → 181**, compilación limpia. Branch
+> `feat/deck-viewer` (PR #123). E2E visual pendiente de confirmación manual por Sebastián.)
 > **Previa:** 2026-06-16 (`modo:implementacion`: **SUB-PR 2 ✅ (#120) CERRADO
 > → REMEDIACIÓN PRE-M4 COMPLETA**. Red de tests pre-cirugía + cap de Estilo a 5 (D-B). 4
 > archivos EditMode nuevos (T3 pre-block, T4 reset+sangrado R-6, T5 dispatchabilidad de los
@@ -96,10 +98,13 @@ Spec: `Docs/dev/specs/visor_de_mazo_spec.md`.
 - [x] `DeckViewerView.cs` — sub-Canvas overlay, badge `Mazo (N)`, modal scrolleable,
       tooltip FadeIn/Out. Helpers static puros: `SortForDisplay`/`BuildRowLabel`/
       `BuildTooltip`/`BuildUpgradePreview`. Preview de mejora PER-LADO en duales.
-- [x] `DeckViewerTests.cs` — 12 casos EditMode en verde.
+- [x] `CardDisplay.cs` (post-revisión, M1) — hogar canónico `public static` de los
+      helpers de label (`RepresentativeCard`/`CardToken`/`SideType`/`EntryToken`); el
+      visor los consume en vez de duplicarlos.
+- [x] `DeckViewerTests.cs` — 15 casos EditMode en verde (incluye fixes M2/M3 de revisión).
 - [x] Montado en `RunFlowController` (RunScene: build + Refresh + Cleanup en 3 transiciones).
 - [x] Montado en `CombatUIController` (BattleScene: build + Refresh null-safe).
-- [x] Suite EditMode 166 → **178/178**. Compilación limpia.
+- [x] Suite EditMode 166 → **181/181**. Compilación limpia.
 - [ ] E2E visual en RunScene + BattleScene — pendiente de validación manual por Sebastián.
 
 **Objetivo:** UI consultable que lista el mazo completo del run. Visible siempre
@@ -587,6 +592,13 @@ cierren los milestones actuales:
   helper. Tests: `ElementTypeColorsTests.cs` ampliado con 4 casos nuevos
   (TypePrefix None, token con corchetes, hex coincide con ReadableOnDark, todos
   los tipos producen prefijo no vacío). Suite EditMode: 146/146 (4 nuevos).
+- **Migrar `ShopNodeController`/`CampfireNodeController` a `CardDisplay`**: el visor
+  de mazo (PR #123) extrajo los helpers de label de carta (`RepresentativeCard`/
+  `CardToken`/`SideType`/`EntryToken`) a `Assets/Scripts/Gameplay/Cards/CardDisplay.cs`
+  como `public static` (hogar canónico). Shop y Campfire todavía tienen sus copias
+  `private static` de `BuildCardSelectLabel`/`CardToken`/`RepresentativeCard` (2 copias
+  pre-existentes). Reemplazarlas por llamadas a `CardDisplay` elimina el drift. NO se
+  hizo en el PR del visor para no tocar los tests de Tienda/Hoguera. Riesgo bajo, ~20 min.
 - **Refactor cross-cutting de los `Initialize()` de las views**: introducir un
   struct `ViewRefs` compartido en lugar de 25+ parámetros. Tiene sentido HACER
   después de Fase 4 cerrada (cuando las 3 views estén estables). ~30 min.

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -7,10 +7,16 @@
 > En `modo:implementacion` se lee al inicio para saber qué milestone está activo
 > y qué sub-tareas quedan.
 >
-> **Fase actual:** M4 activo, reordenado 2026-06-10. Próximo paso: pulido pre-M4 (visor de mazo).
+> **Fase actual:** M4 activo. Pre-M4 visor de mazo: ✅ CERRADO (2026-06-16).
 > **Milestone activo:** M4 — Resto del Acto 1 (bloques: 4a integridad de cartas, 4b eventos+quests, 4c transdim+ancla)
-> **Próximo bloque:** M5 — Bosses con fases + Boss Acto 1 según GDD v2
-> **Última actualización:** 2026-06-16 (`modo:implementacion`: **SUB-PR 2 ✅ (#120) CERRADO
+> **Próximo bloque:** M4 bloque 4a — Integridad del sistema de cartas (spec pendiente)
+> **Última actualización:** 2026-06-16 (`modo:implementacion`: **Visor de mazo ✅ CERRADO** —
+> `DeckViewerView.cs` (sub-Canvas overlay, badge `Mazo (N)`, modal scrolleable, tooltip FadeIn/Out,
+> helpers static puros `SortForDisplay`/`BuildRowLabel`/`BuildTooltip`/`BuildUpgradePreview`).
+> `DeckViewerTests.cs` (12 casos). Montado en `RunFlowController` (RunScene) y `CombatUIController`
+> (BattleScene). Suite EditMode **166 → 178** (12 nuevos), compilación limpia. Branch
+> `feat/deck-viewer`. E2E visual pendiente de confirmación manual por Sebastián en Unity.)
+> **Previa:** 2026-06-16 (`modo:implementacion`: **SUB-PR 2 ✅ (#120) CERRADO
 > → REMEDIACIÓN PRE-M4 COMPLETA**. Red de tests pre-cirugía + cap de Estilo a 5 (D-B). 4
 > archivos EditMode nuevos (T3 pre-block, T4 reset+sangrado R-6, T5 dispatchabilidad de los
 > 23 `.asset`, T6 ×10 Grant* sobre TurnManager real, T7 cap a 5, T9 carta None 90%): suite
@@ -84,21 +90,23 @@
 
 ### Pulido pre-M4 — Visor de mazo ("librito" estilo Slay the Spire)
 
-**Estado:** pendiente — **siguiente paso del proyecto** (formato pulido
-independiente, como el #104).
+**Estado:** ✅ **IMPLEMENTADO 2026-06-16** — branch `feat/deck-viewer`, PR pendiente.
+Spec: `Docs/dev/specs/visor_de_mazo_spec.md`.
 
-**Objetivo:** UI consultable que lista el mazo completo fuera de combate
-(alcance mínimo: mapa; si entra también en nodos/combate se decide en el spec).
-Hoy NO existe ninguna vista del mazo fuera de combate.
+- [x] `DeckViewerView.cs` — sub-Canvas overlay, badge `Mazo (N)`, modal scrolleable,
+      tooltip FadeIn/Out. Helpers static puros: `SortForDisplay`/`BuildRowLabel`/
+      `BuildTooltip`/`BuildUpgradePreview`. Preview de mejora PER-LADO en duales.
+- [x] `DeckViewerTests.cs` — 12 casos EditMode en verde.
+- [x] Montado en `RunFlowController` (RunScene: build + Refresh + Cleanup en 3 transiciones).
+- [x] Montado en `CombatUIController` (BattleScene: build + Refresh null-safe).
+- [x] Suite EditMode 166 → **178/178**. Compilación limpia.
+- [ ] E2E visual en RunScene + BattleScene — pendiente de validación manual por Sebastián.
 
-**Molde:** espejo de `RelicInventoryView` (clase pura no-MonoBehaviour,
-Refresh + tooltips, instanciada por `RunFlowController`). No toca protegidos.
+**Objetivo:** UI consultable que lista el mazo completo del run. Visible siempre
+(mapa, Tienda/Hoguera sobre paneles opacos, combate). Solo lectura.
 
-**Por qué va ANTES de M4:** es la herramienta de playtesting de 4a y 4b —
-sin visor, los eventos que dan/quitan/mejoran cartas son invisibles para
-verificar qué pasó en el mazo.
-
-**Complejidad:** baja. Requiere sesión `modo:diseno` corta para el spec.
+**Por qué va ANTES de M4:** herramienta de playtesting de 4a y 4b — sin visor,
+los eventos que dan/quitan/mejoran cartas son invisibles para verificar el mazo.
 
 ---
 

--- a/Docs/dev/_tech_snapshot.md
+++ b/Docs/dev/_tech_snapshot.md
@@ -7,7 +7,20 @@
 > En `modo:implementacion` se lee OBLIGATORIAMENTE antes de cualquier cambio que
 > afecte arquitectura o componentes críticos.
 >
-> **Última actualización:** 2026-06-16 — **SUB-PR 2 auditoría: red de tests pre-cirugía
+> **Última actualización:** 2026-06-16 — **Visor de mazo** (branch `feat/deck-viewer`).
+> Nuevo `Assets/Scripts/Gameplay/Cards/UI/DeckViewerView.cs`: clase de presentación
+> pura (no MonoBehaviour), sub-Canvas overlay propio (`overrideSorting=true`,
+> `sortingOrder=100`), badge `Mazo (N)` + modal scrolleable + tooltip FadeIn/FadeOut.
+> Helpers static puros `SortForDisplay`/`BuildRowLabel`/`BuildTooltip`/
+> `BuildUpgradePreview` (testeables sin UI). Preview de mejora PER-LADO en duales,
+> leyendo `CardUpgradeDef` directo sin `CreateUpgradedClone`. Orden estable
+> `CardType→coste→nombre→Id` (LINQ OrderBy/ThenBy). Refresh null-safe.
+> Montado en `RunFlowController.BuildUI()` (RunScene: `Refresh` + `Cleanup` en 3
+> transiciones de escena) y en `CombatUIController.BuildUI()` (BattleScene: `Refresh`
+> con `RunSession.Instance?.State?.GetDeckSnapshot()`). Nuevo
+> `Assets/Tests/EditMode/DeckViewerTests.cs` (12 casos). Suite EditMode **166 → 178**.
+>
+> **Última actualización previa:** 2026-06-16 — **SUB-PR 2 auditoría: red de tests pre-cirugía
 > + cap de Estilo** (branch `feat/test-net-pre-surgery`). 4 archivos de test EditMode
 > nuevos (suite **148 → 166**, archivos **18 → 22**): `StyleChargeTests` (T3 pre-block /
 > T4 reset de estado + sangrado de counters R-6 / T7 cap a 5), `RelicAssetTests` (T5:
@@ -391,6 +404,11 @@ Gameplay/
     CardDeckEntry.cs             ← entrada de mazo (puede ser simple o dual)
     CardEnums.cs                 ← CardType, EffectType, EffectTarget
     EffectRef.cs                 ← referencia a efecto en SO
+    UI/
+      DeckViewerView.cs          ← visor de mazo (sub-Canvas overlay, badge + modal
+                                   + scroll + tooltip; static puros SortForDisplay/
+                                   BuildRowLabel/BuildTooltip/BuildUpgradePreview;
+                                   montado por RunFlowController y CombatUIController)
   Combat/
     TurnManager.cs               ← ~1107 loc — PROTEGIDO
     ActionQueue.cs               ← 85 loc — PROTEGIDO
@@ -459,7 +477,7 @@ RelicSoGenerator.cs                   ← MenuItem "Roguelike/Generate Relic Ass
                                         (idempotente — saltea archivos existentes)
 ```
 
-### Tests (`Assets/Tests/EditMode/`) — 22 archivos (suite EditMode 166/166)
+### Tests (`Assets/Tests/EditMode/`) — 23 archivos (suite EditMode 178/178)
 
 ```
 CombatTestBase.cs                ← helper compartido
@@ -502,6 +520,10 @@ RelicGrantEffectsOnTurnManagerTests.cs ← Auditoría SUB-PR 2 (T6: 10 casos de 
                                    TurnManager real, dispatch manual del hook)
 NeutralCardDamageTests.cs        ← Auditoría SUB-PR 2 (T9: carta None aplica 90% del
                                    daño base, DD-002, contra cualquier tipo)
+DeckViewerTests.cs               ← Visor de mazo (12 casos: orden tipo→coste→nombre,
+                                   estabilidad, no-mutación, null/vacío, dual SideA null,
+                                   label simple/dual/None, preview single/dual/sin-upgrade/
+                                   ya-mejorada)
 ```
 
 ### ScriptableObjects (`Assets/ScriptableObjects/`)

--- a/Docs/dev/_tech_snapshot.md
+++ b/Docs/dev/_tech_snapshot.md
@@ -7,18 +7,24 @@
 > En `modo:implementacion` se lee OBLIGATORIAMENTE antes de cualquier cambio que
 > afecte arquitectura o componentes críticos.
 >
-> **Última actualización:** 2026-06-16 — **Visor de mazo** (branch `feat/deck-viewer`).
-> Nuevo `Assets/Scripts/Gameplay/Cards/UI/DeckViewerView.cs`: clase de presentación
-> pura (no MonoBehaviour), sub-Canvas overlay propio (`overrideSorting=true`,
-> `sortingOrder=100`), badge `Mazo (N)` + modal scrolleable + tooltip FadeIn/FadeOut.
-> Helpers static puros `SortForDisplay`/`BuildRowLabel`/`BuildTooltip`/
-> `BuildUpgradePreview` (testeables sin UI). Preview de mejora PER-LADO en duales,
-> leyendo `CardUpgradeDef` directo sin `CreateUpgradedClone`. Orden estable
-> `CardType→coste→nombre→Id` (LINQ OrderBy/ThenBy). Refresh null-safe.
-> Montado en `RunFlowController.BuildUI()` (RunScene: `Refresh` + `Cleanup` en 3
-> transiciones de escena) y en `CombatUIController.BuildUI()` (BattleScene: `Refresh`
-> con `RunSession.Instance?.State?.GetDeckSnapshot()`). Nuevo
-> `Assets/Tests/EditMode/DeckViewerTests.cs` (12 casos). Suite EditMode **166 → 178**.
+> **Última actualización:** 2026-06-16 — **Visor de mazo + fixes de revisión**
+> (branch `feat/deck-viewer`). Nuevo `Assets/Scripts/Gameplay/Cards/UI/DeckViewerView.cs`:
+> clase de presentación pura (no MonoBehaviour), sub-Canvas overlay propio
+> (`overrideSorting=true`, `sortingOrder=100`), badge `Mazo (N)` (esquina superior
+> IZQUIERDA — libre en mapa y combate; la derecha taparía el botón Change World) +
+> modal scrolleable + tooltip FadeIn/FadeOut. Helpers static puros
+> `SortForDisplay`/`BuildRowLabel`/`BuildTooltip`/`BuildUpgradePreview` (testeables
+> sin UI). Preview de mejora PER-LADO en duales, leyendo `CardUpgradeDef` directo sin
+> `CreateUpgradedClone`. Orden estable `CardType→coste→nombre→Id` (LINQ OrderBy/ThenBy,
+> representante resuelto 1× por entry). Refresh null-safe. **Nuevo
+> `Assets/Scripts/Gameplay/Cards/CardDisplay.cs`** (post-revisión): hogar canónico
+> `public static` de los helpers de label (`RepresentativeCard`/`CardToken`/`SideType`/
+> `EntryToken`) que antes eran 3 copias `private static` (Shop/Campfire/visor);
+> el visor los consume. **Migrar Shop/Campfire a `CardDisplay` queda como follow-up**
+> (ver `_roadmap.md` Future work). Montado en `RunFlowController.BuildUI()` (RunScene:
+> `Refresh` + `Cleanup` en 3 transiciones de escena) y en `CombatUIController.BuildUI()`
+> (BattleScene: `Refresh` con `RunSession.Instance?.State?.GetDeckSnapshot()`). Nuevo
+> `Assets/Tests/EditMode/DeckViewerTests.cs` (15 casos). Suite EditMode **166 → 181**.
 >
 > **Última actualización previa:** 2026-06-16 — **SUB-PR 2 auditoría: red de tests pre-cirugía
 > + cap de Estilo** (branch `feat/test-net-pre-surgery`). 4 archivos de test EditMode
@@ -404,6 +410,10 @@ Gameplay/
     CardDeckEntry.cs             ← entrada de mazo (puede ser simple o dual)
     CardEnums.cs                 ← CardType, EffectType, EffectTarget
     EffectRef.cs                 ← referencia a efecto en SO
+    CardDisplay.cs               ← hogar canónico de helpers de label de carta en
+                                   texto (public static: RepresentativeCard/CardToken/
+                                   SideType/EntryToken). Consumido por el visor; Shop/
+                                   Campfire aún tienen copias privadas (follow-up)
     UI/
       DeckViewerView.cs          ← visor de mazo (sub-Canvas overlay, badge + modal
                                    + scroll + tooltip; static puros SortForDisplay/
@@ -477,7 +487,7 @@ RelicSoGenerator.cs                   ← MenuItem "Roguelike/Generate Relic Ass
                                         (idempotente — saltea archivos existentes)
 ```
 
-### Tests (`Assets/Tests/EditMode/`) — 23 archivos (suite EditMode 178/178)
+### Tests (`Assets/Tests/EditMode/`) — 23 archivos (suite EditMode 181/181)
 
 ```
 CombatTestBase.cs                ← helper compartido
@@ -520,10 +530,11 @@ RelicGrantEffectsOnTurnManagerTests.cs ← Auditoría SUB-PR 2 (T6: 10 casos de 
                                    TurnManager real, dispatch manual del hook)
 NeutralCardDamageTests.cs        ← Auditoría SUB-PR 2 (T9: carta None aplica 90% del
                                    daño base, DD-002, contra cualquier tipo)
-DeckViewerTests.cs               ← Visor de mazo (12 casos: orden tipo→coste→nombre,
-                                   estabilidad, no-mutación, null/vacío, dual SideA null,
-                                   label simple/dual/None, preview single/dual/sin-upgrade/
-                                   ya-mejorada)
+DeckViewerTests.cs               ← Visor de mazo (15 casos: orden tipo→coste→nombre
+                                   los 5 CardType, estabilidad, no-mutación, null/vacío,
+                                   dual SideA null, label simple/dual/None, preview
+                                   single/dual/sin-upgrade/ya-mejorada, + BuildTooltip
+                                   dual/lado-null/ya-mejorada)
 ```
 
 ### ScriptableObjects (`Assets/ScriptableObjects/`)

--- a/Docs/dev/_tech_snapshot.md
+++ b/Docs/dev/_tech_snapshot.md
@@ -269,7 +269,7 @@
 
 ### Tests
 - **Unity Test Framework** (NUnit) en EditMode
-- 22 archivos de test en `Assets/Tests/EditMode/` (suite 166/166)
+- 23 archivos de test en `Assets/Tests/EditMode/` (suite 181/181)
 - Helper compartido: `CombatTestBase.cs`
 
 ---

--- a/Docs/dev/specs/visor_de_mazo_spec.md
+++ b/Docs/dev/specs/visor_de_mazo_spec.md
@@ -1,7 +1,10 @@
 # Spec — Visor de mazo ("librito" estilo Slay the Spire)
 
-> **ESTADO: IMPLEMENTADO — PR pendiente (2026-06-16).** Branch `feat/deck-viewer`.
-> Suite EditMode 166 → 178/178. E2E visual pendiente de confirmación por Sebastián.
+> **ESTADO: IMPLEMENTADO + fixes de revisión (2026-06-16).** Branch `feat/deck-viewer`
+> (PR #123). Suite EditMode 166 → 181/181. Revisión aplicada: helpers de label
+> canonizados en `CardDisplay` (M1), Test 7 des-tautologizado (M3), +3 tests de
+> `BuildTooltip` (M2), badge reubicado a esquina sup. izquierda. E2E visual pendiente
+> de confirmación por Sebastián.
 
 ## Origen
 - Roadmap `_roadmap.md` § "Pulido pre-M4 — Visor de mazo". Pieza de pulido

--- a/Docs/dev/specs/visor_de_mazo_spec.md
+++ b/Docs/dev/specs/visor_de_mazo_spec.md
@@ -1,0 +1,405 @@
+# Spec — Visor de mazo ("librito" estilo Slay the Spire)
+
+> **ESTADO: IMPLEMENTADO — PR pendiente (2026-06-16).** Branch `feat/deck-viewer`.
+> Suite EditMode 166 → 178/178. E2E visual pendiente de confirmación por Sebastián.
+
+## Origen
+- Roadmap `_roadmap.md` § "Pulido pre-M4 — Visor de mazo". Pieza de pulido
+  independiente (formato como el #104/#107), previa a M4.
+- `[INTERPRETACIÓN]` Es la herramienta de playtesting de los bloques 4a y 4b:
+  sin un visor del mazo fuera de combate, los eventos que dan/quitan/mejoran
+  cartas son invisibles para verificar qué pasó con el mazo.
+
+## Objetivo
+UI consultable, de solo lectura, que lista el mazo completo del run. Permite al
+jugador (y a quien playtestea) revisar en cualquier momento qué cartas tiene,
+sus tipos, costes, descripciones y la mejora disponible de cada una.
+
+## Comportamiento esperado
+
+**Punto de entrada (siempre visible, incluido combate).** En la esquina superior
+del HUD hay un botón fijo `Mazo (N)` (N = cantidad de cartas). Está disponible:
+- En el mapa del run (RunScene).
+- Dentro de los nodos que tapan el mapa (Tienda, Hoguera, Resolve, Recompensa):
+  el botón flota por encima de esos paneles opacos.
+- En combate (BattleScene).
+
+**Al pulsar el botón** se abre un panel modal (overlay) sobre la escena actual:
+- Fondo oscuro semi-opaco que bloquea los clics de lo que hay detrás (no pausa
+  nada: el combate es por turnos, no en tiempo real).
+- Título `Mazo (N)`.
+- Lista vertical scrolleable con una fila por carta del mazo, **ordenada por
+  tipo de carta → coste → nombre**.
+- Botón `Cerrar` (y el botón `Mazo (N)` actúa como toggle).
+
+**Cada fila** muestra, en una línea de texto clara y **coloreada por tipo
+elemental** (reusa `ElementTypeColors.TypePrefix`):
+- Carta simple: `[Tipo] Nombre · {coste}⚡`.
+- Carta dual: **ambos lados** → `[TipoA] NombreA / [TipoB] NombreB · {coste}⚡`
+  (colapsa a un solo token solo si nombre Y tipo coinciden en los dos lados —
+  mismo criterio que `ShopNodeController.BuildCardSelectLabel`).
+- Marcador de mejora al final de la fila:
+  - `★` si la carta ya está mejorada (`entry.IsUpgraded`).
+  - `+` si la carta tiene una mejora disponible y aún no aplicada
+    (`entry.CanUpgrade()`).
+  - sin marcador si no tiene mejora configurada.
+
+**Al pasar el mouse / tocar una fila** aparece un tooltip (mismo mecanismo que
+`RelicInventoryView`: FadeIn/FadeOut vía `UIAnimationHelper`) con el detalle
+completo:
+- Por cada lado (A y B en duales, único en simples): `[Tipo] Nombre · coste` +
+  descripción completa.
+- Bloque de **preview de mejora** si aplica:
+  - Si ya está mejorada: línea `★ Mejorada`.
+  - Si tiene mejora disponible: bloque `Mejora ▸` con el nombre/coste/descripción
+    que tendría al mejorarse (delta legible: coste nuevo si lo cambia, descripción
+    mejorada).
+  - Si no tiene mejora configurada: nada.
+
+**Datos = solo lectura.** El visor nunca muta el mazo ni ningún estado. Solo
+consulta `RunState.Deck`.
+
+## Sistemas afectados
+- **UI:** clase de presentación nueva `DeckViewerView` (molde: `RelicInventoryView`).
+- **Run:** `RunFlowController` instancia el visor en RunScene.
+- **Combate:** `CombatUIController` instancia el visor en BattleScene.
+- **RunState:** solo lectura de `RunState.Deck` (vía `GetDeckSnapshot()`). Sin
+  cambios.
+- **ScriptableObjects:** ninguno nuevo. Lee `CardDefinition` / `DualCardDefinition`
+  / `CardUpgradeDef` ya existentes.
+- **Combate (TurnManager / protegidos):** **NINGUNO.** Ver "Archivos protegidos".
+
+## Archivos a crear
+- `Assets/Scripts/Gameplay/Cards/UI/DeckViewerView.cs`
+  — namespace `RoguelikeCardBattler.Gameplay.Cards.UI`. Clase de presentación
+  pura (NO MonoBehaviour), molde de `RelicInventoryView`. Vive en el módulo
+  `Cards` porque es la capa compartida más baja que **tanto Run como Combat ya
+  referencian**. `[CÓDIGO ACTUAL]` todo el runtime compila en un **único asmdef**
+  (`Assets/Scripts/RoguelikeCardBattler.asmdef`, `references: []`) → no hay riesgo
+  de dependencia circular a nivel asmdef en NINGUNA ubicación, y Combat→Run ya
+  existe (`CombatUIController.cs:8` `using RoguelikeCardBattler.Run;` +
+  `RunSession.Instance`). Se elige `Cards` para no profundizar el acoplamiento de
+  una vista de cartas a `Run`, no porque evite un ciclo (no lo hay).
+- `Assets/Tests/EditMode/DeckViewerTests.cs`
+  — cubre los helpers static puros (orden, label, tooltip, preview de mejora).
+
+## Archivos a modificar
+- `Assets/Scripts/Run/RunFlowController.cs`
+  — campo `DeckViewerView _deckViewer`; instanciarlo en `BuildUI()`; `Refresh`
+  con `_state.GetDeckSnapshot()` en `BuildUI` y `ShowMap`; `Cleanup()` junto a
+  `_relicView?.Cleanup()` en las transiciones de escena
+  (`StartCombatForNode`, retry de derrota, `ReturnToMainMenu`).
+- `Assets/Scripts/Gameplay/Combat/CombatUIController.cs`
+  — campo `DeckViewerView _deckViewer`; instanciarlo en `BuildUI()` (junto al
+  `_relicView`); `Refresh` con `RunSession.Instance?.State?.GetDeckSnapshot()`.
+  `[CÓDIGO ACTUAL]` `CombatUIController` **NO es archivo protegido** (~752 LOC,
+  ya se modifica libremente; los protegidos son solo TurnManager / ActionQueue /
+  PlayerCombatActor).
+
+## Archivos protegidos involucrados
+- [x] **Ninguno.** El visor no toca combate. La resolución del lado activo de las
+  duales NO depende de `TurnManager` porque el visor muestra **ambos lados
+  siempre** (es agnóstico al mundo actual) → no necesita `GetActiveCardDefinition`
+  ni el `WorldSide` vigente.
+
+## Contratos
+
+### Datos
+No introduce estructuras de datos nuevas ni campos en `RunState`/SOs. Consume:
+- `RunState.Deck : List<CardDeckEntry>` (vía `GetDeckSnapshot()`). `[CÓDIGO
+  ACTUAL]` `GetDeckSnapshot()` es una **copia SHALLOW** (`new List<>(Deck)`):
+  lista nueva pero comparte las MISMAS instancias `CardDeckEntry` que el mazo
+  vivo. Inocuo porque el visor es de solo lectura — refuerza el contrato: nunca
+  llamar mutadores sobre las entries (el visor solo lee
+  `SingleCard`/`DualCard`/`IsUpgraded`/`CanUpgrade()`).
+- `CardDeckEntry`: `SingleCard`, `DualCard`, `IsUpgraded`, `CanUpgrade()`.
+  `[CÓDIGO ACTUAL]` **Semántica dual de `CanUpgrade()` = CUALQUIER lado**
+  (`CardDeckEntry.cs:38-42`: `aHas || bHas`). El marcador `+` y el gate del
+  preview se rigen por esto: una dual con upgrade en UN solo lado ya es mejorable.
+- `CardDefinition`: `CardName`, `Type` (CardType), `Cost`, `Description`,
+  `ElementType`, `Upgrade` (`CardUpgradeDef`).
+- `DualCardDefinition`: `DisplayName`, `SideA`, `SideB`. `[CÓDIGO ACTUAL]`
+  **NO expone `Cost`** — cada lado es un `CardDefinition` con su propio `Cost`. El
+  "comparten coste" es solo convención de autoría (comentario de la clase), NO
+  está enforced. → el coste de la fila se lee del lado representante
+  (`RepresentativeCard.Cost`, espejo de `ShopNodeController.RepresentativeCard`).
+- `CardUpgradeDef`: `HasUpgrade`, `OverrideCost`, `UpgradedCost`, `UpgradedName`,
+  `UpgradedDescription`.
+
+### APIs públicas (de `DeckViewerView`)
+
+**Instancia (presentación):**
+- `DeckViewerView(Canvas hostCanvas, Font font)` — crea, bajo `hostCanvas`, un
+  **sub-Canvas overlay propio** (`overrideSorting = true`, `sortingOrder` alto,
+  p. ej. 100) que contiene el botón `Mazo (N)` + el panel modal + el tooltip. El
+  sub-Canvas garantiza que el visor flote por encima de paneles opacos
+  (ShopPanel, CampfirePanel) y del HUD de combate sin coordinar con ellos.
+  `[PROPUESTA]` **Divergencia intencional del molde:** `RelicInventoryView` toma
+  `(RectTransform parent, Font)` y monta el tooltip vía
+  `parent.GetComponentInParent<Canvas>()`. Acá el ctor toma un `Canvas` y el
+  tooltip se parenta bajo el **sub-Canvas nuevo** (NO copiar el patrón
+  parent-RectTransform del molde para el tooltip).
+- `void Refresh(IReadOnlyList<CardDeckEntry> deck)` — actualiza el contador del
+  badge y, si el modal está abierto, reconstruye la lista. Cachea la última lista
+  para reconstruir al abrir. Lee la lista que le pasa el owner (no referencia
+  `RunState`). **Null-safe:** `deck == null` se trata como vacío → badge
+  `Mazo (0)`, lista vacía, sin excepción. (En BattleScene standalone sin
+  `RunSession`, `RunSession.Instance?.State?.GetDeckSnapshot()` es `null`.)
+- `void Open()` / `void Close()` / `void Toggle()` — control del modal. `Open`
+  reconstruye la lista desde la última recibida en `Refresh`.
+- `void Cleanup()` — destruye los GameObjects creados (sub-Canvas + tooltip),
+  espejo de `RelicInventoryView.Cleanup()`. La llaman los owners en transiciones
+  de escena.
+
+**Helpers static puros (testeables sin UI — patrón `ShopNodeController.BuildStock`
+/ `StarterDraft`):**
+- `static List<CardDeckEntry> SortForDisplay(IReadOnlyList<CardDeckEntry> deck)`
+  — devuelve una **lista nueva** ordenada por
+  `(CardType del representante, Cost del representante, Nombre, Id)`. No muta la
+  entrada. **Orden ESTABLE obligatorio:** usar `OrderBy/ThenBy` (LINQ, estable) o
+  un tie-break final por `Id` — NO `List<T>.Sort` (no es estable) → así dos
+  cartas con la misma `(tipo,coste,nombre)` conservan su orden de entrada de forma
+  determinista (evita tests flaky).
+  - Representante = `SingleCard ?? DualCard.SideA` (espejo de
+    `ShopNodeController.RepresentativeCard`). Entradas inválidas (`!IsValid`) se
+    filtran. **Edge case (`SideA` null):** una dual con `DualCard != null` pero
+    `SideA == null` ES `IsValid` (IsValid solo mira que `dualCard != null`), así
+    que NO la filtra el guard `!IsValid`; el representante caería en null →
+    `RepresentativeCard` debe hacer fallback `SideA ?? SideB` y, si ambos son
+    null, la entrada se omite. Sin esto hay riesgo de `NullReferenceException` al
+    leer `rep.Cost`/`rep.Type`.
+- `static string BuildRowLabel(CardDeckEntry entry)` — la línea de la fila
+  (rich-text con `TypePrefix`, ambos lados en duales, coste, marcador ★/+). Los
+  lados null se renderizan como `?` (mismo guard que `CardToken`); nunca crashea.
+- `static string BuildTooltip(CardDeckEntry entry)` — el cuerpo del tooltip
+  (por lado: tipo/nombre/coste/descripción + bloque de preview de mejora).
+- `static string BuildUpgradePreview(CardDeckEntry entry)` — `""` si no hay
+  mejora configurada; `★ Mejorada` si `IsUpgraded`; si no, el bloque `Mejora ▸`
+  con lo que la carta SE CONVERTIRÍA al mejorarse. Lee los campos de
+  `CardUpgradeDef` **sin** llamar `CreateUpgradedClone()` (no instancia SOs para
+  un preview): nombre vacío ⇒ `Nombre+`, descripción vacía ⇒ la base, coste =
+  `UpgradedCost` si `OverrideCost` else el base.
+  - **CRÍTICO — preview PER-LADO en duales.** `CardDeckEntry.CanUpgrade()` en
+    duales devuelve true si **cualquiera** de los dos lados tiene upgrade
+    (`aHas || bHas`), y `DualCardDefinition.CreateUpgradedClone()` mejora **solo
+    los lados con `HasUpgrade`** (el otro queda igual) y renombra el dual a
+    `displayName + "+"`. Un preview de un solo nombre/coste/descripción NO puede
+    representar "lado A mejorado, lado B sin tocar". Por eso el preview de una
+    dual se construye **por lado** (espejo de la estructura per-lado del tooltip):
+    para cada lado, si `SideX.Upgrade.HasUpgrade` muestra sus valores nuevos, si
+    no muestra el lado sin cambios. Así el preview COINCIDE con lo que produce un
+    upgrade real (el jugador no ve un preview falso).
+
+### Eventos
+Ninguno. El visor no se suscribe a eventos de `TurnManager` ni dispara hooks.
+
+## Reuso
+- **Molde `RelicInventoryView`** (`Gameplay/Relics/UI/`): clase pura no-MonoBehaviour,
+  `Refresh`/`Cleanup`, tooltip único al root con `EventTrigger`
+  PointerEnter/PointerExit + FadeIn/FadeOut. Copiar esa estructura.
+- **`ElementTypeColors.TypePrefix(ElementType)`** — token `[Tipo]` coloreado
+  (fuente única de verdad; `None` ⇒ string vacío).
+- **Patrón de label de carta dual** — `ShopNodeController.BuildCardSelectLabel` /
+  `CardToken` / `RepresentativeCard`. `[CÓDIGO ACTUAL]` estos 3 son `private
+  static` y **ya están duplicados** en `ShopNodeController` y
+  `CampfireNodeController` (lo nota `_tech_snapshot.md`). Para NO crear una 3ª
+  copia que arrastre el drift: el visor define sus versiones como **`public
+  static` en el módulo `Cards`** (p. ej. un `CardDisplay` helper), que quedan como
+  el **hogar canónico** de esta lógica. Migrar Shop/Campfire a ese helper queda
+  como **follow-up fuera de scope** de este pulido (anotado abajo en Estimación)
+  para no inflar la complejidad ni tocar tests de la Tienda/Hoguera. Criterio de
+  colapso a replicar: colapsa a un token solo si nombre Y tipo coinciden en
+  ambos lados, con lados null renderizados como `?` (nunca colapsan).
+- **`UIAnimationHelper`** — `FadeIn`/`FadeOut` (tooltip), `ScaleIn` (apertura del
+  modal, opcional).
+- **`RunState.GetDeckSnapshot()`** — copia del mazo ya existente.
+- **ScrollRect vertical estándar** (Viewport + Content con `VerticalLayoutGroup`
+  + `ContentSizeFitter`). `[ALTERNATIVA]` reusar el `CreateScrollView` de
+  `RunMapView` — descartado: ese está cableado para scroll **horizontal** y
+  matemática de mapa; un ScrollRect vertical vanilla es más simple y sin
+  acoplar `Cards` → `Run.Map`.
+- **`CardDeckEntry.IsUpgraded` / `CanUpgrade()`** y **`CardDefinition.Upgrade`**
+  (`CardUpgradeDef`) — datos de mejora ya existentes (Sub-PR 3C).
+
+## Casos de prueba (EditMode) — `DeckViewerTests.cs`
+1. **Orden tipo→coste→nombre:** dado un mazo con tipos/costes/nombres variados,
+   `SortForDisplay` los devuelve agrupados por `CardType` (Attack→Skill→Power→
+   Curse→Status), dentro por coste asc, luego nombre.
+2. **Sort estable en claves iguales:** dos entries con misma `(tipo,coste,nombre)`
+   conservan su orden de entrada relativo (valida `OrderBy/ThenBy` o tie-break por
+   `Id`, no `List.Sort`).
+3. **Sort no muta la entrada** y devuelve lista nueva (la original conserva su
+   orden y conteo).
+4. **Null / vacío:** `SortForDisplay(null)` y `SortForDisplay(empty)` ⇒ lista
+   vacía, sin excepción. (Es la base de `Refresh(null)` → badge `Mazo (0)`.)
+5. **Dual con `SideA` null no crashea:** entry dual con `SideA == null` (sigue
+   siendo `IsValid`) ⇒ `SortForDisplay`/`BuildRowLabel` no lanzan
+   `NullReferenceException` (fallback a `SideB` o se omite; lados null → `?`).
+6. **Label simple:** incluye el prefijo de tipo coloreado + nombre + coste.
+7. **Label/tooltip dual muestra AMBOS lados:** nombre y tipo de A y de B
+   presentes; colapsa a uno solo cuando nombre Y tipo coinciden en ambos lados
+   **no-null** (no asertar colapso con lados null — esos van como `?`).
+8. **Tipo neutro (None):** `TypePrefix(None)` vacío ⇒ la fila no inserta token de
+   color para esa carta (sin corchetes colgando).
+9. **Preview de mejora disponible (single):** entry single con `CardUpgradeDef`
+   configurado y `!IsUpgraded` ⇒ `BuildUpgradePreview` no vacío y refleja el
+   coste/nombre/descripción mejorados (incluido `OverrideCost`).
+10. **Preview de mejora dual PER-LADO:** entry dual con upgrade SOLO en `SideA`
+    (SideB sin upgrade) ⇒ `CanUpgrade() == true`, `BuildRowLabel` termina en `+`,
+    y el preview muestra los valores nuevos de A **y B sin cambios** — coincide
+    con lo que produciría `ApplyUpgrade()`/`CreateUpgradedClone()`.
+11. **Sin mejora configurada:** `HasUpgrade == false` en todos los lados ⇒
+    `BuildUpgradePreview == ""` y la fila no lleva marcador `+`.
+12. **Ya mejorada:** `entry.IsUpgraded == true` ⇒ marcador `★` y el tooltip dice
+    `Mejorada` (no muestra el "se convertiría en…").
+
+> Construcción de fixtures (molde `NewRunTests`/`ShopTests`/`CampfireTests`):
+> `CardDefinition` vía `ScriptableObject.CreateInstance` + `SetDebugData`
+> (**siempre público, sin `#if`**). La mejora se adjunta sobre la carta ya creada:
+> `cardDef.Upgrade.SetTestData(...)` (`Upgrade` devuelve la instancia default
+> no-null; `SetTestData` SÍ está bajo `UNITY_EDITOR || UNITY_INCLUDE_TESTS`, igual
+> que `CardDeckEntry.SetSingleCard`/`SetDualCard`). El asmdef de EditMode define
+> `UNITY_INCLUDE_TESTS`, así que esos guards están disponibles en los tests.
+
+## Validación manual (RunScene + BattleScene)
+1. **RunScene:** entrar a una run; en el mapa, el botón `Mazo (N)` muestra el
+   conteo correcto (10 al inicio). Abrir → lista ordenada, colores por tipo,
+   duales con ambos lados, scroll si hay muchas. Cerrar.
+2. **Persistencia del conteo:** comprar/eliminar una carta en la Tienda, volver al
+   mapa → el badge y la lista reflejan el cambio. Mejorar una carta en la Hoguera
+   → la fila pasa a `★` y el tooltip dice `Mejorada`.
+3. **Sobre paneles opacos:** abrir Tienda/Hoguera → el botón `Mazo (N)` sigue
+   visible encima del panel; abrir el visor encima de la Tienda funciona.
+4. **Preview de mejora:** una carta del starter con upgrade configurado muestra
+   `+` y, en el tooltip, el bloque `Mejora ▸` con los números nuevos.
+5. **BattleScene:** entrar en combate; el botón `Mazo (N)` está en el HUD; abrir
+   el visor muestra el mazo completo del run; el dimmer bloquea clics sobre las
+   cartas de la mano; cerrar y seguir jugando sin errores.
+6. **Zero console errors** en todos los pasos.
+
+## Decisiones cerradas
+1. **Presentación = filas de texto coloreadas** (no caras con arte), porque el
+   arte de cartas no es final. La clase queda **diseñada para escalar a arte**
+   después (separar `BuildRowLabel` de la construcción de la fila para poder
+   reemplazar la fila por una cara C7 sin tocar la lógica de orden/datos).
+2. **Mostrar ambos lados (A y B) de las duales**, siempre — refuerza la dualidad
+   del juego y hace el visor agnóstico al mundo (no necesita estado de combate).
+3. **Preview de mejora** por carta (★ mejorada / + disponible + bloque en
+   tooltip), leyendo `CardUpgradeDef` sin clonar SOs.
+4. **Orden:** CardType → coste → nombre.
+5. **Alcance: visible en todo momento, incluido combate.** Montado por
+   `RunFlowController` (RunScene) y `CombatUIController` (BattleScene). El
+   sub-Canvas overlay propio lo hace flotar también sobre Tienda/Hoguera/Resolve/
+   Recompensa con un solo punto de montaje por escena.
+6. **Modal overlay** (no escena nueva): respeta el molde y evita transición de
+   escena. Fondo que bloquea raycasts; no pausa (combate por turnos).
+7. **Scroll vertical, sin paginación.** Mazos de 10–25 cartas (GOLDEN_RULES §5)
+   caben en scroll cómodo.
+8. **Solo lectura.** El visor nunca muta `RunState`. (Eliminar/mejorar siguen
+   siendo de Tienda/Hoguera.)
+9. **Fuente de datos = `RunState.Deck`** en ambas escenas (en combate es el mazo
+   maestro del run; `TurnManager` trabaja sobre sus propias pilas runtime y no lo
+   toca). El visor muestra el mazo completo, no la pila de robo/descarte.
+
+## Decisiones abiertas (REQUIEREN cierre antes de implementar)
+- Ninguna. Spec cerrado.
+
+## Alternativas consideradas
+- **Caras de carta con arte (cuadrícula, "librito" StS literal)** — descartada
+  por ahora: el arte de cartas no es final y subía la complejidad a baja-media.
+  Se deja la puerta abierta (decisión cerrada #1).
+- **Pantalla/escena dedicada** — descartada: rompe el molde `RelicInventoryView`
+  y añade transición de escena para una vista de solo lectura.
+- **Botón en `_mapPanel` (sin sub-Canvas)** — descartada: los paneles de
+  Tienda/Hoguera son opacos y tapan el `_mapPanel`; un botón ahí no estaría
+  "visible en todo momento". El sub-Canvas con `sortingOrder` alto resuelve esto
+  sin tocar los controllers de cada nodo.
+- **Refrescar el badge cada frame desde `Update()` del owner** (como
+  `SyncRelicInventory`) — descartada: genera asignación de strings por frame. En
+  su lugar, `Refresh` se llama en puntos de cambio (build, `ShowMap`, y al abrir
+  el modal se relee). `[CÓDIGO ACTUAL]` el badge puede quedar momentáneamente
+  desfasado mientras se está DENTRO de un panel opaco de nodo sin abrir el visor;
+  es cosmético y la lista siempre se construye fresca al abrir.
+
+## Estimación
+- **Complejidad:** baja (se desvía levemente del molde por el sub-Canvas overlay
+  y los 2 puntos de montaje, pero la lógica es de solo lectura y los datos ya
+  existen).
+- **Sub-tareas:**
+  1. `DeckViewerView` (helpers static puros + UI: badge, modal, scroll, tooltip).
+  2. `DeckViewerTests.cs` (12 casos).
+  3. Montaje en `RunFlowController` (build + Refresh + Cleanup).
+  4. Montaje en `CombatUIController` (build + Refresh).
+  5. Validación en Unity (RunScene + BattleScene).
+- **Follow-up FUERA de scope (no hacer en este PR):** migrar
+  `ShopNodeController`/`CampfireNodeController` a los helpers `public static`
+  canónicos de label/representante del módulo `Cards` (hoy son 3 copias privadas).
+  Es deuda de duplicación pre-existente; consolidarla acá inflaría el scope y
+  tocaría tests de Tienda/Hoguera. Anotar en `_roadmap.md` Future work.
+- **Riesgo:** bajo. Único punto fino: el sub-Canvas overlay debe quedar por
+  encima de los paneles opacos (verificar `overrideSorting`/`sortingOrder` en
+  Unity). Sin impacto en combate ni en archivos protegidos.
+
+## Prompt de handoff para `modo:implementacion`
+
+```markdown
+modo:implementacion
+
+Implementá el "Visor de mazo" (pulido pre-M4). El spec cerrado está en
+`Docs/dev/specs/visor_de_mazo_spec.md` — leelo completo antes de tocar código;
+todas las decisiones de diseño ya están cerradas, no abras ninguna.
+
+Setup de branch (no depende de ningún PR previo):
+  git fetch --all --prune
+  git checkout -b feat/deck-viewer origin/main
+
+Qué construir (resumen; el detalle y los contratos están en el spec):
+- CREAR `Assets/Scripts/Gameplay/Cards/UI/DeckViewerView.cs` — clase de
+  presentación pura (molde `RelicInventoryView`): sub-Canvas overlay propio con
+  badge `Mazo (N)` + modal scrolleable + tooltip. Helpers static puros
+  `SortForDisplay` / `BuildRowLabel` / `BuildTooltip` / `BuildUpgradePreview`.
+- CREAR `Assets/Tests/EditMode/DeckViewerTests.cs` — 12 casos (orden tipo→coste→
+  nombre + estabilidad, no-mutación, null/vacío, dual con SideA null sin crash,
+  label simple/dual ambos lados, tipo None, preview mejora single, preview mejora
+  dual PER-LADO, sin mejora, ya-mejorada).
+- MODIFICAR `Assets/Scripts/Run/RunFlowController.cs` — montar `_deckViewer` en
+  `BuildUI()`, `Refresh(_state.GetDeckSnapshot())` en `BuildUI`/`ShowMap`,
+  `Cleanup()` en las transiciones de escena (junto a `_relicView?.Cleanup()`).
+- MODIFICAR `Assets/Scripts/Gameplay/Combat/CombatUIController.cs` — montar
+  `_deckViewer` en `BuildUI()` (junto al `_relicView`) y `Refresh` con
+  `RunSession.Instance?.State?.GetDeckSnapshot()`.
+
+Reglas no negociables:
+- NO tocar archivos protegidos (TurnManager, ActionQueue, PlayerCombatActor).
+  El visor NO los necesita (muestra ambos lados de las duales → agnóstico al
+  mundo, sin GetActiveCardDefinition).
+- No manual editor setup: el visor se auto-crea en runtime, montado por los
+  scene controllers existentes. Sin SOs nuevos.
+- Solo lectura: el visor NUNCA muta RunState. Sin eventos de TurnManager.
+- Reusar `ElementTypeColors.TypePrefix`, el criterio de label dual de
+  `ShopNodeController.BuildCardSelectLabel`, `UIAnimationHelper` (FadeIn/Out),
+  `RunState.GetDeckSnapshot()`. No duplicar helpers.
+- El preview de mejora lee `CardUpgradeDef` directo (sin `CreateUpgradedClone`) y
+  es PER-LADO en duales (mejora solo el lado con `HasUpgrade`; el otro va sin
+  cambios) — debe coincidir con lo que produce `ApplyUpgrade`. `CanUpgrade()` en
+  duales es CUALQUIER lado.
+- `Refresh(null)` es null-safe (→ `Mazo (0)`, lista vacía). `SortForDisplay` usa
+  orden ESTABLE (`OrderBy/ThenBy` o tie-break por `Id`) y tolera `SideA` null
+  (fallback `SideB` / omitir; lados null → `?`).
+- Label/representante: definir los helpers como `public static` en el módulo
+  `Cards` (hogar canónico). NO migrar Shop/Campfire en este PR (follow-up).
+- CS0104: `UnityEngine.Object` explícito donde se use `System` + `UnityEngine`.
+
+Validación obligatoria antes de cerrar:
+- Compilación limpia (zero console errors).
+- `DeckViewerTests` en verde + suite EditMode completa sin regresiones
+  (Unity-MCP `tests-run` o Test Runner EditMode).
+- Flujo end-to-end: RunScene (mapa: badge, lista ordenada, duales, scroll;
+  Tienda/Hoguera: botón visible encima del panel opaco; mejora → ★) y
+  BattleScene (botón en HUD, dimmer bloquea clics de la mano, cerrar y seguir).
+- Validar en Unity con Unity-MCP (abrir escena, Play, screenshot del modal).
+
+Al cerrar: actualizá `_roadmap.md` (checkbox del visor pre-M4 + mover la flecha
+"próximo paso" a M4/4a) y `_tech_snapshot.md` (nuevo `DeckViewerView` + montaje
+en RunFlowController/CombatUIController). Commit + push + PR a main.
+```


### PR DESCRIPTION
## Summary

- **Nuevo `DeckViewerView.cs`** (`Assets/Scripts/Gameplay/Cards/UI/`): clase de presentación pura (no MonoBehaviour) con sub-Canvas overlay propio (`sortingOrder=100`) que flota sobre paneles opacos (Tienda/Hoguera) y el HUD de combate. Badge `Mazo (N)` + modal scrolleable + tooltip FadeIn/FadeOut vía UIAnimationHelper.
- **Helpers static puros** testeables sin UI: `SortForDisplay` (orden estable CardType→coste→nombre→Id, LINQ, tolerante a SideA null), `BuildRowLabel` (rich-text TypePrefix, duales ambos lados, colapso, marcadores ★/+), `BuildTooltip` (por lado A/B), `BuildUpgradePreview` (per-lado en duales, lee `CardUpgradeDef` directo sin `CreateUpgradedClone`). `Refresh(null)` null-safe.
- **Montaje en RunFlowController** (RunScene): build + Refresh + Cleanup en las 3 transiciones de escena (combate, retry, main menu).
- **Montaje en CombatUIController** (BattleScene): build + Refresh con `RunSession.Instance?.State?.GetDeckSnapshot()`.
- **`DeckViewerTests.cs`**: 12 casos EditMode — orden, estabilidad, no-mutación, null/vacío, dual SideA null sin crash, label simple/dual/None, preview single/dual per-lado/sin-upgrade/ya-mejorada.
- No toca archivos protegidos (TurnManager/ActionQueue/PlayerCombatActor). Solo lectura del RunState.

## Test plan

- [x] Suite EditMode 178/178 (166 previos + 12 nuevos DeckViewerTests) — verificado con Unity-MCP `tests-run`
- [x] Compilación limpia (zero console errors) — verificado con `assets-refresh`
- [x] Diagnóstico runtime de helpers: Sort, BuildRowLabel, BuildUpgradePreview — verificado con `script-execute`
- [ ] E2E visual en RunScene (badge visible, modal abre, lista ordenada, duales con ambos lados, scroll) — pendiente de validación manual por Sebastián
- [ ] E2E en nodos sobre mapa (Tienda/Hoguera: badge flota sobre panel opaco) — pendiente
- [ ] E2E en BattleScene (badge en HUD, dimmer bloquea clics de mano, cerrar y seguir) — pendiente

Closes #123 (pre-M4 visor de mazo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)