### PR TITLE
feat(cards): M4 4a — integridad del sistema de cartas (afinidad + cobertura de mejoras)

### DIFF
--- a/Assets/Editor/CardUpgradeSetup.cs
+++ b/Assets/Editor/CardUpgradeSetup.cs
@@ -55,8 +55,8 @@ namespace RoguelikeCardBattler.Editor
             CardDefinition card = LoadCard(assetName);
             if (card == null) { missing++; return 0; }
 
-            List<EffectRef> upgraded = CloneEffectsAddingTo(card, EffectType.Damage, delta);
-            int newValue = FindFirstEffectValue(upgraded, EffectType.Damage, fallback: 0);
+            List<EffectRef> upgraded = EditorCardAuthoring.CloneEffectsBoostingFirst(card, EffectType.Damage, delta);
+            int newValue = EditorCardAuthoring.FirstEffectValue(upgraded, EffectType.Damage, fallback: 0);
             string newDesc = $"Deal {newValue} damage to an enemy.";
             card.Upgrade.SetTestData(false, 0, upgraded, null, newDesc);
             EditorUtility.SetDirty(card);
@@ -68,8 +68,8 @@ namespace RoguelikeCardBattler.Editor
             CardDefinition card = LoadCard(assetName);
             if (card == null) { missing++; return 0; }
 
-            List<EffectRef> upgraded = CloneEffectsAddingTo(card, EffectType.Block, delta);
-            int newValue = FindFirstEffectValue(upgraded, EffectType.Block, fallback: 0);
+            List<EffectRef> upgraded = EditorCardAuthoring.CloneEffectsBoostingFirst(card, EffectType.Block, delta);
+            int newValue = EditorCardAuthoring.FirstEffectValue(upgraded, EffectType.Block, fallback: 0);
             string newDesc = $"Gain {newValue} Block.";
             card.Upgrade.SetTestData(false, 0, upgraded, null, newDesc);
             EditorUtility.SetDirty(card);
@@ -87,44 +87,6 @@ namespace RoguelikeCardBattler.Editor
             card.Upgrade.SetTestData(true, newCost, null, null, null);
             EditorUtility.SetDirty(card);
             return 1;
-        }
-
-        private static int FindFirstEffectValue(List<EffectRef> list, EffectType type, int fallback)
-        {
-            foreach (EffectRef e in list)
-            {
-                if (e.effectType == type) return e.value;
-            }
-            return fallback;
-        }
-
-        /// <summary>
-        /// Devuelve una nueva lista de EffectRef copiando los del card y sumando
-        /// <paramref name="delta"/> al primer efecto cuyo type coincide. Si no
-        /// hay efecto del tipo pedido, devuelve la lista clonada sin cambios
-        /// (CardUpgradeDef seguirá detectando HasUpgrade porque la lista es != vacía).
-        /// </summary>
-        private static List<EffectRef> CloneEffectsAddingTo(CardDefinition card, EffectType type, int delta)
-        {
-            var result = new List<EffectRef>();
-            bool boosted = false;
-            foreach (EffectRef src in card.Effects)
-            {
-                EffectRef copy = new EffectRef
-                {
-                    effectType = src.effectType,
-                    value = src.value,
-                    target = src.target,
-                    statusType = src.statusType
-                };
-                if (!boosted && copy.effectType == type)
-                {
-                    copy.value += delta;
-                    boosted = true;
-                }
-                result.Add(copy);
-            }
-            return result;
         }
 
         private static CardDefinition LoadCard(string assetName)

--- a/Assets/Editor/EditorCardAuthoring.cs
+++ b/Assets/Editor/EditorCardAuthoring.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using RoguelikeCardBattler.Gameplay.Cards;
+
+namespace RoguelikeCardBattler.Editor
+{
+    /// <summary>
+    /// Helpers de autorado de cartas compartidos por los menús editor
+    /// (<see cref="CardUpgradeSetup"/>, <see cref="StarterDeckSetup"/>). Centraliza
+    /// el clonado de efectos para que el balance de upgrades NO derive en silencio
+    /// entre menús (antes existían dos copias byte-idénticas de este código).
+    /// </summary>
+    public static class EditorCardAuthoring
+    {
+        /// <summary>
+        /// Devuelve una copia de los efectos de <paramref name="card"/> sumando
+        /// <paramref name="delta"/> al primer efecto cuyo tipo coincide. Si no hay
+        /// efecto del tipo pedido, devuelve la lista clonada sin cambios (la lista
+        /// resultante sigue siendo != vacía → CardUpgradeDef.HasUpgrade la detecta).
+        /// </summary>
+        public static List<EffectRef> CloneEffectsBoostingFirst(CardDefinition card, EffectType type, int delta)
+        {
+            var result = new List<EffectRef>();
+            bool boosted = false;
+            foreach (EffectRef src in card.Effects)
+            {
+                EffectRef copy = new EffectRef
+                {
+                    effectType = src.effectType,
+                    value = src.value,
+                    target = src.target,
+                    statusType = src.statusType
+                };
+                if (!boosted && copy.effectType == type)
+                {
+                    copy.value += delta;
+                    boosted = true;
+                }
+                result.Add(copy);
+            }
+            return result;
+        }
+
+        /// <summary>Valor del primer efecto del tipo pedido, o <paramref name="fallback"/> si no hay.</summary>
+        public static int FirstEffectValue(IReadOnlyList<EffectRef> list, EffectType type, int fallback)
+        {
+            foreach (EffectRef e in list)
+            {
+                if (e.effectType == type) return e.value;
+            }
+            return fallback;
+        }
+    }
+}

--- a/Assets/Editor/EditorCardAuthoring.cs.meta
+++ b/Assets/Editor/EditorCardAuthoring.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cb57492d5823a2742aedb688cac6b906

--- a/Assets/Editor/StarterDeckSetup.cs
+++ b/Assets/Editor/StarterDeckSetup.cs
@@ -51,11 +51,16 @@ namespace RoguelikeCardBattler.Editor
             // 3. Recomposición del starter deck (9 entradas single).
             bool deckWritten = RecomposeStarterDeck(strikeAffine, strikeNeutral, defendAffine, defendNeutral);
 
+            // 4. Reward pool afín (4a follow-up): las recompensas de combate adoptan los
+            //    tipos de mundo del jugador al ganarlas, en vez de los duales Rojo/Negro fijos.
+            bool rewardWritten = RecomposeRewardPool(strikeAffine, defendAffine, strikeNeutral);
+
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();
 
             Debug.Log($"[StarterDeckSetup] bodies=4 facesUpgraded={facesUpgraded} " +
-                      $"starterDeck={(deckWritten ? "9 entradas" : "NO escrito (config faltante)")}.");
+                      $"starterDeck={(deckWritten ? "9 entradas" : "NO escrito (config faltante)")} " +
+                      $"rewardPool={(rewardWritten ? "3 afines/neutra" : "NO escrito (config faltante)")}.");
         }
 
         // ──────────────────────────────────────────────
@@ -220,6 +225,39 @@ namespace RoguelikeCardBattler.Editor
             {
                 deck.Add(CardDeckEntry.CreateSingle(card));
             }
+        }
+
+        // ──────────────────────────────────────────────
+        // 4. Reward pool afín (4a follow-up)
+        // ──────────────────────────────────────────────
+
+        /// <summary>
+        /// Reescribe RunCombatConfig_Act1.rewardPool a cartas AFINES single (+1 neutra):
+        /// Strike afín, Defend afín, Strike neutra. Al ganarlas, RunState.AddCardToDeck
+        /// las rutea por AffinityResolver → las afines adoptan los tipos elegidos por el
+        /// jugador (Mundo A/B), la neutra entra como None. Reusa los mismos cuerpos del
+        /// starter (no crea SOs nuevos). GetRewardOptions toma las primeras ChoicesCount.
+        /// </summary>
+        private static bool RecomposeRewardPool(
+            CardDefinition strikeAffine, CardDefinition defendAffine, CardDefinition strikeNeutral)
+        {
+            RunCombatConfig config = AssetDatabase.LoadAssetAtPath<RunCombatConfig>(ConfigPath);
+            if (config == null)
+            {
+                Debug.LogWarning($"[StarterDeckSetup] No se encontró {ConfigPath}; reward pool no recompuesto.");
+                return false;
+            }
+
+            var pool = new List<CardDeckEntry>
+            {
+                CardDeckEntry.CreateSingle(strikeAffine),
+                CardDeckEntry.CreateSingle(defendAffine),
+                CardDeckEntry.CreateSingle(strikeNeutral),
+            };
+
+            config.EditorPopulateRewardPool(pool);
+            EditorUtility.SetDirty(config);
+            return true;
         }
     }
 }

--- a/Assets/Editor/StarterDeckSetup.cs
+++ b/Assets/Editor/StarterDeckSetup.cs
@@ -1,0 +1,249 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using RoguelikeCardBattler.Gameplay.Cards;
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Run;
+
+namespace RoguelikeCardBattler.Editor
+{
+    /// <summary>
+    /// Autorado del mazo inicial del Acto 1 (M4 bloque 4a). Menú idempotente que:
+    ///   1. Crea/asegura los 4 SOs de cuerpo del starter (Strike/Defend × afín/neutra)
+    ///      con su mejora (Strike 6→9, Defend 5→10).
+    ///   2. Autora la mejora en las 18 caras de NewRunFaces/ (la dual drafteada se
+    ///      vuelve mejorable en la Hoguera — sus dos lados pasan a tener upgrade).
+    ///   3. Reescribe RunCombatConfig_Act1.starterDeck a la composición GDD §5:
+    ///      3 Strike_Affine + 2 Strike_Neutral + 2 Defend_Affine + 2 Defend_Neutral
+    ///      (9 entradas single; la 10ª es la dual drafteada, inyectada por
+    ///      InitializeDeck vía PendingStarterCard).
+    ///
+    /// Re-ejecutable sin limpieza manual: sobreescribe datos de los SOs existentes.
+    /// Espejo del patrón *Setup.cs (NewRunConfigSetup / ShopConfigSetup / CardUpgradeSetup).
+    /// Los 6 SOs viejos del starter (StrikeBasic/DefendBasic/BattleFocus×lados) NO se
+    /// tocan — quedan intactos para el rewardPool y ya traen su upgrade commiteado.
+    /// </summary>
+    public static class StarterDeckSetup
+    {
+        private const string FolderCards = "Assets/ScriptableObjects/Cards";
+        private const string FacesFolder = FolderCards + "/NewRunFaces";
+        private const string ConfigPath = "Assets/ScriptableObjects/Run/RunCombatConfig_Act1.asset";
+
+        // Valores de balance espejados de los cuerpos básicos actuales (StrikeBasic/
+        // DefendBasic) y de los placeholders de upgrade ya probados en CardUpgradeSetup.
+        private const int StrikeBaseDamage = 6;
+        private const int StrikeUpgradeDelta = 3;   // 6 → 9
+        private const int DefendBaseBlock = 5;
+        private const int DefendUpgradeDelta = 5;   // 5 → 10
+
+        [MenuItem("Roguelike/Setup Starter Deck (4a)")]
+        public static void Setup()
+        {
+            // 1. Cuerpos del starter (afín = adopta tipo del mundo; neutra = None 90%).
+            CardDefinition strikeAffine = EnsureStrikeBody("Strike_Affine", affinity: true);
+            CardDefinition strikeNeutral = EnsureStrikeBody("Strike_Neutral", affinity: false);
+            CardDefinition defendAffine = EnsureDefendBody("Defend_Affine", affinity: true);
+            CardDefinition defendNeutral = EnsureDefendBody("Defend_Neutral", affinity: false);
+
+            // 2. Mejoras en las 18 caras del draft.
+            int facesUpgraded = AuthorFaceUpgrades();
+
+            // 3. Recomposición del starter deck (9 entradas single).
+            bool deckWritten = RecomposeStarterDeck(strikeAffine, strikeNeutral, defendAffine, defendNeutral);
+
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+
+            Debug.Log($"[StarterDeckSetup] bodies=4 facesUpgraded={facesUpgraded} " +
+                      $"starterDeck={(deckWritten ? "9 entradas" : "NO escrito (config faltante)")}.");
+        }
+
+        // ──────────────────────────────────────────────
+        // 1. Cuerpos del starter
+        // ──────────────────────────────────────────────
+
+        private static CardDefinition EnsureStrikeBody(string assetName, bool affinity)
+        {
+            return EnsureBody(
+                assetName,
+                id: assetName.ToLowerInvariant(),
+                cardName: "Strike",
+                description: $"Deal {StrikeBaseDamage} damage to an enemy.",
+                type: CardType.Attack,
+                cardTarget: CardTarget.SingleEnemy,
+                effectType: EffectType.Damage,
+                effectTarget: EffectTarget.SingleEnemy,
+                baseValue: StrikeBaseDamage,
+                upgradeDelta: StrikeUpgradeDelta,
+                upgradedDescription: $"Deal {StrikeBaseDamage + StrikeUpgradeDelta} damage to an enemy.",
+                affinity: affinity);
+        }
+
+        private static CardDefinition EnsureDefendBody(string assetName, bool affinity)
+        {
+            return EnsureBody(
+                assetName,
+                id: assetName.ToLowerInvariant(),
+                cardName: "Defend",
+                description: $"Gain {DefendBaseBlock} Block.",
+                type: CardType.Skill,
+                cardTarget: CardTarget.Self,
+                effectType: EffectType.Block,
+                effectTarget: EffectTarget.Self,
+                baseValue: DefendBaseBlock,
+                upgradeDelta: DefendUpgradeDelta,
+                upgradedDescription: $"Gain {DefendBaseBlock + DefendUpgradeDelta} Block.",
+                affinity: affinity);
+        }
+
+        /// <summary>
+        /// Crea (si falta) y puebla un SO de cuerpo + su mejora. elementType siempre
+        /// None: la carta afín adopta el tipo del mundo en runtime (vía AffinityResolver),
+        /// y la neutra ES None por definición. Idempotente — re-puebla si ya existe.
+        /// </summary>
+        private static CardDefinition EnsureBody(
+            string assetName, string id, string cardName, string description,
+            CardType type, CardTarget cardTarget, EffectType effectType, EffectTarget effectTarget,
+            int baseValue, int upgradeDelta, string upgradedDescription, bool affinity)
+        {
+            string path = $"{FolderCards}/{assetName}.asset";
+            CardDefinition card = AssetDatabase.LoadAssetAtPath<CardDefinition>(path);
+            if (card == null)
+            {
+                card = ScriptableObject.CreateInstance<CardDefinition>();
+                AssetDatabase.CreateAsset(card, path);
+            }
+
+            var effects = new List<EffectRef>
+            {
+                new EffectRef { effectType = effectType, value = baseValue, target = effectTarget }
+            };
+            card.SetDebugData(
+                id, cardName, description, 1, type, CardRarity.Common, cardTarget,
+                new List<string>(), effects, ElementType.None, null, affinity);
+
+            var upgradedEffects = new List<EffectRef>
+            {
+                new EffectRef { effectType = effectType, value = baseValue + upgradeDelta, target = effectTarget }
+            };
+            card.Upgrade.SetTestData(false, 0, upgradedEffects, null, upgradedDescription);
+
+            EditorUtility.SetDirty(card);
+            return card;
+        }
+
+        // ──────────────────────────────────────────────
+        // 2. Mejoras en las 18 caras del draft
+        // ──────────────────────────────────────────────
+
+        private static int AuthorFaceUpgrades()
+        {
+            if (!AssetDatabase.IsValidFolder(FacesFolder))
+            {
+                Debug.LogWarning($"[StarterDeckSetup] No existe {FacesFolder}. " +
+                                 "Corré 'Roguelike > Setup New Run Config' primero para generar las caras.");
+                return 0;
+            }
+
+            string[] guids = AssetDatabase.FindAssets("t:CardDefinition", new[] { FacesFolder });
+            int count = 0;
+            foreach (string guid in guids)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(guid);
+                CardDefinition face = AssetDatabase.LoadAssetAtPath<CardDefinition>(path);
+                if (face == null) continue;
+                AuthorFaceUpgrade(face);
+                count++;
+            }
+            return count;
+        }
+
+        /// <summary>
+        /// Autora la mejora de UNA cara, escalando su efecto primario: Damage +3
+        /// (Golpe) o Block +5 (Guardia), espejando el balance del starter. La
+        /// descripción mejorada respeta el estilo en español de las caras
+        /// (NewRunConfigSetup) para que el HUD muestre el número nuevo.
+        /// </summary>
+        private static void AuthorFaceUpgrade(CardDefinition face)
+        {
+            EffectType primary = EffectType.Damage;
+            int baseValue = 0;
+            bool isBlock = false;
+            foreach (EffectRef e in face.Effects)
+            {
+                if (e.effectType == EffectType.Block) { primary = EffectType.Block; baseValue = e.value; isBlock = true; break; }
+                if (e.effectType == EffectType.Damage) { primary = EffectType.Damage; baseValue = e.value; break; }
+            }
+
+            int delta = isBlock ? DefendUpgradeDelta : StrikeUpgradeDelta;
+            int newValue = baseValue + delta;
+            List<EffectRef> upgradedEffects = CloneEffectsBoostingFirst(face, primary, delta);
+            string desc = isBlock ? $"Bloquea {newValue}." : $"Inflige {newValue} de daño.";
+
+            face.Upgrade.SetTestData(false, 0, upgradedEffects, null, desc);
+            EditorUtility.SetDirty(face);
+        }
+
+        /// <summary>
+        /// Clona la lista de efectos sumando <paramref name="delta"/> al primer
+        /// efecto cuyo tipo coincide. Espejo de CardUpgradeSetup.CloneEffectsAddingTo
+        /// (dev tools editor-only; duplicación local acotada para no acoplar ambos menús).
+        /// </summary>
+        private static List<EffectRef> CloneEffectsBoostingFirst(CardDefinition card, EffectType type, int delta)
+        {
+            var result = new List<EffectRef>();
+            bool boosted = false;
+            foreach (EffectRef src in card.Effects)
+            {
+                EffectRef copy = new EffectRef
+                {
+                    effectType = src.effectType,
+                    value = src.value,
+                    target = src.target,
+                    statusType = src.statusType
+                };
+                if (!boosted && copy.effectType == type)
+                {
+                    copy.value += delta;
+                    boosted = true;
+                }
+                result.Add(copy);
+            }
+            return result;
+        }
+
+        // ──────────────────────────────────────────────
+        // 3. Recomposición del starter deck
+        // ──────────────────────────────────────────────
+
+        private static bool RecomposeStarterDeck(
+            CardDefinition strikeAffine, CardDefinition strikeNeutral,
+            CardDefinition defendAffine, CardDefinition defendNeutral)
+        {
+            RunCombatConfig config = AssetDatabase.LoadAssetAtPath<RunCombatConfig>(ConfigPath);
+            if (config == null)
+            {
+                Debug.LogWarning($"[StarterDeckSetup] No se encontró {ConfigPath}; starter deck no recompuesto.");
+                return false;
+            }
+
+            var deck = new List<CardDeckEntry>();
+            AddCopies(deck, strikeAffine, 3);   // 3 Strike afín
+            AddCopies(deck, strikeNeutral, 2);  // 2 Strike neutra
+            AddCopies(deck, defendAffine, 2);   // 2 Defend afín
+            AddCopies(deck, defendNeutral, 2);  // 2 Defend neutra  → 9 entradas
+
+            config.EditorPopulateStarterDeck(deck);
+            EditorUtility.SetDirty(config);
+            return true;
+        }
+
+        private static void AddCopies(List<CardDeckEntry> deck, CardDefinition card, int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                deck.Add(CardDeckEntry.CreateSingle(card));
+            }
+        }
+    }
+}

--- a/Assets/Editor/StarterDeckSetup.cs
+++ b/Assets/Editor/StarterDeckSetup.cs
@@ -62,20 +62,24 @@ namespace RoguelikeCardBattler.Editor
         // 1. Cuerpos del starter
         // ──────────────────────────────────────────────
 
+        // Texto en español, espejo del vocabulario de las caras del draft
+        // (NewRunConfigSetup: "Golpe"/"Guardia", "Inflige N de daño."/"Bloquea N.")
+        // para que el mazo inicial — cuerpos + la dual drafteada — lea consistente
+        // en la misma mano. (El número/identidad es placeholder hasta el curado real.)
         private static CardDefinition EnsureStrikeBody(string assetName, bool affinity)
         {
             return EnsureBody(
                 assetName,
                 id: assetName.ToLowerInvariant(),
-                cardName: "Strike",
-                description: $"Deal {StrikeBaseDamage} damage to an enemy.",
+                cardName: "Golpe",
+                description: $"Inflige {StrikeBaseDamage} de daño.",
                 type: CardType.Attack,
                 cardTarget: CardTarget.SingleEnemy,
                 effectType: EffectType.Damage,
                 effectTarget: EffectTarget.SingleEnemy,
                 baseValue: StrikeBaseDamage,
                 upgradeDelta: StrikeUpgradeDelta,
-                upgradedDescription: $"Deal {StrikeBaseDamage + StrikeUpgradeDelta} damage to an enemy.",
+                upgradedDescription: $"Inflige {StrikeBaseDamage + StrikeUpgradeDelta} de daño.",
                 affinity: affinity);
         }
 
@@ -84,15 +88,15 @@ namespace RoguelikeCardBattler.Editor
             return EnsureBody(
                 assetName,
                 id: assetName.ToLowerInvariant(),
-                cardName: "Defend",
-                description: $"Gain {DefendBaseBlock} Block.",
+                cardName: "Guardia",
+                description: $"Bloquea {DefendBaseBlock}.",
                 type: CardType.Skill,
                 cardTarget: CardTarget.Self,
                 effectType: EffectType.Block,
                 effectTarget: EffectTarget.Self,
                 baseValue: DefendBaseBlock,
                 upgradeDelta: DefendUpgradeDelta,
-                upgradedDescription: $"Gain {DefendBaseBlock + DefendUpgradeDelta} Block.",
+                upgradedDescription: $"Bloquea {DefendBaseBlock + DefendUpgradeDelta}.",
                 affinity: affinity);
         }
 
@@ -177,39 +181,11 @@ namespace RoguelikeCardBattler.Editor
 
             int delta = isBlock ? DefendUpgradeDelta : StrikeUpgradeDelta;
             int newValue = baseValue + delta;
-            List<EffectRef> upgradedEffects = CloneEffectsBoostingFirst(face, primary, delta);
+            List<EffectRef> upgradedEffects = EditorCardAuthoring.CloneEffectsBoostingFirst(face, primary, delta);
             string desc = isBlock ? $"Bloquea {newValue}." : $"Inflige {newValue} de daño.";
 
             face.Upgrade.SetTestData(false, 0, upgradedEffects, null, desc);
             EditorUtility.SetDirty(face);
-        }
-
-        /// <summary>
-        /// Clona la lista de efectos sumando <paramref name="delta"/> al primer
-        /// efecto cuyo tipo coincide. Espejo de CardUpgradeSetup.CloneEffectsAddingTo
-        /// (dev tools editor-only; duplicación local acotada para no acoplar ambos menús).
-        /// </summary>
-        private static List<EffectRef> CloneEffectsBoostingFirst(CardDefinition card, EffectType type, int delta)
-        {
-            var result = new List<EffectRef>();
-            bool boosted = false;
-            foreach (EffectRef src in card.Effects)
-            {
-                EffectRef copy = new EffectRef
-                {
-                    effectType = src.effectType,
-                    value = src.value,
-                    target = src.target,
-                    statusType = src.statusType
-                };
-                if (!boosted && copy.effectType == type)
-                {
-                    copy.value += delta;
-                    boosted = true;
-                }
-                result.Add(copy);
-            }
-            return result;
         }
 
         // ──────────────────────────────────────────────

--- a/Assets/Editor/StarterDeckSetup.cs.meta
+++ b/Assets/Editor/StarterDeckSetup.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eda7805e3c28b6847ad8e2203fc6f83c

--- a/Assets/ScriptableObjects/Cards/BattleFocus.asset
+++ b/Assets/ScriptableObjects/Cards/BattleFocus.asset
@@ -29,6 +29,7 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 0
+  affinity: 0
   art: {fileID: 21300000, guid: 2537d72642610244092ab7c5934e91d6, type: 3}
   _upgrade:
     overrideCost: 1

--- a/Assets/ScriptableObjects/Cards/BattleFocusSideB.asset
+++ b/Assets/ScriptableObjects/Cards/BattleFocusSideB.asset
@@ -29,6 +29,7 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 0
+  affinity: 0
   art: {fileID: 21300000, guid: 10e79b2b516d0d948b496c4e010159f9, type: 3}
   _upgrade:
     overrideCost: 1

--- a/Assets/ScriptableObjects/Cards/DefendBasic.asset
+++ b/Assets/ScriptableObjects/Cards/DefendBasic.asset
@@ -29,6 +29,7 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 0
+  affinity: 0
   art: {fileID: 21300000, guid: 40113e85301cdab4689fa8ef27471c36, type: 3}
   _upgrade:
     overrideCost: 0

--- a/Assets/ScriptableObjects/Cards/DefendSideB.asset
+++ b/Assets/ScriptableObjects/Cards/DefendSideB.asset
@@ -29,6 +29,7 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 0
+  affinity: 0
   art: {fileID: 21300000, guid: 1468c27ec3e2a2243ac39dd5505cfe75, type: 3}
   _upgrade:
     overrideCost: 0

--- a/Assets/ScriptableObjects/Cards/Defend_Affine.asset
+++ b/Assets/ScriptableObjects/Cards/Defend_Affine.asset
@@ -10,33 +10,33 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 829af9ee0e044e9f9aae0fd53295d85f, type: 3}
-  m_Name: Face_Rojo_3
+  m_Name: Defend_Affine
   m_EditorClassIdentifier: RoguelikeCardBattler::RoguelikeCardBattler.Gameplay.Cards.CardDefinition
-  id: face_rojo_3
-  cardName: Golpe Rojo
-  description: "Inflige 8 de da\xF1o."
+  id: defend_affine
+  cardName: Defend
+  description: Gain 5 Block.
   cost: 1
-  type: 0
-  rarity: 1
-  target: 2
+  type: 1
+  rarity: 0
+  target: 1
   tags: []
   effects:
-  - effectType: 0
-    value: 8
-    target: 1
+  - effectType: 1
+    value: 5
+    target: 0
     statusType: 0
     extraParams: []
-  elementType: 1
-  affinity: 0
-  art: {fileID: 21300000, guid: 41a999b1ee711eb4fa34520717f9793d, type: 3}
+  elementType: 0
+  affinity: 1
+  art: {fileID: 0}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
     upgradedEffects:
-    - effectType: 0
-      value: 11
-      target: 1
+    - effectType: 1
+      value: 10
+      target: 0
       statusType: 0
       extraParams: []
     upgradedName: 
-    upgradedDescription: "Inflige 11 de da\xF1o."
+    upgradedDescription: Gain 10 Block.

--- a/Assets/ScriptableObjects/Cards/Defend_Affine.asset
+++ b/Assets/ScriptableObjects/Cards/Defend_Affine.asset
@@ -13,8 +13,8 @@ MonoBehaviour:
   m_Name: Defend_Affine
   m_EditorClassIdentifier: RoguelikeCardBattler::RoguelikeCardBattler.Gameplay.Cards.CardDefinition
   id: defend_affine
-  cardName: Defend
-  description: Gain 5 Block.
+  cardName: Guardia
+  description: Bloquea 5.
   cost: 1
   type: 1
   rarity: 0
@@ -39,4 +39,4 @@ MonoBehaviour:
       statusType: 0
       extraParams: []
     upgradedName: 
-    upgradedDescription: Gain 10 Block.
+    upgradedDescription: Bloquea 10.

--- a/Assets/ScriptableObjects/Cards/Defend_Affine.asset.meta
+++ b/Assets/ScriptableObjects/Cards/Defend_Affine.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 16b3c3158630c944a994d96546b6b2e0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Cards/Defend_Neutral.asset
+++ b/Assets/ScriptableObjects/Cards/Defend_Neutral.asset
@@ -13,8 +13,8 @@ MonoBehaviour:
   m_Name: Defend_Neutral
   m_EditorClassIdentifier: RoguelikeCardBattler::RoguelikeCardBattler.Gameplay.Cards.CardDefinition
   id: defend_neutral
-  cardName: Defend
-  description: Gain 5 Block.
+  cardName: Guardia
+  description: Bloquea 5.
   cost: 1
   type: 1
   rarity: 0
@@ -39,4 +39,4 @@ MonoBehaviour:
       statusType: 0
       extraParams: []
     upgradedName: 
-    upgradedDescription: Gain 10 Block.
+    upgradedDescription: Bloquea 10.

--- a/Assets/ScriptableObjects/Cards/Defend_Neutral.asset
+++ b/Assets/ScriptableObjects/Cards/Defend_Neutral.asset
@@ -10,33 +10,33 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 829af9ee0e044e9f9aae0fd53295d85f, type: 3}
-  m_Name: Face_Rojo_3
+  m_Name: Defend_Neutral
   m_EditorClassIdentifier: RoguelikeCardBattler::RoguelikeCardBattler.Gameplay.Cards.CardDefinition
-  id: face_rojo_3
-  cardName: Golpe Rojo
-  description: "Inflige 8 de da\xF1o."
+  id: defend_neutral
+  cardName: Defend
+  description: Gain 5 Block.
   cost: 1
-  type: 0
-  rarity: 1
-  target: 2
+  type: 1
+  rarity: 0
+  target: 1
   tags: []
   effects:
-  - effectType: 0
-    value: 8
-    target: 1
+  - effectType: 1
+    value: 5
+    target: 0
     statusType: 0
     extraParams: []
-  elementType: 1
+  elementType: 0
   affinity: 0
-  art: {fileID: 21300000, guid: 41a999b1ee711eb4fa34520717f9793d, type: 3}
+  art: {fileID: 0}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
     upgradedEffects:
-    - effectType: 0
-      value: 11
-      target: 1
+    - effectType: 1
+      value: 10
+      target: 0
       statusType: 0
       extraParams: []
     upgradedName: 
-    upgradedDescription: "Inflige 11 de da\xF1o."
+    upgradedDescription: Gain 10 Block.

--- a/Assets/ScriptableObjects/Cards/Defend_Neutral.asset.meta
+++ b/Assets/ScriptableObjects/Cards/Defend_Neutral.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c07b53e2a8aa92f40b4753800f76d375
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Amarillo_1.asset
+++ b/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Amarillo_1.asset
@@ -27,10 +27,16 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 2
+  affinity: 0
   art: {fileID: 21300000, guid: 502b6504c0a0ea54c93bcad448839a3e, type: 3}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
-    upgradedEffects: []
+    upgradedEffects:
+    - effectType: 0
+      value: 9
+      target: 1
+      statusType: 0
+      extraParams: []
     upgradedName: 
-    upgradedDescription: 
+    upgradedDescription: "Inflige 9 de da\xF1o."

--- a/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Amarillo_2.asset
+++ b/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Amarillo_2.asset
@@ -27,10 +27,16 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 2
+  affinity: 0
   art: {fileID: 21300000, guid: 0e51d59bdaaece24182aca4ec260e5e3, type: 3}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
-    upgradedEffects: []
+    upgradedEffects:
+    - effectType: 1
+      value: 10
+      target: 0
+      statusType: 0
+      extraParams: []
     upgradedName: 
-    upgradedDescription: 
+    upgradedDescription: Bloquea 10.

--- a/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Amarillo_3.asset
+++ b/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Amarillo_3.asset
@@ -27,10 +27,16 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 2
+  affinity: 0
   art: {fileID: 21300000, guid: 168ad3a0752545b449b31365ed37edef, type: 3}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
-    upgradedEffects: []
+    upgradedEffects:
+    - effectType: 0
+      value: 11
+      target: 1
+      statusType: 0
+      extraParams: []
     upgradedName: 
-    upgradedDescription: 
+    upgradedDescription: "Inflige 11 de da\xF1o."

--- a/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Azul_1.asset
+++ b/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Azul_1.asset
@@ -27,10 +27,16 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 3
+  affinity: 0
   art: {fileID: 21300000, guid: b8db64df375202146bcf7ce24fd79c0a, type: 3}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
-    upgradedEffects: []
+    upgradedEffects:
+    - effectType: 0
+      value: 9
+      target: 1
+      statusType: 0
+      extraParams: []
     upgradedName: 
-    upgradedDescription: 
+    upgradedDescription: "Inflige 9 de da\xF1o."

--- a/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Azul_2.asset
+++ b/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Azul_2.asset
@@ -27,10 +27,16 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 3
+  affinity: 0
   art: {fileID: 21300000, guid: 4719e0119b2829840a5288e1ecb1c7b9, type: 3}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
-    upgradedEffects: []
+    upgradedEffects:
+    - effectType: 1
+      value: 10
+      target: 0
+      statusType: 0
+      extraParams: []
     upgradedName: 
-    upgradedDescription: 
+    upgradedDescription: Bloquea 10.

--- a/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Azul_3.asset
+++ b/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Azul_3.asset
@@ -27,10 +27,16 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 3
+  affinity: 0
   art: {fileID: 21300000, guid: b34c6a4b652f86345b61f4a01a21eac8, type: 3}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
-    upgradedEffects: []
+    upgradedEffects:
+    - effectType: 0
+      value: 11
+      target: 1
+      statusType: 0
+      extraParams: []
     upgradedName: 
-    upgradedDescription: 
+    upgradedDescription: "Inflige 11 de da\xF1o."

--- a/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Blanco_1.asset
+++ b/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Blanco_1.asset
@@ -27,10 +27,16 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 6
+  affinity: 0
   art: {fileID: 21300000, guid: 0e19b6ad4c2c75e4882058c4741625cb, type: 3}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
-    upgradedEffects: []
+    upgradedEffects:
+    - effectType: 0
+      value: 9
+      target: 1
+      statusType: 0
+      extraParams: []
     upgradedName: 
-    upgradedDescription: 
+    upgradedDescription: "Inflige 9 de da\xF1o."

--- a/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Blanco_2.asset
+++ b/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Blanco_2.asset
@@ -27,10 +27,16 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 6
+  affinity: 0
   art: {fileID: 21300000, guid: 07049f0ce0267e44d9bf1c7a32e088e0, type: 3}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
-    upgradedEffects: []
+    upgradedEffects:
+    - effectType: 1
+      value: 10
+      target: 0
+      statusType: 0
+      extraParams: []
     upgradedName: 
-    upgradedDescription: 
+    upgradedDescription: Bloquea 10.

--- a/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Blanco_3.asset
+++ b/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Blanco_3.asset
@@ -27,10 +27,16 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 6
+  affinity: 0
   art: {fileID: 21300000, guid: 19fcc0fde6c8c9b468a6031a7031e8ab, type: 3}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
-    upgradedEffects: []
+    upgradedEffects:
+    - effectType: 0
+      value: 11
+      target: 1
+      statusType: 0
+      extraParams: []
     upgradedName: 
-    upgradedDescription: 
+    upgradedDescription: "Inflige 11 de da\xF1o."

--- a/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Morado_1.asset
+++ b/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Morado_1.asset
@@ -27,10 +27,16 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 4
+  affinity: 0
   art: {fileID: 21300000, guid: f0a63017d29fafc43af05ce7265593ec, type: 3}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
-    upgradedEffects: []
+    upgradedEffects:
+    - effectType: 0
+      value: 9
+      target: 1
+      statusType: 0
+      extraParams: []
     upgradedName: 
-    upgradedDescription: 
+    upgradedDescription: "Inflige 9 de da\xF1o."

--- a/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Morado_2.asset
+++ b/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Morado_2.asset
@@ -27,10 +27,16 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 4
+  affinity: 0
   art: {fileID: 21300000, guid: e8f22c760877b0c45afd6ad307a50f09, type: 3}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
-    upgradedEffects: []
+    upgradedEffects:
+    - effectType: 1
+      value: 10
+      target: 0
+      statusType: 0
+      extraParams: []
     upgradedName: 
-    upgradedDescription: 
+    upgradedDescription: Bloquea 10.

--- a/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Morado_3.asset
+++ b/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Morado_3.asset
@@ -27,10 +27,16 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 4
+  affinity: 0
   art: {fileID: 21300000, guid: 5e62f3c933c82a84a86a4f1cdb3d651a, type: 3}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
-    upgradedEffects: []
+    upgradedEffects:
+    - effectType: 0
+      value: 11
+      target: 1
+      statusType: 0
+      extraParams: []
     upgradedName: 
-    upgradedDescription: 
+    upgradedDescription: "Inflige 11 de da\xF1o."

--- a/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Negro_1.asset
+++ b/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Negro_1.asset
@@ -27,10 +27,16 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 5
+  affinity: 0
   art: {fileID: 21300000, guid: 0e8b93a41569cd84a945ba212ad84940, type: 3}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
-    upgradedEffects: []
+    upgradedEffects:
+    - effectType: 0
+      value: 9
+      target: 1
+      statusType: 0
+      extraParams: []
     upgradedName: 
-    upgradedDescription: 
+    upgradedDescription: "Inflige 9 de da\xF1o."

--- a/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Negro_2.asset
+++ b/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Negro_2.asset
@@ -27,10 +27,16 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 5
+  affinity: 0
   art: {fileID: 21300000, guid: 51071d01e34981444bc355d0247986bf, type: 3}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
-    upgradedEffects: []
+    upgradedEffects:
+    - effectType: 1
+      value: 10
+      target: 0
+      statusType: 0
+      extraParams: []
     upgradedName: 
-    upgradedDescription: 
+    upgradedDescription: Bloquea 10.

--- a/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Negro_3.asset
+++ b/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Negro_3.asset
@@ -27,10 +27,16 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 5
+  affinity: 0
   art: {fileID: 21300000, guid: c3d92ad5987bf634fb462ec7f329243d, type: 3}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
-    upgradedEffects: []
+    upgradedEffects:
+    - effectType: 0
+      value: 11
+      target: 1
+      statusType: 0
+      extraParams: []
     upgradedName: 
-    upgradedDescription: 
+    upgradedDescription: "Inflige 11 de da\xF1o."

--- a/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Rojo_1.asset
+++ b/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Rojo_1.asset
@@ -27,10 +27,16 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 1
+  affinity: 0
   art: {fileID: 21300000, guid: 665ae663b44b8594cbb905e133263c72, type: 3}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
-    upgradedEffects: []
+    upgradedEffects:
+    - effectType: 0
+      value: 9
+      target: 1
+      statusType: 0
+      extraParams: []
     upgradedName: 
-    upgradedDescription: 
+    upgradedDescription: "Inflige 9 de da\xF1o."

--- a/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Rojo_2.asset
+++ b/Assets/ScriptableObjects/Cards/NewRunFaces/Face_Rojo_2.asset
@@ -27,10 +27,16 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 1
+  affinity: 0
   art: {fileID: 21300000, guid: 87d72b6bc33c90a4d949c8efa03bd489, type: 3}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
-    upgradedEffects: []
+    upgradedEffects:
+    - effectType: 1
+      value: 10
+      target: 0
+      statusType: 0
+      extraParams: []
     upgradedName: 
-    upgradedDescription: 
+    upgradedDescription: Bloquea 10.

--- a/Assets/ScriptableObjects/Cards/StrikeBasic.asset
+++ b/Assets/ScriptableObjects/Cards/StrikeBasic.asset
@@ -29,6 +29,7 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 1
+  affinity: 0
   art: {fileID: 21300000, guid: 33ee287930cd848488509b73d6ff8c42, type: 3}
   _upgrade:
     overrideCost: 0

--- a/Assets/ScriptableObjects/Cards/StrikeSideB.asset
+++ b/Assets/ScriptableObjects/Cards/StrikeSideB.asset
@@ -29,6 +29,7 @@ MonoBehaviour:
     statusType: 0
     extraParams: []
   elementType: 5
+  affinity: 0
   art: {fileID: 21300000, guid: 7272562290c3c7c4f9f859622bc64d9b, type: 3}
   _upgrade:
     overrideCost: 0

--- a/Assets/ScriptableObjects/Cards/Strike_Affine.asset
+++ b/Assets/ScriptableObjects/Cards/Strike_Affine.asset
@@ -13,8 +13,8 @@ MonoBehaviour:
   m_Name: Strike_Affine
   m_EditorClassIdentifier: RoguelikeCardBattler::RoguelikeCardBattler.Gameplay.Cards.CardDefinition
   id: strike_affine
-  cardName: Strike
-  description: Deal 6 damage to an enemy.
+  cardName: Golpe
+  description: "Inflige 6 de da\xF1o."
   cost: 1
   type: 0
   rarity: 0
@@ -39,4 +39,4 @@ MonoBehaviour:
       statusType: 0
       extraParams: []
     upgradedName: 
-    upgradedDescription: Deal 9 damage to an enemy.
+    upgradedDescription: "Inflige 9 de da\xF1o."

--- a/Assets/ScriptableObjects/Cards/Strike_Affine.asset
+++ b/Assets/ScriptableObjects/Cards/Strike_Affine.asset
@@ -10,33 +10,33 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 829af9ee0e044e9f9aae0fd53295d85f, type: 3}
-  m_Name: Face_Rojo_3
+  m_Name: Strike_Affine
   m_EditorClassIdentifier: RoguelikeCardBattler::RoguelikeCardBattler.Gameplay.Cards.CardDefinition
-  id: face_rojo_3
-  cardName: Golpe Rojo
-  description: "Inflige 8 de da\xF1o."
+  id: strike_affine
+  cardName: Strike
+  description: Deal 6 damage to an enemy.
   cost: 1
   type: 0
-  rarity: 1
+  rarity: 0
   target: 2
   tags: []
   effects:
   - effectType: 0
-    value: 8
+    value: 6
     target: 1
     statusType: 0
     extraParams: []
-  elementType: 1
-  affinity: 0
-  art: {fileID: 21300000, guid: 41a999b1ee711eb4fa34520717f9793d, type: 3}
+  elementType: 0
+  affinity: 1
+  art: {fileID: 0}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
     upgradedEffects:
     - effectType: 0
-      value: 11
+      value: 9
       target: 1
       statusType: 0
       extraParams: []
     upgradedName: 
-    upgradedDescription: "Inflige 11 de da\xF1o."
+    upgradedDescription: Deal 9 damage to an enemy.

--- a/Assets/ScriptableObjects/Cards/Strike_Affine.asset.meta
+++ b/Assets/ScriptableObjects/Cards/Strike_Affine.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 024230aa8255f0c459f367763fdd8b50
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Cards/Strike_Neutral.asset
+++ b/Assets/ScriptableObjects/Cards/Strike_Neutral.asset
@@ -10,33 +10,33 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 829af9ee0e044e9f9aae0fd53295d85f, type: 3}
-  m_Name: Face_Rojo_3
+  m_Name: Strike_Neutral
   m_EditorClassIdentifier: RoguelikeCardBattler::RoguelikeCardBattler.Gameplay.Cards.CardDefinition
-  id: face_rojo_3
-  cardName: Golpe Rojo
-  description: "Inflige 8 de da\xF1o."
+  id: strike_neutral
+  cardName: Strike
+  description: Deal 6 damage to an enemy.
   cost: 1
   type: 0
-  rarity: 1
+  rarity: 0
   target: 2
   tags: []
   effects:
   - effectType: 0
-    value: 8
+    value: 6
     target: 1
     statusType: 0
     extraParams: []
-  elementType: 1
+  elementType: 0
   affinity: 0
-  art: {fileID: 21300000, guid: 41a999b1ee711eb4fa34520717f9793d, type: 3}
+  art: {fileID: 0}
   _upgrade:
     overrideCost: 0
     upgradedCost: 0
     upgradedEffects:
     - effectType: 0
-      value: 11
+      value: 9
       target: 1
       statusType: 0
       extraParams: []
     upgradedName: 
-    upgradedDescription: "Inflige 11 de da\xF1o."
+    upgradedDescription: Deal 9 damage to an enemy.

--- a/Assets/ScriptableObjects/Cards/Strike_Neutral.asset
+++ b/Assets/ScriptableObjects/Cards/Strike_Neutral.asset
@@ -13,8 +13,8 @@ MonoBehaviour:
   m_Name: Strike_Neutral
   m_EditorClassIdentifier: RoguelikeCardBattler::RoguelikeCardBattler.Gameplay.Cards.CardDefinition
   id: strike_neutral
-  cardName: Strike
-  description: Deal 6 damage to an enemy.
+  cardName: Golpe
+  description: "Inflige 6 de da\xF1o."
   cost: 1
   type: 0
   rarity: 0
@@ -39,4 +39,4 @@ MonoBehaviour:
       statusType: 0
       extraParams: []
     upgradedName: 
-    upgradedDescription: Deal 9 damage to an enemy.
+    upgradedDescription: "Inflige 9 de da\xF1o."

--- a/Assets/ScriptableObjects/Cards/Strike_Neutral.asset.meta
+++ b/Assets/ScriptableObjects/Cards/Strike_Neutral.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3fe0f3064d148024389c15328f3635e0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Run/RunCombatConfig_Act1.asset
+++ b/Assets/ScriptableObjects/Run/RunCombatConfig_Act1.asset
@@ -16,20 +16,24 @@ MonoBehaviour:
   choicesCount: 3
   defaultEnemy: {fileID: 11400000, guid: a5f86b9e5ecb4de5bf5dfbcfbcff3577, type: 2}
   starterDeck:
-  - singleCard: {fileID: 0}
-    dualCard: {fileID: 11400000, guid: dc5f57a1b1114ca3bce64dbe9843de30, type: 2}
-  - singleCard: {fileID: 0}
-    dualCard: {fileID: 11400000, guid: dc5f57a1b1114ca3bce64dbe9843de30, type: 2}
-  - singleCard: {fileID: 0}
-    dualCard: {fileID: 11400000, guid: dc5f57a1b1114ca3bce64dbe9843de30, type: 2}
-  - singleCard: {fileID: 0}
-    dualCard: {fileID: 11400000, guid: 9adafdc7d3964a2ba54afa9b5740d5af, type: 2}
-  - singleCard: {fileID: 0}
-    dualCard: {fileID: 11400000, guid: 9adafdc7d3964a2ba54afa9b5740d5af, type: 2}
-  - singleCard: {fileID: 0}
-    dualCard: {fileID: 11400000, guid: ce1ce5bd21da4478861f66b51d98d240, type: 2}
-  - singleCard: {fileID: 0}
-    dualCard: {fileID: 11400000, guid: dc5f57a1b1114ca3bce64dbe9843de30, type: 2}
+  - singleCard: {fileID: 11400000, guid: 024230aa8255f0c459f367763fdd8b50, type: 2}
+    dualCard: {fileID: 0}
+  - singleCard: {fileID: 11400000, guid: 024230aa8255f0c459f367763fdd8b50, type: 2}
+    dualCard: {fileID: 0}
+  - singleCard: {fileID: 11400000, guid: 024230aa8255f0c459f367763fdd8b50, type: 2}
+    dualCard: {fileID: 0}
+  - singleCard: {fileID: 11400000, guid: 3fe0f3064d148024389c15328f3635e0, type: 2}
+    dualCard: {fileID: 0}
+  - singleCard: {fileID: 11400000, guid: 3fe0f3064d148024389c15328f3635e0, type: 2}
+    dualCard: {fileID: 0}
+  - singleCard: {fileID: 11400000, guid: 16b3c3158630c944a994d96546b6b2e0, type: 2}
+    dualCard: {fileID: 0}
+  - singleCard: {fileID: 11400000, guid: 16b3c3158630c944a994d96546b6b2e0, type: 2}
+    dualCard: {fileID: 0}
+  - singleCard: {fileID: 11400000, guid: c07b53e2a8aa92f40b4753800f76d375, type: 2}
+    dualCard: {fileID: 0}
+  - singleCard: {fileID: 11400000, guid: c07b53e2a8aa92f40b4753800f76d375, type: 2}
+    dualCard: {fileID: 0}
   rewardPool:
   - singleCard: {fileID: 0}
     dualCard: {fileID: 11400000, guid: dc5f57a1b1114ca3bce64dbe9843de30, type: 2}

--- a/Assets/ScriptableObjects/Run/RunCombatConfig_Act1.asset
+++ b/Assets/ScriptableObjects/Run/RunCombatConfig_Act1.asset
@@ -35,12 +35,12 @@ MonoBehaviour:
   - singleCard: {fileID: 11400000, guid: c07b53e2a8aa92f40b4753800f76d375, type: 2}
     dualCard: {fileID: 0}
   rewardPool:
-  - singleCard: {fileID: 0}
-    dualCard: {fileID: 11400000, guid: dc5f57a1b1114ca3bce64dbe9843de30, type: 2}
-  - singleCard: {fileID: 0}
-    dualCard: {fileID: 11400000, guid: 9adafdc7d3964a2ba54afa9b5740d5af, type: 2}
-  - singleCard: {fileID: 0}
-    dualCard: {fileID: 11400000, guid: ce1ce5bd21da4478861f66b51d98d240, type: 2}
+  - singleCard: {fileID: 11400000, guid: 024230aa8255f0c459f367763fdd8b50, type: 2}
+    dualCard: {fileID: 0}
+  - singleCard: {fileID: 11400000, guid: 16b3c3158630c944a994d96546b6b2e0, type: 2}
+    dualCard: {fileID: 0}
+  - singleCard: {fileID: 11400000, guid: 3fe0f3064d148024389c15328f3635e0, type: 2}
+    dualCard: {fileID: 0}
   eliteRelicDropPool:
   - {fileID: 11400000, guid: e0601204906f3d5439a5091b1b10e507, type: 2}
   - {fileID: 11400000, guid: 092dd118b9c894949994675c5053c4a6, type: 2}

--- a/Assets/Scripts/Gameplay/Cards/AffinityResolver.cs
+++ b/Assets/Scripts/Gameplay/Cards/AffinityResolver.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using UnityEngine;
+using RoguelikeCardBattler.Gameplay.Combat;
+
+namespace RoguelikeCardBattler.Gameplay.Cards
+{
+    /// <summary>
+    /// Resuelve la afinidad de tipo del mazo inicial (4a, DD-022 opción A). Helper
+    /// <b>static puro</b> (espejo de <see cref="Run.NewRun.StarterDraft"/>): sin UI,
+    /// sin estado, testeable directo.
+    ///
+    /// Una carta afín (su <see cref="CardDefinition.Affinity"/> == true) no tiene
+    /// tipo fijo: en runtime debe usar el tipo elegido para el Mundo A cuando el
+    /// jugador está en A, y el del Mundo B cuando está en B. Eso es exactamente lo
+    /// que ya hace una carta DUAL al conmutar de lado por mundo. Por eso la afinidad
+    /// se implementa representando cada carta afín como una <see cref="DualCardDefinition"/>
+    /// runtime cuyos dos lados son el mismo cuerpo tipado: lado A con
+    /// <paramref name="typeA"/>, lado B con <paramref name="typeB"/>. Así TurnManager
+    /// (protegido) NO necesita cambios: ya lee <c>GetActiveCard(CurrentWorld).ElementType</c>.
+    ///
+    /// Las cartas neutras (Affinity=false, tipo None) y las ya-duales pasan sin tocar.
+    /// </summary>
+    public static class AffinityResolver
+    {
+        /// <summary>
+        /// Resuelve UNA entrada de mazo. Si es una carta single con afinidad, la
+        /// convierte en una dual runtime tipada por mundo. Si es neutra (single sin
+        /// afinidad) o ya es dual, devuelve una copia sin cambios (Clone evita
+        /// aliasar la lista del SO de config). Entrada null/ inválida → null.
+        /// </summary>
+        public static CardDeckEntry Resolve(CardDeckEntry authored, ElementType typeA, ElementType typeB)
+        {
+            if (authored == null || !authored.IsValid) return null;
+
+            CardDefinition single = authored.SingleCard;
+            if (single != null && single.Affinity)
+            {
+                // Cuerpo tipado por mundo. CreateAffinityVariant preserva el payload
+                // de upgrade (a diferencia de CreateUpgradedClone) → la dual afín
+                // resuelta sigue siendo mejorable en la Hoguera.
+                DualCardDefinition dual = ScriptableObject.CreateInstance<DualCardDefinition>();
+                dual.InitRuntimeSides(
+                    $"affine_{single.Id}",
+                    single.CardName,
+                    single.CreateAffinityVariant(typeA),   // lado A
+                    single.CreateAffinityVariant(typeB));  // lado B
+                return CardDeckEntry.CreateDual(dual);
+            }
+
+            // Neutra o ya-dual: sin cambios.
+            return authored.Clone();
+        }
+
+        /// <summary>
+        /// Resuelve la lista entera mapeando <see cref="Resolve"/> sobre cada entrada
+        /// válida (saltea null/ inválidas). El orden se preserva.
+        /// </summary>
+        public static List<CardDeckEntry> ResolveDeck(IReadOnlyList<CardDeckEntry> deck, ElementType typeA, ElementType typeB)
+        {
+            var result = new List<CardDeckEntry>();
+            if (deck == null) return result;
+
+            foreach (CardDeckEntry entry in deck)
+            {
+                if (entry == null || !entry.IsValid) continue;
+                CardDeckEntry resolved = Resolve(entry, typeA, typeB);
+                if (resolved != null) result.Add(resolved);
+            }
+
+            return result;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Cards/AffinityResolver.cs.meta
+++ b/Assets/Scripts/Gameplay/Cards/AffinityResolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f2e72c392993a4b40bcfadc040e25695

--- a/Assets/Scripts/Gameplay/Cards/CardDefinition.cs
+++ b/Assets/Scripts/Gameplay/Cards/CardDefinition.cs
@@ -20,6 +20,13 @@ namespace RoguelikeCardBattler.Gameplay.Cards
         [SerializeField] private List<string> tags = new List<string>();
         [SerializeField] private List<EffectRef> effects = new List<EffectRef>();
         [SerializeField] private ElementType elementType = ElementType.None;
+        // Afinidad de tipo (4a, DD-022 opción A): si true, la carta NO tiene tipo
+        // fijo — adopta en runtime el tipo del mundo activo. AffinityResolver la
+        // resuelve a una dual runtime (lado A = tipo Mundo A, lado B = tipo Mundo B)
+        // antes de que llegue al mazo. Su elementType autorado en el SO es
+        // irrelevante (se autora None). affinity=false → usa elementType fijo
+        // (incluido None = carta neutra 90%).
+        [SerializeField] private bool affinity = false;
         [SerializeField] private Sprite art = null;   // ilustración de la carta (C7). null = fallback a texto.
         [SerializeField] private CardUpgradeDef _upgrade = new CardUpgradeDef();
 
@@ -35,6 +42,7 @@ namespace RoguelikeCardBattler.Gameplay.Cards
         public IReadOnlyList<string> Tags => tags;
         public IReadOnlyList<EffectRef> Effects => effects;
         public ElementType ElementType => elementType;
+        public bool Affinity => affinity;
         public Sprite Art => art;
 
         public void SetDebugData(
@@ -48,7 +56,8 @@ namespace RoguelikeCardBattler.Gameplay.Cards
             List<string> newTags,
             List<EffectRef> newEffects,
             ElementType newElementType = ElementType.None,
-            Sprite newArt = null)
+            Sprite newArt = null,
+            bool newAffinity = false)
         {
             id = newId;
             cardName = newName;
@@ -61,6 +70,7 @@ namespace RoguelikeCardBattler.Gameplay.Cards
             effects = newEffects;
             elementType = newElementType;
             art = newArt;
+            affinity = newAffinity;
         }
 
         /// <summary>
@@ -98,8 +108,45 @@ namespace RoguelikeCardBattler.Gameplay.Cards
                 new List<string>(tags),
                 newEffects,
                 elementType,
-                art);   // el clon de upgrade conserva la ilustración base (D3)
+                art,        // el clon de upgrade conserva la ilustración base (D3)
+                affinity);  // y el flag de afinidad (caso defensivo: en el flujo normal
+                            // el afín ya es dual antes de mejorarse, ver CreateAffinityVariant)
 
+            return clone;
+        }
+
+        /// <summary>
+        /// Crea una variante runtime de esta carta tipada para un mundo concreto
+        /// (4a, afinidad DD-022). Idéntica al cuerpo (effects, cost, name,
+        /// description, type, rarity, target, tags, art) salvo que su
+        /// <see cref="ElementType"/> pasa a ser <paramref name="worldType"/> y su
+        /// <see cref="Affinity"/> queda en false (ya resuelta a un tipo).
+        ///
+        /// A diferencia de <see cref="CreateUpgradedClone"/> (que NO copia el
+        /// payload de upgrade), PRESERVA <c>_upgrade</c> compartiendo la referencia
+        /// para que la dual afín resuelta siga siendo mejorable en la Hoguera.
+        /// El <see cref="CardUpgradeDef"/> es read-only en runtime, así que
+        /// compartir la referencia es seguro. NO toca el SO de origen.
+        /// </summary>
+        public CardDefinition CreateAffinityVariant(ElementType worldType)
+        {
+            CardDefinition clone = ScriptableObject.CreateInstance<CardDefinition>();
+
+            clone.SetDebugData(
+                id,
+                cardName,
+                description,
+                cost,
+                type,
+                rarity,
+                target,
+                new List<string>(tags),
+                new List<EffectRef>(effects),
+                worldType,
+                art,
+                false);   // affinity=false: la variante ya está resuelta a worldType
+
+            clone._upgrade = _upgrade;   // comparte el payload de upgrade (read-only)
             return clone;
         }
     }

--- a/Assets/Scripts/Run/RunCombatConfig.cs
+++ b/Assets/Scripts/Run/RunCombatConfig.cs
@@ -26,5 +26,18 @@ namespace RoguelikeCardBattler.Run
         public IReadOnlyList<CardDeckEntry> RewardPool => rewardPool;
         public IReadOnlyList<RelicDefinition> EliteRelicDropPool => eliteRelicDropPool;
         public RelicDefinition BossRelicDrop => bossRelicDrop;
+
+#if UNITY_EDITOR
+        /// <summary>
+        /// Setter editor-only para que <c>StarterDeckSetup</c> (4a) reescriba el
+        /// starter deck a la composición GDD §5 sin edición manual del inspector.
+        /// Mismo patrón que <c>NewRunConfig.EditorPopulateFaces</c> /
+        /// <c>ShopConfig.EditorPopulatePools</c>. No disponible en runtime.
+        /// </summary>
+        public void EditorPopulateStarterDeck(List<CardDeckEntry> entries)
+        {
+            starterDeck = entries ?? new List<CardDeckEntry>();
+        }
+#endif
     }
 }

--- a/Assets/Scripts/Run/RunCombatConfig.cs
+++ b/Assets/Scripts/Run/RunCombatConfig.cs
@@ -38,6 +38,17 @@ namespace RoguelikeCardBattler.Run
         {
             starterDeck = entries ?? new List<CardDeckEntry>();
         }
+
+        /// <summary>
+        /// Setter editor-only para que <c>StarterDeckSetup</c> (4a follow-up) reescriba
+        /// el reward pool a cartas AFINES, de modo que las recompensas de combate adopten
+        /// los tipos de mundo del jugador al ganarlas (vía RunState.AddCardToDeck →
+        /// AffinityResolver). Antes el pool tenía duales Rojo/Negro fijos que no resolvían.
+        /// </summary>
+        public void EditorPopulateRewardPool(List<CardDeckEntry> entries)
+        {
+            rewardPool = entries ?? new List<CardDeckEntry>();
+        }
 #endif
     }
 }

--- a/Assets/Scripts/Run/RunSession.cs
+++ b/Assets/Scripts/Run/RunSession.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using RoguelikeCardBattler.Gameplay.Cards;
 using RoguelikeCardBattler.Gameplay.Enemies;
 using RoguelikeCardBattler.Gameplay.Relics;
 
@@ -157,7 +158,20 @@ namespace RoguelikeCardBattler.Run
             }
 
             CombatConfig = config;
-            State.InitializeDeck(config.StarterDeck);
+
+            // 4a: resolver afinidad SOLO al poblar el mazo por primera vez. El guard
+            // Deck.Count==0 evita re-crear (y descartar) ScriptableObjects runtime en
+            // cada combate — InitializeDeck ya no-opea tras el primero, así que sin
+            // este guard resolveríamos y tiraríamos SOs cada vez (leak de instancias).
+            // Los tipos por mundo ya están en RunState (los escribe NewRunScene vía
+            // StarterDraft.ApplySelectionToState antes de cargar RunScene); si se
+            // entra directo a BattleScene caen a los defaults de RunState (no crashea).
+            if (State.Deck.Count == 0)
+            {
+                var resolved = AffinityResolver.ResolveDeck(
+                    config.StarterDeck, State.PlayerWorldAType, State.PlayerWorldBType);
+                State.InitializeDeck(resolved);
+            }
         }
     }
 }

--- a/Assets/Scripts/Run/RunState.cs
+++ b/Assets/Scripts/Run/RunState.cs
@@ -178,7 +178,18 @@ namespace RoguelikeCardBattler.Run
                 return;
             }
 
-            Deck.Add(entry.Clone());
+            // 4a follow-up: toda carta ganada/comprada/de-evento durante la run pasa por
+            // la MISMA resolución de afinidad que el mazo inicial (RunSession.ConfigureCombat).
+            // Una carta afín adopta los tipos de mundo elegidos por el jugador (A/B); las
+            // neutras y las ya-duales se clonan sin cambios. Sin esto, una recompensa afín
+            // (single, ElementType.None) entraría al mazo sin tipo de mundo y nunca
+            // explotaría la afinidad — se veía como una carta de tipos ajenos a los elegidos.
+            // AffinityResolver.Resolve ya clona internamente → no duplicar Clone aquí.
+            CardDeckEntry resolved = AffinityResolver.Resolve(entry, PlayerWorldAType, PlayerWorldBType);
+            if (resolved != null)
+            {
+                Deck.Add(resolved);
+            }
         }
 
         public void AddCardToDeck(CardDefinition card)

--- a/Assets/Tests/EditMode/AffinityTests.cs
+++ b/Assets/Tests/EditMode/AffinityTests.cs
@@ -17,21 +17,48 @@ namespace RoguelikeCardBattler.Tests.EditMode
     /// </summary>
     public class AffinityTests : CombatTestBase
     {
-        // SOs runtime creados a mano por estos tests (afines: CombatTestBase no expone
-        // un helper de afinidad). Se destruyen en TearDown local; el base limpia los suyos.
-        private readonly List<UnityEngine.Object> _affineAssets = new List<UnityEngine.Object>();
+        // SOs runtime creados por estos tests (cuerpos a mano + duales/variantes que
+        // produce el resolver y los clones de upgrade). CombatTestBase no expone un
+        // helper de afinidad ni rastrea estos SOs runtime, así que los registramos acá
+        // y los destruimos en TearDown — sin esto cada Resolve/upgrade dejaría SOs
+        // huérfanos en memoria (higiene de test).
+        private readonly List<UnityEngine.Object> _runtimeSos = new List<UnityEngine.Object>();
 
         [TearDown]
-        public void CleanupAffineAssets()
+        public void CleanupRuntimeSos()
         {
-            foreach (UnityEngine.Object asset in _affineAssets)
+            foreach (UnityEngine.Object so in _runtimeSos)
             {
-                if (asset != null) UnityEngine.Object.DestroyImmediate(asset);
+                if (so != null) UnityEngine.Object.DestroyImmediate(so);
             }
-            _affineAssets.Clear();
+            _runtimeSos.Clear();
         }
 
         // ── Helpers ──────────────────────────────────────────────────────────────
+
+        // Registra un SO runtime para limpieza. Devuelve el mismo objeto (fluido).
+        private T TrackSO<T>(T so) where T : UnityEngine.Object
+        {
+            if (so != null) _runtimeSos.Add(so);
+            return so;
+        }
+
+        // Registra los SOs que cuelgan de una entry dual (la dual + sus 2 lados).
+        // Las entries single comparten el SO del cuerpo (ya rastreado), no crean SOs.
+        private CardDeckEntry TrackEntry(CardDeckEntry entry)
+        {
+            if (entry?.DualCard != null)
+            {
+                TrackSO(entry.DualCard);
+                TrackSO(entry.DualCard.SideA);
+                TrackSO(entry.DualCard.SideB);
+            }
+            return entry;
+        }
+
+        // Resolve + registro de los SOs runtime que produce.
+        private CardDeckEntry ResolveTracked(CardDeckEntry authored, ElementType typeA, ElementType typeB)
+            => TrackEntry(AffinityResolver.Resolve(authored, typeA, typeB));
 
         private CardDefinition MakeAffineStrike(string id = "aff_strike", int damage = 6)
         {
@@ -41,8 +68,7 @@ namespace RoguelikeCardBattler.Tests.EditMode
                 CardRarity.Common, CardTarget.SingleEnemy, new List<string>(),
                 new List<EffectRef> { CreateEffect(EffectType.Damage, damage, EffectTarget.SingleEnemy) },
                 ElementType.None, null, /*affinity*/ true);
-            _affineAssets.Add(card);
-            return card;
+            return TrackSO(card);
         }
 
         private CardDefinition MakeAffineDefend(string id = "aff_defend", int block = 5)
@@ -53,8 +79,7 @@ namespace RoguelikeCardBattler.Tests.EditMode
                 CardRarity.Common, CardTarget.Self, new List<string>(),
                 new List<EffectRef> { CreateEffect(EffectType.Block, block, EffectTarget.Self) },
                 ElementType.None, null, /*affinity*/ true);
-            _affineAssets.Add(card);
-            return card;
+            return TrackSO(card);
         }
 
         // Neutra: mismo cuerpo que la afín pero affinity=false (sigue None → 90%).
@@ -68,8 +93,7 @@ namespace RoguelikeCardBattler.Tests.EditMode
                 CardRarity.Common, CardTarget.SingleEnemy, new List<string>(),
                 new List<EffectRef> { CreateEffect(EffectType.Damage, damage, EffectTarget.SingleEnemy) },
                 ElementType.None, null, /*affinity*/ false);
-            _affineAssets.Add(card);
-            return card;
+            return TrackSO(card);
         }
 
         private CardDefinition MakeNeutralDefend(string id, int block = 5)
@@ -80,8 +104,7 @@ namespace RoguelikeCardBattler.Tests.EditMode
                 CardRarity.Common, CardTarget.Self, new List<string>(),
                 new List<EffectRef> { CreateEffect(EffectType.Block, block, EffectTarget.Self) },
                 ElementType.None, null, /*affinity*/ false);
-            _affineAssets.Add(card);
-            return card;
+            return TrackSO(card);
         }
 
         private void SetStrikeUpgrade(CardDefinition card, int upgradedDamage)
@@ -108,12 +131,15 @@ namespace RoguelikeCardBattler.Tests.EditMode
             return manager;
         }
 
+        private EnemyDefinition Enemy(string id, ElementType type, int hp = 50) =>
+            CreateEnemyDefinition(id, "Enemy", hp, EnemyAIPattern.Sequence, new List<EnemyMove>(), type);
+
         // ── Casos ──────────────────────────────────────────────────────────────────
 
         [Test] // 1 — Resolución afín → dual tipada por mundo
         public void Resolve_AffineSingle_BecomesDualTypedPerWorld()
         {
-            CardDeckEntry resolved = AffinityResolver.Resolve(
+            CardDeckEntry resolved = ResolveTracked(
                 CardDeckEntry.CreateSingle(MakeAffineStrike()), ElementType.Rojo, ElementType.Azul);
 
             Assert.IsNotNull(resolved.DualCard, "Una carta afín se resuelve a una entrada dual.");
@@ -126,7 +152,7 @@ namespace RoguelikeCardBattler.Tests.EditMode
         public void CreateAffinityVariant_PreservesBody_OnlyTypeDiffers()
         {
             CardDefinition body = MakeAffineStrike("body_test", damage: 7);
-            CardDefinition variant = body.CreateAffinityVariant(ElementType.Morado);
+            CardDefinition variant = TrackSO(body.CreateAffinityVariant(ElementType.Morado));
 
             Assert.AreEqual(body.CardName, variant.CardName);
             Assert.AreEqual(body.Cost, variant.Cost);
@@ -145,11 +171,12 @@ namespace RoguelikeCardBattler.Tests.EditMode
             CardDefinition affine = MakeAffineStrike("upg_strike", damage: 6);
             SetStrikeUpgrade(affine, 9);
 
-            CardDeckEntry resolved = AffinityResolver.Resolve(
+            CardDeckEntry resolved = ResolveTracked(
                 CardDeckEntry.CreateSingle(affine), ElementType.Rojo, ElementType.Azul);
 
             Assert.IsTrue(resolved.CanUpgrade(), "La dual afín conserva el payload de upgrade.");
             resolved.ApplyUpgrade();
+            TrackEntry(resolved);   // ApplyUpgrade reemplaza la dual por un clon nuevo
             Assert.AreEqual(9, FirstDamage(resolved.DualCard.SideA), "Lado A mejorado.");
             Assert.AreEqual(9, FirstDamage(resolved.DualCard.SideB), "Lado B mejorado.");
         }
@@ -157,7 +184,7 @@ namespace RoguelikeCardBattler.Tests.EditMode
         [Test] // 4 — Una neutra (sin afinidad, None) pasa sin tocar (sigue single None)
         public void Resolve_NeutralSingle_StaysSingleNone()
         {
-            CardDeckEntry resolved = AffinityResolver.Resolve(
+            CardDeckEntry resolved = ResolveTracked(
                 CreateSingleCardEntry(MakeNeutralStrike("neutral_strike")), ElementType.Rojo, ElementType.Azul);
 
             Assert.IsNotNull(resolved.SingleCard, "Una neutra no se convierte en dual.");
@@ -168,7 +195,7 @@ namespace RoguelikeCardBattler.Tests.EditMode
         [Test] // 5 — Integración con CardDeckEntry: GetActiveCard conmuta tipo por mundo
         public void Resolve_GetActiveCard_SwitchesTypePerWorld()
         {
-            CardDeckEntry resolved = AffinityResolver.Resolve(
+            CardDeckEntry resolved = ResolveTracked(
                 CardDeckEntry.CreateSingle(MakeAffineStrike()), ElementType.Negro, ElementType.Blanco);
 
             Assert.AreEqual(ElementType.Negro, resolved.GetActiveCard(TurnManager.WorldSide.A).ElementType);
@@ -185,6 +212,7 @@ namespace RoguelikeCardBattler.Tests.EditMode
             for (int i = 0; i < 2; i++) authored.Add(CreateSingleCardEntry(MakeNeutralDefend("dn" + i)));        // 2 Defend neutra
 
             List<CardDeckEntry> resolved = AffinityResolver.ResolveDeck(authored, ElementType.Rojo, ElementType.Azul);
+            foreach (CardDeckEntry e in resolved) TrackEntry(e);
 
             Assert.AreEqual(9, resolved.Count, "9 entradas single autoradas (la 10ª es la dual drafteada).");
             Assert.AreEqual(5, resolved.Count(e => RepName(e) == "Strike"), "5 Strike.");
@@ -200,11 +228,9 @@ namespace RoguelikeCardBattler.Tests.EditMode
         {
             // Afín Strike (base 6) en Mundo A con tipo Rojo, enemigo Azul → Rojo es
             // SuperEficaz vs Azul → 6 × 1.5 = 9 daño y +1 carga de Estilo.
-            CardDeckEntry affineEntry = AffinityResolver.Resolve(
+            CardDeckEntry affineEntry = ResolveTracked(
                 CardDeckEntry.CreateSingle(MakeAffineStrike("tm_affine", 6)), ElementType.Rojo, ElementType.Azul);
-            EnemyDefinition azulEnemy = CreateEnemyDefinition("azul_a", "Enemy", 50,
-                EnemyAIPattern.Sequence, new List<EnemyMove>(), ElementType.Azul);
-            TurnManager mAff = CreateManager(affineEntry, azulEnemy);
+            TurnManager mAff = CreateManager(affineEntry, Enemy("azul_a", ElementType.Azul));
             mAff.SetCurrentWorldForTest(TurnManager.WorldSide.A);
             int hpBeforeAff = mAff.EnemyHP;
             mAff.PlayCard(mAff.PlayerHand[0]);
@@ -212,11 +238,9 @@ namespace RoguelikeCardBattler.Tests.EditMode
             Assert.AreEqual(1, mAff.StyleCharges, "Un SuperEficaz otorga 1 carga de Estilo.");
 
             // Neutra Strike (base 6) → None → round(6 × 0.9) = 5 daño, Estilo sin cambios.
-            CardDeckEntry neutralEntry = AffinityResolver.Resolve(
+            CardDeckEntry neutralEntry = ResolveTracked(
                 CreateSingleCardEntry(MakeNeutralStrike("tm_neutral", 6)), ElementType.Rojo, ElementType.Azul);
-            EnemyDefinition azulEnemy2 = CreateEnemyDefinition("azul_b", "Enemy", 50,
-                EnemyAIPattern.Sequence, new List<EnemyMove>(), ElementType.Azul);
-            TurnManager mNeu = CreateManager(neutralEntry, azulEnemy2);
+            TurnManager mNeu = CreateManager(neutralEntry, Enemy("azul_b", ElementType.Azul));
             mNeu.SetCurrentWorldForTest(TurnManager.WorldSide.A);
             int hpBeforeNeu = mNeu.EnemyHP;
             mNeu.PlayCard(mNeu.PlayerHand[0]);
@@ -230,11 +254,53 @@ namespace RoguelikeCardBattler.Tests.EditMode
             CardDefinition affine = MakeAffineStrike("rt_strike", 6);
             SetStrikeUpgrade(affine, 9);
 
-            CardDefinition upgraded = affine.CreateUpgradedClone();
+            CardDefinition upgraded = TrackSO(affine.CreateUpgradedClone());
             Assert.IsTrue(upgraded.Affinity, "CreateUpgradedClone preserva el flag de afinidad.");
 
-            CardDefinition variant = affine.CreateAffinityVariant(ElementType.Rojo);
+            CardDefinition variant = TrackSO(affine.CreateAffinityVariant(ElementType.Rojo));
             Assert.IsFalse(variant.Affinity, "CreateAffinityVariant resuelve el flag a false.");
+        }
+
+        [Test] // 9 — La MISMA carta afín conmuta su tipo por mundo a través del TurnManager real
+        public void Resolve_SameAffineCard_SwitchesTypeByWorld_OnRealTurnManager()
+        {
+            // Afín base 8, A=Rojo / B=Azul. Una sola dual resuelta, clonada en dos managers.
+            CardDeckEntry resolved = ResolveTracked(
+                CardDeckEntry.CreateSingle(MakeAffineStrike("wb", 8)), ElementType.Rojo, ElementType.Azul);
+
+            // Mundo A → tipo Rojo, enemigo Azul: Rojo→Azul SuperEficaz → 8×1.5 = 12, +1 Estilo.
+            TurnManager mA = CreateManager(resolved.Clone(), Enemy("e_a", ElementType.Azul));
+            mA.SetCurrentWorldForTest(TurnManager.WorldSide.A);
+            int hpA = mA.EnemyHP;
+            mA.PlayCard(mA.PlayerHand[0]);
+            Assert.AreEqual(hpA - 12, mA.EnemyHP, "En Mundo A usa el tipo A (Rojo, SuperEficaz vs Azul).");
+            Assert.AreEqual(1, mA.StyleCharges);
+
+            // Mundo B → tipo Azul, enemigo Azul: Azul→Azul mismo tipo = Neutro → 8×1.0 = 8, sin Estilo.
+            TurnManager mB = CreateManager(resolved.Clone(), Enemy("e_b", ElementType.Azul));
+            mB.SetCurrentWorldForTest(TurnManager.WorldSide.B);
+            int hpB = mB.EnemyHP;
+            mB.PlayCard(mB.PlayerHand[0]);
+            Assert.AreEqual(hpB - 8, mB.EnemyHP, "En Mundo B usa el tipo B (Azul, Neutro vs Azul) — conmutó en vivo.");
+            Assert.AreEqual(0, mB.StyleCharges, "Neutro no otorga Estilo → confirma que el tipo cambió con el mundo.");
+        }
+
+        [Test] // 10 — Una afín YA MEJORADA juega su daño mejorado en combate
+        public void Resolve_UpgradedAffine_PlaysUpgradedDamage_InCombat()
+        {
+            CardDefinition affine = MakeAffineStrike("upg_combat", damage: 6);
+            SetStrikeUpgrade(affine, 9);
+            CardDeckEntry resolved = ResolveTracked(
+                CardDeckEntry.CreateSingle(affine), ElementType.Rojo, ElementType.Azul);
+            resolved.ApplyUpgrade();
+            TrackEntry(resolved);
+
+            // Mundo A → tipo Rojo, enemigo Morado: Rojo→Morado Neutro → daño mejorado 9 × 1.0 = 9.
+            TurnManager m = CreateManager(resolved, Enemy("morado", ElementType.Morado));
+            m.SetCurrentWorldForTest(TurnManager.WorldSide.A);
+            int hp = m.EnemyHP;
+            m.PlayCard(m.PlayerHand[0]);
+            Assert.AreEqual(hp - 9, m.EnemyHP, "La afín mejorada inflige su daño mejorado (9) en combate.");
         }
 
         // Nombre de la carta representante de una entry (single → su carta; dual → SideA).

--- a/Assets/Tests/EditMode/AffinityTests.cs
+++ b/Assets/Tests/EditMode/AffinityTests.cs
@@ -1,0 +1,244 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using RoguelikeCardBattler.Gameplay.Cards;
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Gameplay.Enemies;
+
+namespace RoguelikeCardBattler.Tests.EditMode
+{
+    /// <summary>
+    /// M4 bloque 4a — Afinidad de cartas (DD-022 opción A). Verifica que
+    /// <see cref="AffinityResolver"/> convierte una carta afín en una dual runtime
+    /// tipada por mundo, preserva cuerpo y upgrade, deja pasar neutras/duales, y que
+    /// el resultado conmuta tipo por mundo sobre un <see cref="TurnManager"/> REAL sin
+    /// que el protegido cambie (el daño/Estilo salen del path orgánico existente).
+    /// </summary>
+    public class AffinityTests : CombatTestBase
+    {
+        // SOs runtime creados a mano por estos tests (afines: CombatTestBase no expone
+        // un helper de afinidad). Se destruyen en TearDown local; el base limpia los suyos.
+        private readonly List<UnityEngine.Object> _affineAssets = new List<UnityEngine.Object>();
+
+        [TearDown]
+        public void CleanupAffineAssets()
+        {
+            foreach (UnityEngine.Object asset in _affineAssets)
+            {
+                if (asset != null) UnityEngine.Object.DestroyImmediate(asset);
+            }
+            _affineAssets.Clear();
+        }
+
+        // ── Helpers ──────────────────────────────────────────────────────────────
+
+        private CardDefinition MakeAffineStrike(string id = "aff_strike", int damage = 6)
+        {
+            var card = ScriptableObject.CreateInstance<CardDefinition>();
+            card.SetDebugData(
+                id, "Strike", $"Deal {damage} damage to an enemy.", 1, CardType.Attack,
+                CardRarity.Common, CardTarget.SingleEnemy, new List<string>(),
+                new List<EffectRef> { CreateEffect(EffectType.Damage, damage, EffectTarget.SingleEnemy) },
+                ElementType.None, null, /*affinity*/ true);
+            _affineAssets.Add(card);
+            return card;
+        }
+
+        private CardDefinition MakeAffineDefend(string id = "aff_defend", int block = 5)
+        {
+            var card = ScriptableObject.CreateInstance<CardDefinition>();
+            card.SetDebugData(
+                id, "Defend", $"Gain {block} Block.", 1, CardType.Skill,
+                CardRarity.Common, CardTarget.Self, new List<string>(),
+                new List<EffectRef> { CreateEffect(EffectType.Block, block, EffectTarget.Self) },
+                ElementType.None, null, /*affinity*/ true);
+            _affineAssets.Add(card);
+            return card;
+        }
+
+        // Neutra: mismo cuerpo que la afín pero affinity=false (sigue None → 90%).
+        // Se construye a mano (no vía CreateCardWithElement) para fijar cardName
+        // "Strike"/"Defend" — ese helper de la base fuerza cardName = id.
+        private CardDefinition MakeNeutralStrike(string id, int damage = 6)
+        {
+            var card = ScriptableObject.CreateInstance<CardDefinition>();
+            card.SetDebugData(
+                id, "Strike", $"Deal {damage} damage to an enemy.", 1, CardType.Attack,
+                CardRarity.Common, CardTarget.SingleEnemy, new List<string>(),
+                new List<EffectRef> { CreateEffect(EffectType.Damage, damage, EffectTarget.SingleEnemy) },
+                ElementType.None, null, /*affinity*/ false);
+            _affineAssets.Add(card);
+            return card;
+        }
+
+        private CardDefinition MakeNeutralDefend(string id, int block = 5)
+        {
+            var card = ScriptableObject.CreateInstance<CardDefinition>();
+            card.SetDebugData(
+                id, "Defend", $"Gain {block} Block.", 1, CardType.Skill,
+                CardRarity.Common, CardTarget.Self, new List<string>(),
+                new List<EffectRef> { CreateEffect(EffectType.Block, block, EffectTarget.Self) },
+                ElementType.None, null, /*affinity*/ false);
+            _affineAssets.Add(card);
+            return card;
+        }
+
+        private void SetStrikeUpgrade(CardDefinition card, int upgradedDamage)
+        {
+            card.Upgrade.SetTestData(false, 0,
+                new List<EffectRef> { CreateEffect(EffectType.Damage, upgradedDamage, EffectTarget.SingleEnemy) },
+                null, $"Deal {upgradedDamage} damage to an enemy.");
+        }
+
+        private static int FirstDamage(CardDefinition c)
+        {
+            foreach (EffectRef e in c.Effects) if (e.effectType == EffectType.Damage) return e.value;
+            return -1;
+        }
+
+        private TurnManager CreateManager(CardDeckEntry entry, EnemyDefinition enemy)
+        {
+            var deck = new List<CardDeckEntry> { entry };
+            var go = CreateGameObject("TurnManager");
+            var manager = AddComponent<TurnManager>(go);
+            manager.SetTestConfig(maxHp: 30, energy: 3, startingHand: 1, cardsPerTurnCount: 1);
+            manager.SetTestData(deck, enemy);
+            manager.InitializeCombat();
+            return manager;
+        }
+
+        // ── Casos ──────────────────────────────────────────────────────────────────
+
+        [Test] // 1 — Resolución afín → dual tipada por mundo
+        public void Resolve_AffineSingle_BecomesDualTypedPerWorld()
+        {
+            CardDeckEntry resolved = AffinityResolver.Resolve(
+                CardDeckEntry.CreateSingle(MakeAffineStrike()), ElementType.Rojo, ElementType.Azul);
+
+            Assert.IsNotNull(resolved.DualCard, "Una carta afín se resuelve a una entrada dual.");
+            Assert.IsNull(resolved.SingleCard);
+            Assert.AreEqual(ElementType.Rojo, resolved.DualCard.SideA.ElementType, "Lado A toma el tipo del Mundo A.");
+            Assert.AreEqual(ElementType.Azul, resolved.DualCard.SideB.ElementType, "Lado B toma el tipo del Mundo B.");
+        }
+
+        [Test] // 2 — La variante afín preserva el cuerpo; solo cambia el tipo (y Affinity)
+        public void CreateAffinityVariant_PreservesBody_OnlyTypeDiffers()
+        {
+            CardDefinition body = MakeAffineStrike("body_test", damage: 7);
+            CardDefinition variant = body.CreateAffinityVariant(ElementType.Morado);
+
+            Assert.AreEqual(body.CardName, variant.CardName);
+            Assert.AreEqual(body.Cost, variant.Cost);
+            Assert.AreEqual(body.Type, variant.Type);
+            Assert.AreEqual(body.Target, variant.Target);
+            Assert.AreEqual(body.Art, variant.Art);
+            Assert.AreEqual(body.Effects.Count, variant.Effects.Count);
+            Assert.AreEqual(FirstDamage(body), FirstDamage(variant), "El payload de efectos se conserva.");
+            Assert.AreEqual(ElementType.Morado, variant.ElementType, "Solo difiere el tipo elemental.");
+            Assert.IsFalse(variant.Affinity, "La variante queda resuelta (Affinity=false).");
+        }
+
+        [Test] // 3 — La dual afín resuelta sigue siendo mejorable; mejora ambos lados
+        public void Resolve_PreservesUpgrade_BothSidesUpgrade()
+        {
+            CardDefinition affine = MakeAffineStrike("upg_strike", damage: 6);
+            SetStrikeUpgrade(affine, 9);
+
+            CardDeckEntry resolved = AffinityResolver.Resolve(
+                CardDeckEntry.CreateSingle(affine), ElementType.Rojo, ElementType.Azul);
+
+            Assert.IsTrue(resolved.CanUpgrade(), "La dual afín conserva el payload de upgrade.");
+            resolved.ApplyUpgrade();
+            Assert.AreEqual(9, FirstDamage(resolved.DualCard.SideA), "Lado A mejorado.");
+            Assert.AreEqual(9, FirstDamage(resolved.DualCard.SideB), "Lado B mejorado.");
+        }
+
+        [Test] // 4 — Una neutra (sin afinidad, None) pasa sin tocar (sigue single None)
+        public void Resolve_NeutralSingle_StaysSingleNone()
+        {
+            CardDeckEntry resolved = AffinityResolver.Resolve(
+                CreateSingleCardEntry(MakeNeutralStrike("neutral_strike")), ElementType.Rojo, ElementType.Azul);
+
+            Assert.IsNotNull(resolved.SingleCard, "Una neutra no se convierte en dual.");
+            Assert.IsNull(resolved.DualCard);
+            Assert.AreEqual(ElementType.None, resolved.SingleCard.ElementType);
+        }
+
+        [Test] // 5 — Integración con CardDeckEntry: GetActiveCard conmuta tipo por mundo
+        public void Resolve_GetActiveCard_SwitchesTypePerWorld()
+        {
+            CardDeckEntry resolved = AffinityResolver.Resolve(
+                CardDeckEntry.CreateSingle(MakeAffineStrike()), ElementType.Negro, ElementType.Blanco);
+
+            Assert.AreEqual(ElementType.Negro, resolved.GetActiveCard(TurnManager.WorldSide.A).ElementType);
+            Assert.AreEqual(ElementType.Blanco, resolved.GetActiveCard(TurnManager.WorldSide.B).ElementType);
+        }
+
+        [Test] // 6 — Composición de mazo completo: 9 entradas, 5 Strike / 4 Defend con duales/singles esperados
+        public void ResolveDeck_StarterComposition_ProducesGddShape()
+        {
+            var authored = new List<CardDeckEntry>();
+            for (int i = 0; i < 3; i++) authored.Add(CardDeckEntry.CreateSingle(MakeAffineStrike("sa" + i)));   // 3 Strike afín
+            for (int i = 0; i < 2; i++) authored.Add(CreateSingleCardEntry(MakeNeutralStrike("sn" + i)));        // 2 Strike neutra
+            for (int i = 0; i < 2; i++) authored.Add(CardDeckEntry.CreateSingle(MakeAffineDefend("da" + i)));    // 2 Defend afín
+            for (int i = 0; i < 2; i++) authored.Add(CreateSingleCardEntry(MakeNeutralDefend("dn" + i)));        // 2 Defend neutra
+
+            List<CardDeckEntry> resolved = AffinityResolver.ResolveDeck(authored, ElementType.Rojo, ElementType.Azul);
+
+            Assert.AreEqual(9, resolved.Count, "9 entradas single autoradas (la 10ª es la dual drafteada).");
+            Assert.AreEqual(5, resolved.Count(e => RepName(e) == "Strike"), "5 Strike.");
+            Assert.AreEqual(4, resolved.Count(e => RepName(e) == "Defend"), "4 Defend.");
+            Assert.AreEqual(3, resolved.Count(e => RepName(e) == "Strike" && e.DualCard != null), "3 Strike afín → dual.");
+            Assert.AreEqual(2, resolved.Count(e => RepName(e) == "Strike" && e.SingleCard != null), "2 Strike neutra → single.");
+            Assert.AreEqual(2, resolved.Count(e => RepName(e) == "Defend" && e.DualCard != null), "2 Defend afín → dual.");
+            Assert.AreEqual(2, resolved.Count(e => RepName(e) == "Defend" && e.SingleCard != null), "2 Defend neutra → single.");
+        }
+
+        [Test] // 7 — Sobre un TurnManager real: afín en Mundo A = efectividad; neutra = 90% sin Estilo
+        public void Resolve_OnRealTurnManager_AffineSuperEffective_NeutralFlat()
+        {
+            // Afín Strike (base 6) en Mundo A con tipo Rojo, enemigo Azul → Rojo es
+            // SuperEficaz vs Azul → 6 × 1.5 = 9 daño y +1 carga de Estilo.
+            CardDeckEntry affineEntry = AffinityResolver.Resolve(
+                CardDeckEntry.CreateSingle(MakeAffineStrike("tm_affine", 6)), ElementType.Rojo, ElementType.Azul);
+            EnemyDefinition azulEnemy = CreateEnemyDefinition("azul_a", "Enemy", 50,
+                EnemyAIPattern.Sequence, new List<EnemyMove>(), ElementType.Azul);
+            TurnManager mAff = CreateManager(affineEntry, azulEnemy);
+            mAff.SetCurrentWorldForTest(TurnManager.WorldSide.A);
+            int hpBeforeAff = mAff.EnemyHP;
+            mAff.PlayCard(mAff.PlayerHand[0]);
+            Assert.AreEqual(hpBeforeAff - 9, mAff.EnemyHP, "Afín en Mundo A vs SuperEficaz = base×1.5.");
+            Assert.AreEqual(1, mAff.StyleCharges, "Un SuperEficaz otorga 1 carga de Estilo.");
+
+            // Neutra Strike (base 6) → None → round(6 × 0.9) = 5 daño, Estilo sin cambios.
+            CardDeckEntry neutralEntry = AffinityResolver.Resolve(
+                CreateSingleCardEntry(MakeNeutralStrike("tm_neutral", 6)), ElementType.Rojo, ElementType.Azul);
+            EnemyDefinition azulEnemy2 = CreateEnemyDefinition("azul_b", "Enemy", 50,
+                EnemyAIPattern.Sequence, new List<EnemyMove>(), ElementType.Azul);
+            TurnManager mNeu = CreateManager(neutralEntry, azulEnemy2);
+            mNeu.SetCurrentWorldForTest(TurnManager.WorldSide.A);
+            int hpBeforeNeu = mNeu.EnemyHP;
+            mNeu.PlayCard(mNeu.PlayerHand[0]);
+            Assert.AreEqual(hpBeforeNeu - 5, mNeu.EnemyHP, "Neutra = 90% del daño base (DD-002).");
+            Assert.AreEqual(0, mNeu.StyleCharges, "La neutra no pasa por la tabla → no mueve Estilo.");
+        }
+
+        [Test] // 8 — Round-trip del flag: el clon de upgrade lo preserva; la variante lo resuelve a false
+        public void AffinityFlag_RoundTrip()
+        {
+            CardDefinition affine = MakeAffineStrike("rt_strike", 6);
+            SetStrikeUpgrade(affine, 9);
+
+            CardDefinition upgraded = affine.CreateUpgradedClone();
+            Assert.IsTrue(upgraded.Affinity, "CreateUpgradedClone preserva el flag de afinidad.");
+
+            CardDefinition variant = affine.CreateAffinityVariant(ElementType.Rojo);
+            Assert.IsFalse(variant.Affinity, "CreateAffinityVariant resuelve el flag a false.");
+        }
+
+        // Nombre de la carta representante de una entry (single → su carta; dual → SideA).
+        private static string RepName(CardDeckEntry entry) =>
+            CardDisplay.RepresentativeCard(entry)?.CardName;
+    }
+}

--- a/Assets/Tests/EditMode/AffinityTests.cs.meta
+++ b/Assets/Tests/EditMode/AffinityTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7e799230632e57d4e88bec6a7f2cb495

--- a/Assets/Tests/EditMode/CardUpgradeCoverageTests.cs
+++ b/Assets/Tests/EditMode/CardUpgradeCoverageTests.cs
@@ -1,0 +1,67 @@
+#if UNITY_EDITOR
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEditor;
+using RoguelikeCardBattler.Gameplay.Cards;
+using RoguelikeCardBattler.Run.NewRun;
+
+namespace RoguelikeCardBattler.Tests.EditMode
+{
+    /// <summary>
+    /// M4 bloque 4a — Guard de cobertura de mejoras (DD-023). Garantía PERMANENTE:
+    /// TODA CardDefinition del proyecto tiene mejora autorada, así la Hoguera no
+    /// vuelve a "verse rota" en silencio (un mazo con cartas no mejorables). Test
+    /// editor-only (usa AssetDatabase): el archivo entero va bajo #if UNITY_EDITOR
+    /// por higiene — EditModeTests.asmdef corre en plataforma Editor.
+    /// </summary>
+    public class CardUpgradeCoverageTests
+    {
+        [Test] // 9 — Guard global: ningún CardDefinition queda sin upgrade
+        public void EveryCardDefinition_HasUpgradeAuthored()
+        {
+            string[] guids = AssetDatabase.FindAssets("t:CardDefinition");
+            var missing = new List<string>();
+
+            foreach (string guid in guids)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(guid);
+                CardDefinition card = AssetDatabase.LoadAssetAtPath<CardDefinition>(path);
+                if (card == null) continue;
+                if (card.Upgrade == null || !card.Upgrade.HasUpgrade)
+                {
+                    missing.Add($"{card.name}  ({path})");
+                }
+            }
+
+            Assert.IsEmpty(missing,
+                "Estos CardDefinition no tienen mejora autorada (DD-023). Corré los menús " +
+                "'Roguelike > Setup Starter Deck (4a)' y 'Roguelike > Setup Placeholder Card Upgrades':\n  " +
+                string.Join("\n  ", missing));
+        }
+
+        [Test] // 10 — La dual compuesta de 2 caras es mejorable (caras con upgrade poblado)
+        public void ComposedDualFromFaces_IsUpgradeable()
+        {
+            CardDefinition faceA = LoadFace("Face_Rojo_1");
+            CardDefinition faceB = LoadFace("Face_Azul_1");
+            Assert.IsNotNull(faceA, "Falta Face_Rojo_1 (corré 'Setup New Run Config').");
+            Assert.IsNotNull(faceB, "Falta Face_Azul_1 (corré 'Setup New Run Config').");
+
+            DualCardDefinition dual = StarterDraft.ComposeDualCard(faceA, faceB);
+            CardDeckEntry entry = CardDeckEntry.CreateDual(dual);
+
+            Assert.IsTrue(entry.CanUpgrade(),
+                "La dual drafteada (2 caras) debe ser mejorable: ambos lados tienen upgrade " +
+                "autorado por 'Setup Starter Deck (4a)'.");
+        }
+
+        private static CardDefinition LoadFace(string assetName)
+        {
+            string[] guids = AssetDatabase.FindAssets(
+                $"{assetName} t:CardDefinition", new[] { "Assets/ScriptableObjects/Cards/NewRunFaces" });
+            if (guids.Length == 0) return null;
+            return AssetDatabase.LoadAssetAtPath<CardDefinition>(AssetDatabase.GUIDToAssetPath(guids[0]));
+        }
+    }
+}
+#endif

--- a/Assets/Tests/EditMode/CardUpgradeCoverageTests.cs.meta
+++ b/Assets/Tests/EditMode/CardUpgradeCoverageTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 320d8e1d25f7ef24a951228f2cb3a9c0

--- a/Assets/Tests/EditMode/RunStateAffinityTests.cs
+++ b/Assets/Tests/EditMode/RunStateAffinityTests.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using RoguelikeCardBattler.Gameplay.Cards;
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Run;
+
+namespace RoguelikeCardBattler.Tests.EditMode
+{
+    /// <summary>
+    /// 4a follow-up — afinidad en cartas ganadas/compradas/de-evento durante la run.
+    /// Verifica que <see cref="RunState.AddCardToDeck(CardDeckEntry)"/> rutea por
+    /// <see cref="AffinityResolver"/>: una carta afín adopta los tipos de mundo del
+    /// jugador al entrar al mazo (no se queda como single sin tipo), mientras neutras y
+    /// duales pasan sin cambios. Cubre el seam único que reward (RunFlowController) y
+    /// Tienda (ShopNodeController) ya usan — y que reusarán los eventos de 4b.
+    /// </summary>
+    public class RunStateAffinityTests
+    {
+        // SOs runtime creados en estos tests (cuerpos a mano + las duales/lados que
+        // produce el resolver). Se destruyen en TearDown para no dejar SOs huérfanos.
+        private readonly List<Object> _sos = new List<Object>();
+
+        [TearDown]
+        public void Cleanup()
+        {
+            foreach (Object so in _sos)
+            {
+                if (so != null) Object.DestroyImmediate(so);
+            }
+            _sos.Clear();
+        }
+
+        private T Track<T>(T so) where T : Object
+        {
+            if (so != null) _sos.Add(so);
+            return so;
+        }
+
+        private void TrackResolved(CardDeckEntry entry)
+        {
+            if (entry?.DualCard != null)
+            {
+                Track(entry.DualCard);
+                Track(entry.DualCard.SideA);
+                Track(entry.DualCard.SideB);
+            }
+        }
+
+        private CardDefinition MakeStrike(string id, ElementType type, bool affinity)
+        {
+            var card = ScriptableObject.CreateInstance<CardDefinition>();
+            card.SetDebugData(
+                id, "Golpe", "Inflige 6 de daño.", 1, CardType.Attack, CardRarity.Common,
+                CardTarget.SingleEnemy, new List<string>(),
+                new List<EffectRef> { new EffectRef { effectType = EffectType.Damage, value = 6, target = EffectTarget.SingleEnemy } },
+                type, null, affinity);
+            return Track(card);
+        }
+
+        private RunState NewState(ElementType a, ElementType b)
+        {
+            var state = new RunState();
+            state.PlayerWorldAType = a;
+            state.PlayerWorldBType = b;
+            return state;
+        }
+
+        [Test] // Una recompensa AFÍN entra al mazo como dual tipada por los mundos del jugador
+        public void AddCardToDeck_AffineSingle_ResolvesToWorldTypedDual()
+        {
+            RunState state = NewState(ElementType.Amarillo, ElementType.Morado);
+            state.AddCardToDeck(CardDeckEntry.CreateSingle(MakeStrike("reward_aff", ElementType.None, affinity: true)));
+
+            Assert.AreEqual(1, state.Deck.Count);
+            CardDeckEntry e = state.Deck[0];
+            TrackResolved(e);
+            Assert.IsNotNull(e.DualCard, "Una recompensa afín entra al mazo como dual resuelta.");
+            Assert.IsNull(e.SingleCard);
+            Assert.AreEqual(ElementType.Amarillo, e.DualCard.SideA.ElementType, "Lado A = tipo del Mundo A del jugador.");
+            Assert.AreEqual(ElementType.Morado, e.DualCard.SideB.ElementType, "Lado B = tipo del Mundo B del jugador.");
+        }
+
+        [Test] // Una recompensa NEUTRA sigue siendo single None (no se convierte en dual)
+        public void AddCardToDeck_NeutralSingle_StaysSingleNone()
+        {
+            RunState state = NewState(ElementType.Amarillo, ElementType.Morado);
+            state.AddCardToDeck(CardDeckEntry.CreateSingle(MakeStrike("reward_neu", ElementType.None, affinity: false)));
+
+            Assert.AreEqual(1, state.Deck.Count);
+            CardDeckEntry e = state.Deck[0];
+            Assert.IsNotNull(e.SingleCard);
+            Assert.IsNull(e.DualCard);
+            Assert.AreEqual(ElementType.None, e.SingleCard.ElementType);
+        }
+
+        [Test] // Una dual YA tipada pasa sin cambios (clon) — no se re-resuelve
+        public void AddCardToDeck_TypedDual_PassesUnchanged()
+        {
+            CardDefinition sideA = MakeStrike("dual_a", ElementType.Rojo, affinity: false);
+            CardDefinition sideB = MakeStrike("dual_b", ElementType.Negro, affinity: false);
+            var dual = Track(ScriptableObject.CreateInstance<DualCardDefinition>());
+            dual.InitRuntimeSides("dual_test", "Golpe", sideA, sideB);
+
+            RunState state = NewState(ElementType.Amarillo, ElementType.Morado);
+            state.AddCardToDeck(CardDeckEntry.CreateDual(dual));
+
+            Assert.AreEqual(1, state.Deck.Count);
+            CardDeckEntry e = state.Deck[0];
+            TrackResolved(e);
+            Assert.IsNotNull(e.DualCard, "Una dual entra como dual.");
+            Assert.AreEqual(ElementType.Rojo, e.DualCard.SideA.ElementType, "Una dual ya tipada NO se re-resuelve a los mundos del jugador.");
+            Assert.AreEqual(ElementType.Negro, e.DualCard.SideB.ElementType);
+        }
+
+        [Test] // El clon es independiente del SO autorado (no aliasa la lista de config)
+        public void AddCardToDeck_ClonesEntry_NoAliasing()
+        {
+            RunState state = NewState(ElementType.Amarillo, ElementType.Morado);
+            CardDeckEntry authored = CardDeckEntry.CreateSingle(MakeStrike("alias_neu", ElementType.None, affinity: false));
+            state.AddCardToDeck(authored);
+
+            Assert.AreEqual(1, state.Deck.Count);
+            Assert.AreNotSame(authored, state.Deck[0], "La entry del mazo es un clon, no la referencia autorada.");
+        }
+    }
+}

--- a/Assets/Tests/EditMode/RunStateAffinityTests.cs.meta
+++ b/Assets/Tests/EditMode/RunStateAffinityTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 78ac9e05a09316446aee4caf118678e0

--- a/Docs/design/DESIGN_DECISIONS.md
+++ b/Docs/design/DESIGN_DECISIONS.md
@@ -43,7 +43,7 @@ En la revision de M4 (2026-06-10) se abrieron y cerraron **DD-022 y DD-023**.
 | DD-018 | Multiplicador de dano enemigo SuperEficaz contra el tipo activo del jugador | **Si**: el dano se multiplica x1.5 (igual que dano del jugador). El multiplicador es configurable (constante en codigo, ajustable sin cambiar logica). Esto reabre la regla anterior de "efectividad solo al dano jugador->enemigo": ahora aplica en ambas direcciones | GOLDEN_RULES §3 |
 | DD-019 | Sangrado y Virus: genericos o exclusivos del boss | **Exclusivos del Boss Acto 1** (Costura Maldita / UNIT-RB7). No son debuffs genericos del juego. Si en futuros bosses se necesita el mismo concepto, se reevalua entonces | GOLDEN_RULES §6 |
 | DD-020 | Carta especial dual inicial: filtrada o pool fijo | **Filtrada** por los 2 tipos elementales que el jugador elige al inicio del run | GOLDEN_RULES §5 |
-| DD-021 | Representacion del MCguffin de quests | **Diferida** al diseno de M4 (Eventos). No es bloqueante para diseno actual. Se decide cuando se ataque el sistema de eventos | — |
+| DD-021 | Representacion del MCguffin de quests | **Cerrada 2026-06-18** (sesion `modo:diseno`, spec `Docs/dev/specs/m4_4b_events_quests_spec.md`). El "objeto" del quest **ES un Retazo** (RelicDefinition) entregado al Aceptar el quest → reusa el sistema de Retazos completo (pasivo, inventario, hooks); no se crea infra de items dedicada. El "llevarlo a un punto del mapa" es tracking en RunState (`QuestState` con `DestinationNodeId`); completar el nodo destino otorga la recompensa final (oro, sin reward si no se llega). Variante por mundo: pasivo Mundo A = +oro por combate (`RelicEndGoldEffect`), Mundo B = +bloqueo por carta de escudo (`RelicCardPlayedBlockEffect`, nuevo, hook `OnCardPlayed`) | GOLDEN_RULES §7, §10 |
 
 ---
 
@@ -69,5 +69,5 @@ Tema: vinetas narrativas, dialogo de los hermanos, lore. **Postponed** hasta que
 
 ---
 
-> Ultima actualizacion: 2026-06-10 (DD-022 y DD-023 cerradas en revision de M4)
+> Ultima actualizacion: 2026-06-18 (DD-021 cerrada — MCguffin como Retazo + QuestState; variantes A/B)
 > Cuando una decision se cierra, su regla resultante se mueve a GOLDEN_RULES.md y se marca su entrada aqui con la referencia a la seccion correspondiente.

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -9,8 +9,21 @@
 >
 > **Fase actual:** M4 activo. Pre-M4 visor de mazo: ✅ CERRADO (2026-06-17). Bloque 4a: ✅ CERRADO (2026-06-17).
 > **Milestone activo:** M4 — Resto del Acto 1 (bloques: 4a integridad de cartas, 4b eventos+quests, 4c transdim+ancla)
-> **Próximo bloque:** M4 bloque 4b — Eventos + Quests (arranca con sesión `modo:diseno` para su spec)
-> **Última actualización:** 2026-06-17 (`modo:implementacion`: **Bloque 4a ✅ CERRADO** — integridad
+> **Próximo bloque:** M4 bloque 4b — Eventos + Quests. **Spec ✅ CERRADO (2026-06-18)** →
+> `Docs/dev/specs/m4_4b_events_quests_spec.md`, dividido en 2 sub-PRs (4b-1 motor + simples,
+> 4b-2 multidim + quest). Próximo paso: implementar 4b-1 con `modo:implementacion`.
+> **Última actualización:** 2026-06-18 (4a follow-up: **fix de afinidad en recompensas** —
+> `RunState.AddCardToDeck` ahora rutea por `AffinityResolver`: toda carta ganada/comprada/de-evento
+> durante la run adopta los tipos del jugador. Seam único que cubre recompensas + tienda + futuros
+> eventos de 4b. `RunCombatConfig.EditorPopulateRewardPool` (#if UNITY_EDITOR) + `StarterDeckSetup`
+> gana paso 4 `RecomposeRewardPool`: reescribe `rewardPool` de `RunCombatConfig_Act1` a 3 cartas
+> afines/neutras (Strike afín + Defend afín + Strike neutra). Nuevo `RunStateAffinityTests.cs` (4
+> casos: afín→dual, neutra→None, dual ya-tipada pasa sin cambios, sin aliasing de entry). **E2E visual
+> confirmado por Sebastián:** strike de recompensa adopta `[Amarillo]/[Morado]` (tipos del jugador),
+> no los Rojo/Negro fijos previos. Suite EditMode **193 → 197/197**. Cero archivos protegidos.
+> **Spec 4b ✅ CERRADO 2026-06-18** → `Docs/dev/specs/m4_4b_events_quests_spec.md`, DD-021
+> cerrada (MCguffin = Retazo + `QuestState`, variantes A/B), 2 sub-PRs definidos.)
+> **Previa:** 2026-06-17 (`modo:implementacion`: **Bloque 4a ✅ CERRADO** — integridad
 > del sistema de cartas. Afinidad (DD-022 opción A) + cobertura de mejoras (DD-023). Nuevos:
 > `Assets/Scripts/Gameplay/Cards/AffinityResolver.cs` (static puro: afín single → dual runtime tipada
 > por mundo; neutras/duales pasan sin tocar), `Assets/Editor/StarterDeckSetup.cs` (menú
@@ -173,12 +186,22 @@ sesión `modo:diseno` para su spec):**
       2 neutra) + 1 dual drafteada = 10. BattleFocus sale del starter (queda para recompensas).
 
 #### Bloque 4b — Eventos + Quests (narrativo, lo grande)
-- [ ] Eventos (DD-005): `EventDefinition` SO + `EventNodeController` (hoy el
-      nodo Event es stub: panel genérico "Contenido placeholder" en
-      `RunFlowController.ShowResolvePanel`), choice UI, sistema de decisiones
-- [ ] Eventos multidimensionales: elegir mundo al entrar al evento
-- [ ] Quests con MCguffin (DD-021 se cierra aquí): tracking en RunState, marca
-      de nodo destino en mapa, eventos de aceptar/robar
+
+**Spec cerrado 2026-06-18** (`modo:diseno`) → `Docs/dev/specs/m4_4b_events_quests_spec.md`.
+Las 4 decisiones abiertas se cerraron: 2 sub-PRs · MCguffin = Retazo + quest tracking
+(DD-021) · recompensa de quest = oro al llegar al destino (sin reward si no se llega) ·
+pasivo Mundo B = `RelicCardPlayedBlockEffect` nuevo sobre `OnCardPlayed`. **Cero archivos
+protegidos.**
+
+- [ ] **Sub-PR 4b-1 — Motor de eventos + eventos simples:** `EventDefinition`/`EventChoice`/
+      `EventConsequence`/`EventResolver`/`EventNodeController`/`EventPoolConfig` +
+      `EventConfigSetup` (menú) + `EventTests`. `RunFlowController` ramifica `NodeType.Event`
+      (hoy stub: "Contenido placeholder" en `ShowResolvePanel`); `MapNode.AssignedEvent` +
+      `RunMapGenerator.AssignEvents`. Consecuencias: dar/quitar carta, ±oro, ±HP, dar Retazo.
+- [ ] **Sub-PR 4b-2 — Multidimensionales + quest/MCguffin:** elección de mundo + variantes
+      A/B; `QuestState` en RunState (`StartQuest`/`CompleteQuestIfDestination`); nodo destino
+      resaltado en `RunMapView` (alcanzabilidad en DAG); `RelicCardPlayedBlockEffect`.
+      Depende de 4b-1 mergeado. (DD-021 ya transcripta en DESIGN_DECISIONS.md 2026-06-18.)
 - Dependencia interna: 4a cerrado (eventos que otorgan mejoras necesitan que
   toda carta sea mejorable) + visor pre-M4 (verificación en playtest)
 

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -15,7 +15,7 @@
 > `Assets/Scripts/Gameplay/Cards/AffinityResolver.cs` (static puro: afín single → dual runtime tipada
 > por mundo; neutras/duales pasan sin tocar), `Assets/Editor/StarterDeckSetup.cs` (menú
 > `Roguelike > Setup Starter Deck (4a)`: 4 cuerpos + 18 upgrades de caras + recomposición del starter),
-> `AffinityTests.cs` (8 casos) + `CardUpgradeCoverageTests.cs` (guard DD-023, 2 casos). `CardDefinition`
+> `AffinityTests.cs` (10 casos) + `CardUpgradeCoverageTests.cs` (guard DD-023, 2 casos). `CardDefinition`
 > gana flag `affinity` + getter + `CreateAffinityVariant` (preserva el payload de upgrade, a diferencia
 > de `CreateUpgradedClone`); propagación en `SetDebugData`/`CreateUpgradedClone`.
 > `RunSession.ConfigureCombat` resuelve afinidad detrás del guard `Deck.Count==0`;
@@ -23,10 +23,13 @@
 > (Strike/Defend × afín/neutra; upg Strike 6→9 / Defend 5→10), 18 caras con upgrade,
 > `RunCombatConfig_Act1.starterDeck` = 3 Strike_Affine + 2 Strike_Neutral + 2 Defend_Affine +
 > 2 Defend_Neutral (9 entradas; la 10ª es la dual drafteada). **CERO cambios en archivos protegidos**
-> (la afinidad se monta sobre el mecanismo dual existente). Suite EditMode **181 → 191/191**,
+> (la afinidad se monta sobre el mecanismo dual existente). Suite EditMode **181 → 193/193**,
 > compilación limpia. E2E data-layer validado en Unity-MCP (config real → 9 entradas: 5 afines tipadas
 > A/B + 4 neutras None → mazo de 10, todas mejorables). E2E visual en escena pendiente de confirmación
-> manual por Sebastián.)
+> manual por Sebastián. **Pasada de `modo:revision` (sin críticos ni mayores):** se aplicaron los
+> fixes — helper editor compartido `EditorCardAuthoring` (elimina la duplicación del clonado de efectos
+> entre StarterDeckSetup/CardUpgradeSetup), cuerpos del starter a texto en español (matchean las caras),
+> trackeo de SOs runtime en tests, y 2 tests extra (conmutación de tipo A↔B en combate + afín mejorada).)
 > **Previa:** 2026-06-17 (`modo:diseno`: **Spec M4 bloque 4a ✅ CERRADO** →
 > `Docs/dev/specs/m4_4a_card_integrity_spec.md`. TurnManager confirmado SIN cambios para afinidad.
 > PR #123 visor de mazo MERGED a main (46347fb), E2E visual confirmado por Sebastián.)

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -7,10 +7,30 @@
 > En `modo:implementacion` se lee al inicio para saber qué milestone está activo
 > y qué sub-tareas quedan.
 >
-> **Fase actual:** M4 activo. Pre-M4 visor de mazo: ✅ CERRADO (2026-06-16).
+> **Fase actual:** M4 activo. Pre-M4 visor de mazo: ✅ CERRADO (2026-06-17). Bloque 4a: ✅ CERRADO (2026-06-17).
 > **Milestone activo:** M4 — Resto del Acto 1 (bloques: 4a integridad de cartas, 4b eventos+quests, 4c transdim+ancla)
-> **Próximo bloque:** M4 bloque 4a — Integridad del sistema de cartas (spec pendiente)
-> **Última actualización:** 2026-06-16 (`modo:implementacion`: **Visor de mazo ✅ CERRADO + fixes
+> **Próximo bloque:** M4 bloque 4b — Eventos + Quests (arranca con sesión `modo:diseno` para su spec)
+> **Última actualización:** 2026-06-17 (`modo:implementacion`: **Bloque 4a ✅ CERRADO** — integridad
+> del sistema de cartas. Afinidad (DD-022 opción A) + cobertura de mejoras (DD-023). Nuevos:
+> `Assets/Scripts/Gameplay/Cards/AffinityResolver.cs` (static puro: afín single → dual runtime tipada
+> por mundo; neutras/duales pasan sin tocar), `Assets/Editor/StarterDeckSetup.cs` (menú
+> `Roguelike > Setup Starter Deck (4a)`: 4 cuerpos + 18 upgrades de caras + recomposición del starter),
+> `AffinityTests.cs` (8 casos) + `CardUpgradeCoverageTests.cs` (guard DD-023, 2 casos). `CardDefinition`
+> gana flag `affinity` + getter + `CreateAffinityVariant` (preserva el payload de upgrade, a diferencia
+> de `CreateUpgradedClone`); propagación en `SetDebugData`/`CreateUpgradedClone`.
+> `RunSession.ConfigureCombat` resuelve afinidad detrás del guard `Deck.Count==0`;
+> `RunCombatConfig.EditorPopulateStarterDeck` (#if UNITY_EDITOR). SOs autorados vía menú: 4 cuerpos
+> (Strike/Defend × afín/neutra; upg Strike 6→9 / Defend 5→10), 18 caras con upgrade,
+> `RunCombatConfig_Act1.starterDeck` = 3 Strike_Affine + 2 Strike_Neutral + 2 Defend_Affine +
+> 2 Defend_Neutral (9 entradas; la 10ª es la dual drafteada). **CERO cambios en archivos protegidos**
+> (la afinidad se monta sobre el mecanismo dual existente). Suite EditMode **181 → 191/191**,
+> compilación limpia. E2E data-layer validado en Unity-MCP (config real → 9 entradas: 5 afines tipadas
+> A/B + 4 neutras None → mazo de 10, todas mejorables). E2E visual en escena pendiente de confirmación
+> manual por Sebastián.)
+> **Previa:** 2026-06-17 (`modo:diseno`: **Spec M4 bloque 4a ✅ CERRADO** →
+> `Docs/dev/specs/m4_4a_card_integrity_spec.md`. TurnManager confirmado SIN cambios para afinidad.
+> PR #123 visor de mazo MERGED a main (46347fb), E2E visual confirmado por Sebastián.)
+> **Previa:** 2026-06-16 (`modo:implementacion`: **Visor de mazo ✅ CERRADO + fixes
 > de revisión aplicados**. `DeckViewerView.cs` (sub-Canvas overlay, badge `Mazo (N)` en esquina sup.
 > izquierda, modal scrolleable, tooltip FadeIn/Out, helpers static puros). Post-revisión: nuevo
 > `CardDisplay.cs` (hogar canónico `public static` de helpers de label — corrige la 3ª copia
@@ -92,8 +112,8 @@
 
 ### Pulido pre-M4 — Visor de mazo ("librito" estilo Slay the Spire)
 
-**Estado:** ✅ **IMPLEMENTADO 2026-06-16** — branch `feat/deck-viewer`, PR pendiente.
-Spec: `Docs/dev/specs/visor_de_mazo_spec.md`.
+**Estado:** ✅ **MERGED 2026-06-17** — PR #123 squasheado a `main` (46347fb).
+E2E visual confirmado por Sebastián. Spec: `Docs/dev/specs/visor_de_mazo_spec.md`.
 
 - [x] `DeckViewerView.cs` — sub-Canvas overlay, badge `Mazo (N)`, modal scrolleable,
       tooltip FadeIn/Out. Helpers static puros: `SortForDisplay`/`BuildRowLabel`/
@@ -105,7 +125,7 @@ Spec: `Docs/dev/specs/visor_de_mazo_spec.md`.
 - [x] Montado en `RunFlowController` (RunScene: build + Refresh + Cleanup en 3 transiciones).
 - [x] Montado en `CombatUIController` (BattleScene: build + Refresh null-safe).
 - [x] Suite EditMode 166 → **181/181**. Compilación limpia.
-- [ ] E2E visual en RunScene + BattleScene — pendiente de validación manual por Sebastián.
+- [x] E2E visual en RunScene + BattleScene — confirmado por Sebastián, PR #123 merged 2026-06-17.
 
 **Objetivo:** UI consultable que lista el mazo completo del run. Visible siempre
 (mapa, Tienda/Hoguera sobre paneles opacos, combate). Solo lectura.
@@ -130,23 +150,24 @@ maquinaria transdimensional que M5 necesita para el boss.
 **Bloques ordenados (sub-PRs chicos como en M3; cada bloque arranca con
 sesión `modo:diseno` para su spec):**
 
-#### Bloque 4a — Integridad del sistema de cartas
-- [ ] **Cobertura de mejoras (DD-013, re-scopeada):** el MECANISMO ya existe
+#### Bloque 4a — Integridad del sistema de cartas ✅ CERRADO (2026-06-17)
+- [x] **Cobertura de mejoras (DD-013, re-scopeada / DD-023):** el MECANISMO ya existía
       desde 3C (`CardUpgradeDef`, `CanUpgrade`/`ApplyUpgrade`, UI Hoguera,
-      dual mejora ambos lados). Lo que falta son DATOS: poblar `CardUpgradeDef`
-      en las 18 caras de `NewRunFaces/` (la dual drafteada se vuelve mejorable
-      gratis: `ComposeDualCard` usa las caras como lados y `CanUpgrade` exige
-      upgrade en ambos). **Decisión cerrada 2026-06-10 (DD-023):** mejora
-      autorada a mano por carta (NO fallback genérico) + **test guard EditMode**
-      que recorre todos los `CardDefinition` SOs y falla si alguno queda sin
-      `HasUpgrade` → la Hoguera no vuelve a "verse rota" en silencio.
-- [ ] **Afinidad de cartas (DD-022, cerrada 2026-06-10 → opción A):** flag de
-      afinidad en `CardDefinition`; las cartas con afinidad NO tienen tipo fijo —
-      adoptan en runtime el tipo elegido para el mundo activo (Mundo A = tipo 1,
-      Mundo B = tipo 2). Recomposición del mazo inicial según GDD §5: 5 Strike
-      (3 afines + 2 neutras) + 4 Defend (2 afines + 2 neutras) + 1 dual
-      drafteada. La resolución debería vivir en `CardDeckEntry`/`CardDefinition`
-      (capa de datos); **confirmar en el spec si TurnManager necesita cambios**.
+      dual mejora ambos lados). Se poblaron los DATOS: `CardUpgradeDef` en las 18
+      caras de `NewRunFaces/` (vía menú `Setup Starter Deck (4a)`) → la dual
+      drafteada se volvió mejorable (sus 2 caras ahora tienen upgrade). **Guard
+      EditMode** `CardUpgradeCoverageTests.cs`: recorre todos los `CardDefinition`
+      SOs y falla si alguno queda sin `HasUpgrade` (mensaje accionable que los lista)
+      → la Hoguera no vuelve a "verse rota" en silencio.
+- [x] **Afinidad de cartas (DD-022 → opción A):** flag `affinity` + getter en
+      `CardDefinition`; las cartas afines NO tienen tipo fijo — adoptan en runtime
+      el tipo del mundo activo (A = tipo 1, B = tipo 2). Mecanismo: `AffinityResolver`
+      (static puro) resuelve cada afín a una **dual runtime** tipada por mundo
+      (reusa `InitRuntimeSides`/`GetSide`; `CreateAffinityVariant` preserva el payload
+      de upgrade) → **TurnManager NO cambió** (ya lee `GetActiveCard(CurrentWorld).ElementType`).
+      Resolución en `RunSession.ConfigureCombat` detrás del guard `Deck.Count==0`. Mazo
+      inicial recompuesto a GDD §5: 5 Strike (3 afín + 2 neutra) + 4 Defend (2 afín +
+      2 neutra) + 1 dual drafteada = 10. BattleFocus sale del starter (queda para recompensas).
 
 #### Bloque 4b — Eventos + Quests (narrativo, lo grande)
 - [ ] Eventos (DD-005): `EventDefinition` SO + `EventNodeController` (hoy el
@@ -170,7 +191,8 @@ sesión `modo:diseno` para su spec):**
   contenido de enemigos comunes transdim/ancla llega en M6a/M6b.
 
 **Toca archivos protegidos:** sí, SOLO el bloque 4c (TurnManager —
-[REQUIERE APROBACIÓN] al llegar). 4a probablemente no (confirmar en spec);
+[REQUIERE APROBACIÓN] al llegar). 4a **NO** (confirmado en implementación
+2026-06-17: cero cambios; la afinidad se monta sobre el mecanismo dual);
 4b no (rewards vía RunState).
 
 **Dependencias:** M3 cerrado ✅ 2026-06-05. Orden interno duro:

--- a/Docs/dev/_tech_snapshot.md
+++ b/Docs/dev/_tech_snapshot.md
@@ -30,13 +30,19 @@
 > `RunCombatConfig_Act1.starterDeck` a la composición GDD §5 (3 Strike_Affine + 2 Strike_Neutral +
 > 2 Defend_Affine + 2 Defend_Neutral = 9; la 10ª es la dual drafteada inyectada por
 > `PendingStarterCard`). BattleFocus sale del starter (queda en `rewardPool`). Nuevos tests
-> `Assets/Tests/EditMode/AffinityTests.cs` (8 casos: resolución afín→dual, preservación de cuerpo/
+> `Assets/Tests/EditMode/AffinityTests.cs` (10 casos: resolución afín→dual, preservación de cuerpo/
 > upgrade, neutra sin tocar, integración `CardDeckEntry` + `TurnManager` real, composición de mazo,
-> round-trip del flag) + `CardUpgradeCoverageTests.cs` (guard DD-023 editor-only `#if UNITY_EDITOR`:
+> round-trip del flag, **misma carta afín conmuta tipo por mundo en combate (A vs B)**, **afín mejorada
+> juega su daño mejorado**) + `CardUpgradeCoverageTests.cs` (guard DD-023 editor-only `#if UNITY_EDITOR`:
 > todo `CardDefinition` tiene upgrade + dual compuesta de caras es mejorable). Suite EditMode
-> **181 → 191/191**, compilación limpia. **Validado en Unity-MCP:** menú corrido (4 cuerpos + 18 caras
+> **181 → 193/193**, compilación limpia. **Validado en Unity-MCP:** menú corrido (4 cuerpos + 18 caras
 > + starter 9 entradas), E2E data-layer (config real → 9 entradas: 5 afines tipadas A/B + 4 neutras
 > None → mazo de 10, todas mejorables). E2E visual en escena pendiente de confirmación manual.
+> **Fixes de revisión (modo:revision):** helper editor compartido `Assets/Editor/EditorCardAuthoring.cs`
+> (consolida el clonado de efectos que duplicaban StarterDeckSetup y CardUpgradeSetup → sin drift);
+> los 4 cuerpos del starter pasan a texto en español ("Golpe"/"Guardia") para matchear las caras del
+> draft en la misma mano; trackeo de SOs runtime en los tests (sin huérfanos). El campo `affinity` se
+> serializa ahora en todos los `CardDefinition` (default `0`).
 >
 > **Última actualización previa:** 2026-06-16 — **Visor de mazo + fixes de revisión**
 > (branch `feat/deck-viewer`). Nuevo `Assets/Scripts/Gameplay/Cards/UI/DeckViewerView.cs`:
@@ -300,7 +306,7 @@
 
 ### Tests
 - **Unity Test Framework** (NUnit) en EditMode
-- 25 archivos de test en `Assets/Tests/EditMode/` (suite 191/191)
+- 25 archivos de test en `Assets/Tests/EditMode/` (suite 193/193)
 - Helper compartido: `CombatTestBase.cs`
 
 ---
@@ -523,10 +529,12 @@ StarterDeckSetup.cs                   ← 4a: MenuItem "Roguelike/Setup Starter 
                                         18 caras + recomposición de RunCombatConfig_Act1.starterDeck
 CardUpgradeSetup.cs                   ← MenuItem "Roguelike/Setup Placeholder Card Upgrades"
                                         (3C): upgrades de los 6 SOs básicos del starter
+EditorCardAuthoring.cs                ← 4a: helper compartido (CloneEffectsBoostingFirst /
+                                        FirstEffectValue) que consumen StarterDeckSetup y CardUpgradeSetup
 NewRunConfigSetup.cs / ShopConfigSetup.cs  ← menús de config (3E / 3D)
 ```
 
-### Tests (`Assets/Tests/EditMode/`) — 25 archivos (suite EditMode 191/191)
+### Tests (`Assets/Tests/EditMode/`) — 25 archivos (suite EditMode 193/193)
 
 ```
 CombatTestBase.cs                ← helper compartido
@@ -574,10 +582,11 @@ DeckViewerTests.cs               ← Visor de mazo (15 casos: orden tipo→coste
                                    dual SideA null, label simple/dual/None, preview
                                    single/dual/sin-upgrade/ya-mejorada, + BuildTooltip
                                    dual/lado-null/ya-mejorada)
-AffinityTests.cs                 ← M4 4a (8 casos: resolución afín→dual tipada por mundo,
+AffinityTests.cs                 ← M4 4a (10 casos: resolución afín→dual tipada por mundo,
                                    preservación de cuerpo/upgrade, neutra sin tocar, integración
                                    CardDeckEntry, composición de mazo 5/4, TurnManager real
-                                   —afín SuperEficaz vs neutra 90%—, round-trip del flag affinity)
+                                   —afín SuperEficaz vs neutra 90%—, round-trip del flag affinity,
+                                   misma carta afín conmuta tipo A↔B en combate, afín mejorada en combate)
 CardUpgradeCoverageTests.cs      ← M4 4a guard DD-023, editor-only #if UNITY_EDITOR (2 casos:
                                    todo CardDefinition tiene upgrade; dual compuesta de 2 caras
                                    es mejorable)

--- a/Docs/dev/_tech_snapshot.md
+++ b/Docs/dev/_tech_snapshot.md
@@ -7,7 +7,18 @@
 > En `modo:implementacion` se lee OBLIGATORIAMENTE antes de cualquier cambio que
 > afecte arquitectura o componentes críticos.
 >
-> **Última actualización:** 2026-06-17 — **M4 bloque 4a: integridad del sistema de cartas**
+> **Última actualización:** 2026-06-18 — **M4 4a follow-up: fix de afinidad en recompensas** —
+> `RunState.AddCardToDeck` ahora rutea por `AffinityResolver` → toda carta ganada/comprada/de-evento
+> adopta los tipos del jugador (afín→dual runtime; neutra/dual pasan sin cambios). Seam único:
+> cubre recompensas + tienda + eventos de 4b. `RunCombatConfig.EditorPopulateRewardPool`
+> (#if UNITY_EDITOR). `StarterDeckSetup.RecomposeRewardPool` (paso 4 del menú): reescribe
+> `rewardPool` de `RunCombatConfig_Act1` a 3 cartas afines/neutras (Strike afín, Defend afín,
+> Strike neutra). Nuevo `Assets/Tests/EditMode/RunStateAffinityTests.cs` (4 casos: afín→dual,
+> neutra→None, dual ya-tipada pasa sin cambios, sin aliasing). **E2E visual confirmado por
+> Sebastián:** strike de recompensa adopta `[Amarillo]/[Morado]` (tipos del jugador). Suite
+> EditMode **193 → 197/197** (26 archivos de test). Cero archivos protegidos.
+>
+> **Última actualización previa:** 2026-06-17 — **M4 bloque 4a: integridad del sistema de cartas**
 > (branch `feat/m4-4a-card-integrity`). Afinidad de tipo (DD-022 opción A) + cobertura de
 > mejoras (DD-023), **sin tocar archivos protegidos** (la afinidad se monta sobre el mecanismo
 > dual existente). `CardDefinition` gana `[SerializeField] bool affinity` + getter `Affinity` y
@@ -306,7 +317,7 @@
 
 ### Tests
 - **Unity Test Framework** (NUnit) en EditMode
-- 25 archivos de test en `Assets/Tests/EditMode/` (suite 193/193)
+- 26 archivos de test en `Assets/Tests/EditMode/` (suite 197/197)
 - Helper compartido: `CombatTestBase.cs`
 
 ---
@@ -527,6 +538,7 @@ RelicSoGenerator.cs                   ← MenuItem "Roguelike/Generate Relic Ass
 StarterDeckSetup.cs                   ← 4a: MenuItem "Roguelike/Setup Starter Deck (4a)"
                                         (idempotente): 4 cuerpos del starter + upgrade en las
                                         18 caras + recomposición de RunCombatConfig_Act1.starterDeck
+                                        + reescritura del rewardPool a afines (4a follow-up, paso 4)
 CardUpgradeSetup.cs                   ← MenuItem "Roguelike/Setup Placeholder Card Upgrades"
                                         (3C): upgrades de los 6 SOs básicos del starter
 EditorCardAuthoring.cs                ← 4a: helper compartido (CloneEffectsBoostingFirst /
@@ -590,6 +602,9 @@ AffinityTests.cs                 ← M4 4a (10 casos: resolución afín→dual t
 CardUpgradeCoverageTests.cs      ← M4 4a guard DD-023, editor-only #if UNITY_EDITOR (2 casos:
                                    todo CardDefinition tiene upgrade; dual compuesta de 2 caras
                                    es mejorable)
+RunStateAffinityTests.cs         ← M4 4a follow-up: afinidad en AddCardToDeck (4 casos: afín→dual
+                                   tipada por mundo, neutra→None, dual ya-tipada pasa sin cambios,
+                                   sin aliasing de entry)
 ```
 
 ### ScriptableObjects (`Assets/ScriptableObjects/`)

--- a/Docs/dev/_tech_snapshot.md
+++ b/Docs/dev/_tech_snapshot.md
@@ -7,7 +7,38 @@
 > En `modo:implementacion` se lee OBLIGATORIAMENTE antes de cualquier cambio que
 > afecte arquitectura o componentes críticos.
 >
-> **Última actualización:** 2026-06-16 — **Visor de mazo + fixes de revisión**
+> **Última actualización:** 2026-06-17 — **M4 bloque 4a: integridad del sistema de cartas**
+> (branch `feat/m4-4a-card-integrity`). Afinidad de tipo (DD-022 opción A) + cobertura de
+> mejoras (DD-023), **sin tocar archivos protegidos** (la afinidad se monta sobre el mecanismo
+> dual existente). `CardDefinition` gana `[SerializeField] bool affinity` + getter `Affinity` y
+> el método `CreateAffinityVariant(ElementType)`: clona el cuerpo tipado para un mundo (effects/
+> cost/name/type/target/art idénticos, `elementType=worldType`, `affinity=false`) y **preserva el
+> payload de upgrade** compartiendo la referencia `_upgrade` (a diferencia de `CreateUpgradedClone`,
+> que no lo copia) → la dual afín resuelta sigue mejorable en la Hoguera. `affinity` se propaga en
+> `SetDebugData` (nuevo param `newAffinity=false` al final) y en `CreateUpgradedClone`. Nuevo
+> `Assets/Scripts/Gameplay/Cards/AffinityResolver.cs` (static puro, espejo de `StarterDraft`):
+> `Resolve(entry, typeA, typeB)` convierte una single afín en una `DualCardDefinition` runtime
+> (lado A=typeA, lado B=typeB vía `InitRuntimeSides`/`CreateAffinityVariant`); neutras (None) y
+> ya-duales pasan con `Clone()`. `ResolveDeck(...)` mapea sobre la lista. `RunSession.ConfigureCombat`
+> resuelve afinidad **detrás del guard `State.Deck.Count == 0`** (evita re-crear/descartar SOs runtime
+> cada combate) y pasa el mazo resuelto a `InitializeDeck`; `RunState`/`InitializeDeck` no cambian de
+> contrato. `RunCombatConfig.EditorPopulateStarterDeck(List<CardDeckEntry>)` (#if UNITY_EDITOR, patrón
+> `NewRunConfig.EditorPopulateFaces`). Nuevo `Assets/Editor/StarterDeckSetup.cs` — menú
+> `Roguelike > Setup Starter Deck (4a)` idempotente: crea/asegura 4 cuerpos
+> (`Strike_Affine`/`Strike_Neutral`/`Defend_Affine`/`Defend_Neutral`, upg Strike 6→9 / Defend 5→10,
+> elementType None), autora upgrade en las 18 caras de `NewRunFaces/`, y reescribe
+> `RunCombatConfig_Act1.starterDeck` a la composición GDD §5 (3 Strike_Affine + 2 Strike_Neutral +
+> 2 Defend_Affine + 2 Defend_Neutral = 9; la 10ª es la dual drafteada inyectada por
+> `PendingStarterCard`). BattleFocus sale del starter (queda en `rewardPool`). Nuevos tests
+> `Assets/Tests/EditMode/AffinityTests.cs` (8 casos: resolución afín→dual, preservación de cuerpo/
+> upgrade, neutra sin tocar, integración `CardDeckEntry` + `TurnManager` real, composición de mazo,
+> round-trip del flag) + `CardUpgradeCoverageTests.cs` (guard DD-023 editor-only `#if UNITY_EDITOR`:
+> todo `CardDefinition` tiene upgrade + dual compuesta de caras es mejorable). Suite EditMode
+> **181 → 191/191**, compilación limpia. **Validado en Unity-MCP:** menú corrido (4 cuerpos + 18 caras
+> + starter 9 entradas), E2E data-layer (config real → 9 entradas: 5 afines tipadas A/B + 4 neutras
+> None → mazo de 10, todas mejorables). E2E visual en escena pendiente de confirmación manual.
+>
+> **Última actualización previa:** 2026-06-16 — **Visor de mazo + fixes de revisión**
 > (branch `feat/deck-viewer`). Nuevo `Assets/Scripts/Gameplay/Cards/UI/DeckViewerView.cs`:
 > clase de presentación pura (no MonoBehaviour), sub-Canvas overlay propio
 > (`overrideSorting=true`, `sortingOrder=100`), badge `Mazo (N)` (esquina superior
@@ -269,7 +300,7 @@
 
 ### Tests
 - **Unity Test Framework** (NUnit) en EditMode
-- 23 archivos de test en `Assets/Tests/EditMode/` (suite 181/181)
+- 25 archivos de test en `Assets/Tests/EditMode/` (suite 191/191)
 - Helper compartido: `CombatTestBase.cs`
 
 ---
@@ -363,7 +394,7 @@ Exclusivamente vía `RunSession.State` (= `RunState`). Flags principales:
 
 ## Estructura de archivos
 
-### Scripts (`Assets/Scripts/`) — 108 archivos C#
+### Scripts (`Assets/Scripts/`) — 109 archivos C#
 
 ```
 Core/
@@ -405,9 +436,11 @@ Run/
 
 Gameplay/
   Cards/
-    CardDefinition.cs            ← SO base de carta
+    CardDefinition.cs            ← SO base de carta (+ flag `affinity` + CreateAffinityVariant, 4a)
     DualCardDefinition.cs        ← SO con sideA/sideB
     CardDeckEntry.cs             ← entrada de mazo (puede ser simple o dual)
+    AffinityResolver.cs          ← 4a: static puro — afín single → dual runtime tipada por mundo
+                                   (Resolve/ResolveDeck); neutras/duales pasan con Clone()
     CardEnums.cs                 ← CardType, EffectType, EffectTarget
     EffectRef.cs                 ← referencia a efecto en SO
     CardDisplay.cs               ← hogar canónico de helpers de label de carta en
@@ -485,9 +518,15 @@ RoguelikeCardBattler.Editor.asmdef   ← editor-only, references runtime asmdef
 RelicSoGenerator.cs                   ← MenuItem "Roguelike/Generate Relic Assets":
                                         crea los 23 .asset en Assets/ScriptableObjects/Relics/
                                         (idempotente — saltea archivos existentes)
+StarterDeckSetup.cs                   ← 4a: MenuItem "Roguelike/Setup Starter Deck (4a)"
+                                        (idempotente): 4 cuerpos del starter + upgrade en las
+                                        18 caras + recomposición de RunCombatConfig_Act1.starterDeck
+CardUpgradeSetup.cs                   ← MenuItem "Roguelike/Setup Placeholder Card Upgrades"
+                                        (3C): upgrades de los 6 SOs básicos del starter
+NewRunConfigSetup.cs / ShopConfigSetup.cs  ← menús de config (3E / 3D)
 ```
 
-### Tests (`Assets/Tests/EditMode/`) — 23 archivos (suite EditMode 181/181)
+### Tests (`Assets/Tests/EditMode/`) — 25 archivos (suite EditMode 191/191)
 
 ```
 CombatTestBase.cs                ← helper compartido
@@ -535,14 +574,23 @@ DeckViewerTests.cs               ← Visor de mazo (15 casos: orden tipo→coste
                                    dual SideA null, label simple/dual/None, preview
                                    single/dual/sin-upgrade/ya-mejorada, + BuildTooltip
                                    dual/lado-null/ya-mejorada)
+AffinityTests.cs                 ← M4 4a (8 casos: resolución afín→dual tipada por mundo,
+                                   preservación de cuerpo/upgrade, neutra sin tocar, integración
+                                   CardDeckEntry, composición de mazo 5/4, TurnManager real
+                                   —afín SuperEficaz vs neutra 90%—, round-trip del flag affinity)
+CardUpgradeCoverageTests.cs      ← M4 4a guard DD-023, editor-only #if UNITY_EDITOR (2 casos:
+                                   todo CardDefinition tiene upgrade; dual compuesta de 2 caras
+                                   es mejorable)
 ```
 
 ### ScriptableObjects (`Assets/ScriptableObjects/`)
 
 ```
 Cards/
-  StrikeBasic.asset, DefendBasic.asset, BattleFocus.asset
-  [+ duales]
+  StrikeBasic.asset, DefendBasic.asset, BattleFocus.asset (+ lados SideB)
+  Strike_Affine/Strike_Neutral/Defend_Affine/Defend_Neutral.asset  ← 4a: cuerpos del starter
+  Dual/ [StrikeDual, DefendDual, BattleFocusDual]  ← rewardPool
+  NewRunFaces/ [18 caras tipadas, con upgrade autorado en 4a]
 Enemies/
   WeakSlime.asset, Goblin.asset, SkeletonWarrior.asset, DarkMage.asset
   BossAct1.asset

--- a/Docs/dev/specs/m4_4a_card_integrity_spec.md
+++ b/Docs/dev/specs/m4_4a_card_integrity_spec.md
@@ -1,8 +1,12 @@
 # Spec — M4 Bloque 4a: Integridad del sistema de cartas
 
-> **ESTADO: IMPLEMENTADO** — branch `feat/m4-4a-card-integrity` (2026-06-17), PR a
-> `main`. Suite EditMode 191/191; CERO cambios en archivos protegidos (la afinidad se
-> monta sobre el mecanismo dual). `/cierre-sesion` puede fijar el número de PR exacto.
+> **ESTADO: IMPLEMENTADO — PR #124 (2026-06-17)** — branch `feat/m4-4a-card-integrity`,
+> pendiente de merge a `main`. Suite EditMode **193/193**; CERO cambios en archivos
+> protegidos (la afinidad se monta sobre el mecanismo dual). Pasada de `modo:revision`
+> aplicada (sin críticos ni mayores): helper compartido `EditorCardAuthoring`, texto
+> español en cuerpos del starter, trackeo de SOs en tests, 2 tests extra (A↔B en combate
+> + afín mejorada). Pendiente de Sebastián: E2E visual en escena + tabla efectividad
+> GOLDEN_RULES §3 (reconciliar vs código).
 
 ## Origen
 - Roadmap `_roadmap.md` §M4 Bloque 4a (reordenado 2026-06-10, `modo:gdd`).

--- a/Docs/dev/specs/m4_4a_card_integrity_spec.md
+++ b/Docs/dev/specs/m4_4a_card_integrity_spec.md
@@ -1,0 +1,421 @@
+# Spec — M4 Bloque 4a: Integridad del sistema de cartas
+
+> **ESTADO: IMPLEMENTADO** — branch `feat/m4-4a-card-integrity` (2026-06-17), PR a
+> `main`. Suite EditMode 191/191; CERO cambios en archivos protegidos (la afinidad se
+> monta sobre el mecanismo dual). `/cierre-sesion` puede fijar el número de PR exacto.
+
+## Origen
+- Roadmap `_roadmap.md` §M4 Bloque 4a (reordenado 2026-06-10, `modo:gdd`).
+- `DESIGN_DECISIONS.md` **DD-022** (afinidad de cartas → opción A) y **DD-023**
+  (mejora autorada por carta + test guard), ambas cerradas 2026-06-10.
+- `GOLDEN_RULES.md` §5 (Mazo inicial ⏳, Mejora de cartas ⏳) y §3 (tipo activo,
+  cartas neutras 90%).
+
+## Objetivo
+Cerrar la "integridad" del sistema de cartas del Acto 1 pegado al GDD §5: (1) que
+**toda** carta del juego sea mejorable (datos de upgrade autorados en cada SO,
+con un test que lo garantice) y (2) implementar la **afinidad de tipo**: las
+cartas afines del mazo inicial adoptan en runtime el tipo del mundo activo, y el
+mazo inicial se recompone a la fórmula exacta del GDD (5 Strike: 3 afines + 2
+neutras; 4 Defend: 2 afines + 2 neutras; 1 dual drafteada = 10 cartas).
+
+## Comportamiento esperado
+
+### Sub-tarea 1 — Cobertura de mejoras (DD-013 re-scopeada / DD-023)
+- Sin cambios visibles de gameplay nuevos: el mecanismo de mejora ya existe
+  (Hoguera, Sub-PR 3C). El cambio es de **datos**: cada `CardDefinition` del
+  proyecto define su mejora en su ficha.
+- Concretamente: las **18 caras de `NewRunFaces/`** (hoy con `_upgrade` vacío)
+  pasan a tener mejora autorada. Consecuencia: la **carta dual drafteada** (que
+  se compone de 2 caras) se vuelve mejorable en la Hoguera (sus dos lados tienen
+  upgrade → `CardDeckEntry.CanUpgrade()` devuelve `true`).
+- Garantía permanente: un **test guard EditMode** recorre todos los
+  `CardDefinition` SOs del proyecto y falla si alguno queda sin
+  `Upgrade.HasUpgrade`. La Hoguera no vuelve a "verse rota" en silencio.
+
+### Sub-tarea 2 — Afinidad de cartas (DD-022 opción A)
+Desde la perspectiva del jugador:
+- Las cartas **afines** (3 de las 5 Strike, 2 de las 4 Defend del mazo inicial)
+  NO tienen tipo fijo: en el Mundo A muestran y usan el tipo elegido para A, en
+  el Mundo B el tipo elegido para B. Al cambiar de mundo en combate, su tipo
+  (y su tinte en HUD/visor) **conmuta en vivo**, igual que ya hacen las cartas
+  duales.
+- Las cartas **neutras** (2 Strike, 2 Defend) son tipo `None`: 90 % del daño base
+  fijo, sin generar ni quitar cargas de Estilo (DD-002, ya implementado).
+- El mazo inicial pasa de su composición placeholder actual
+  (`[CÓDIGO ACTUAL]` 4 StrikeDual + 2 DefendDual + 1 BattleFocusDual = 7) a la
+  del GDD: **5 Strike (3 afín + 2 neutra) + 4 Defend (2 afín + 2 neutra) + 1 dual
+  drafteada = 10**. BattleFocus sale del starter (queda como SO disponible para
+  recompensas/Tienda; no se borra).
+
+## Sistemas afectados
+- **Combate:** **ninguno** (confirmado abajo — ver "Confirmación: TurnManager NO
+  cambia"). La afinidad se monta sobre el mecanismo dual existente.
+- **Datos (capa de cartas):** `CardDefinition` gana un flag `affinity` y un método
+  de clonado por-tipo. Nuevo helper puro de resolución del mazo.
+- **Run:** `RunSession.ConfigureCombat` resuelve afinidad antes de poblar el mazo.
+  `RunState` no cambia (sigue clonando lo que recibe).
+- **ScriptableObjects:** 4 SOs de cuerpo del starter (Strike/Defend × afín/neutra)
+  + recomposición del `starterDeck` de `RunCombatConfig_Act1`; upgrades poblados
+  en las 18 caras.
+- **UI:** ninguna línea nueva — el visor de mazo y `CardHandView` renderizan las
+  cartas afines como duales automáticamente (consecuencia gratis, ver validación).
+- **Editor:** menú de setup (autorado idempotente de SOs + starter deck + upgrades).
+
+## Archivos a crear
+- `Assets/Scripts/Gameplay/Cards/AffinityResolver.cs` — helper **static puro**
+  (espejo de `StarterDraft`): convierte una entrada de mazo afín en una dual
+  runtime tipada por mundo; deja pasar neutras/duales sin tocar. Testeable sin UI.
+- `Assets/Editor/StarterDeckSetup.cs` — menú `Roguelike > Setup Starter Deck (4a)`:
+  crea/asegura los 4 SOs de cuerpo, autora sus upgrades + las 18 caras, y reescribe
+  `RunCombatConfig_Act1.starterDeck` a la composición GDD. Idempotente.
+- `Assets/Tests/EditMode/AffinityTests.cs` — casos de afinidad (resolución,
+  preservación de cuerpo/upgrade, integración con `CardDeckEntry` y con un
+  `TurnManager` real).
+- `Assets/Tests/EditMode/CardUpgradeCoverageTests.cs` — el **test guard** DD-023.
+
+## Archivos a modificar
+- `Assets/Scripts/Gameplay/Cards/CardDefinition.cs` — añade el flag de afinidad,
+  su propagación en `SetDebugData`/`CreateUpgradedClone`, y `CreateAffinityVariant`.
+- `Assets/Scripts/Run/RunSession.cs` — `ConfigureCombat` resuelve afinidad
+  (detrás del guard `State.Deck.Count == 0`) y pasa el mazo resuelto a
+  `InitializeDeck`.
+- `Assets/Scripts/Run/RunCombatConfig.cs` — método editor-gated
+  `EditorPopulateStarterDeck(List<CardDeckEntry>)` (patrón de
+  `NewRunConfig.EditorPopulateFaces` / `ShopConfig.EditorPopulatePools`).
+- `Assets/Editor/CardUpgradeSetup.cs` — extender para autorar las 18 caras (o
+  delegar en `StarterDeckSetup`; ver "Decisiones cerradas").
+- SOs de datos (vía el menú, no a mano):
+  `Assets/ScriptableObjects/Cards/` (4 cuerpos nuevos) +
+  `NewRunFaces/*` (18 upgrades) + `Run/RunCombatConfig_Act1.asset` (starterDeck).
+
+## Archivos protegidos involucrados
+- [x] **Ninguno.** `TurnManager.cs`, `ActionQueue.cs`, `PlayerCombatActor.cs` NO
+  se tocan. Confirmación explícita abajo.
+
+### Confirmación: TurnManager NO cambia (la pregunta abierta del roadmap)
+El roadmap pedía "confirmar en el spec si TurnManager necesita cambios (intentar
+que no)". **No necesita.** Verificado leyendo el código hoy:
+
+1. Al jugar una carta, el tipo que entra a la tabla de efectividad es
+   `activeCard.ElementType`, donde `activeCard = GetActiveCardDefinition(entry)`
+   ([TurnManager.cs:826,842](../../../Assets/Scripts/Gameplay/Combat/TurnManager.cs#L826)).
+2. `GetActiveCardDefinition(entry)` = `entry.GetActiveCard(CurrentWorld)`
+   ([TurnManager.cs:803-806](../../../Assets/Scripts/Gameplay/Combat/TurnManager.cs#L803)).
+3. Para una carta dual, `GetActiveCard(world)` devuelve el lado del mundo activo
+   (`dualCard.GetSide(world)`), y cada lado es un `CardDefinition` con su propio
+   `ElementType` ([CardDeckEntry.cs:67-75](../../../Assets/Scripts/Gameplay/Cards/CardDeckEntry.cs#L67)).
+
+→ Las duales **ya conmutan tipo por mundo sin que TurnManager sepa nada**. La
+afinidad se implementa representando cada carta afín como una **dual runtime**
+cuyos lados son el mismo cuerpo con el tipo del Mundo A (lado A) y del Mundo B
+(lado B). El daño neutro (tipo `None`, 90 %) ya está cubierto por
+`ApplyPlayerToEnemyEffectiveness` ([TurnManager.cs:611](../../../Assets/Scripts/Gameplay/Combat/TurnManager.cs#L611)).
+Cero líneas nuevas en archivos protegidos.
+
+## Contratos
+
+### Datos
+
+**`CardDefinition` (modificado)** — campo nuevo + getter:
+```csharp
+[SerializeField] private bool affinity = false;
+public bool Affinity => affinity;
+```
+- `affinity == true`  → carta afín: en runtime adopta el tipo del mundo activo.
+  Su `elementType` autorado en el SO es irrelevante (se autora `None`).
+- `affinity == false` → comportamiento actual: usa su `elementType` fijo
+  (incluido `None` = neutra 90 %).
+
+**`AffinityResolver` (nuevo, static puro)**:
+```csharp
+// Resuelve UNA entrada. Afín-single → dual runtime tipada por mundo.
+// Neutra-single o ya-dual → Clone() sin cambios.
+public static CardDeckEntry Resolve(CardDeckEntry authored, ElementType typeA, ElementType typeB);
+
+// Resuelve la lista entera (mapea Resolve sobre cada entrada válida).
+public static List<CardDeckEntry> ResolveDeck(IReadOnlyList<CardDeckEntry> deck, ElementType typeA, ElementType typeB);
+```
+Construcción de la dual afín (reusa lo existente):
+```csharp
+var dual = ScriptableObject.CreateInstance<DualCardDefinition>();
+dual.InitRuntimeSides(
+    $"affine_{single.Id}", single.CardName,
+    single.CreateAffinityVariant(typeA),   // lado A
+    single.CreateAffinityVariant(typeB));  // lado B
+return CardDeckEntry.CreateDual(dual);
+```
+
+### APIs públicas
+
+**`CardDefinition.CreateAffinityVariant(ElementType worldType)`** (nuevo):
+- Devuelve una **instancia runtime** idéntica al cuerpo (effects, cost, name,
+  description, type, rarity, target, tags, art) pero con `elementType = worldType`
+  y `affinity = false` (ya resuelto).
+- **Preserva el payload de upgrade** (`_upgrade`) — a diferencia de
+  `CreateUpgradedClone`, que no lo copia — para que la dual resuelta siga siendo
+  mejorable en la Hoguera. Como el método vive en `CardDefinition`, asigna
+  `clone._upgrade = _upgrade;` directo (el `CardUpgradeDef` es read-only en
+  runtime; compartir la referencia es seguro).
+- Side effects: crea un `ScriptableObject` runtime (igual que
+  `CreateUpgradedClone`/`ComposeDualCard`). NO toca el SO de origen.
+
+**`SetDebugData(...)`** (modificado): añade parámetro opcional
+`bool newAffinity = false` al final y lo asigna. Compatibilidad: los call sites
+existentes (tests, `CardUpgradeSetup`, `CreateUpgradedClone`) siguen compilando.
+
+**`CreateUpgradedClone()`** (modificado, 1 línea): pasa `affinity` a `SetDebugData`
+para que un afín mejorado conserve el flag (caso defensivo; en el flujo normal el
+afín ya es dual antes de mejorarse).
+
+**`RunCombatConfig.EditorPopulateStarterDeck(List<CardDeckEntry>)`** (nuevo,
+editor-gated `#if UNITY_EDITOR`): setter para que el menú reescriba el starter
+deck sin edición manual del inspector.
+
+### Eventos
+- Ninguno nuevo. No se tocan eventos de TurnManager ni hooks de Retazos.
+
+### Punto de inyección de la resolución
+`RunSession.ConfigureCombat` ([RunSession.cs:152-161](../../../Assets/Scripts/Run/RunSession.cs#L152)):
+```csharp
+public void ConfigureCombat(RunCombatConfig config)
+{
+    if (config == null) return;
+    CombatConfig = config;
+
+    // 4a: resolver afinidad SOLO al poblar el mazo por primera vez. El guard
+    // Deck.Count==0 evita re-crear (y filtrar) ScriptableObjects runtime en cada
+    // combate — InitializeDeck ya no-opea tras el primero, así que sin guard
+    // resolveríamos y descartaríamos SOs cada vez (leak de instancias).
+    if (State.Deck.Count == 0)
+    {
+        var resolved = AffinityResolver.ResolveDeck(
+            config.StarterDeck, State.PlayerWorldAType, State.PlayerWorldBType);
+        State.InitializeDeck(resolved);
+    }
+}
+```
+- Orden garantizado: `NewRunScene` escribe `PlayerWorldAType/BType` en `RunState`
+  (`StarterDraft.ApplySelectionToState`) **antes** de que cargue RunScene; la
+  primera llamada a `ConfigureCombat` (desde `BattleFlowController.TryConfigureCombat`
+  o `RunFlowController`) ya ve los tipos. Si se entra directo a BattleScene sin
+  pasar por NewRunScene, los tipos caen a los defaults de `RunState` (Rojo/Amarillo)
+  — no crashea.
+- `RunState.InitializeDeck` **no cambia**: sigue recibiendo una lista y clonándola
+  (+ inyectando `PendingStarterCard`). La dual drafteada **no** pasa por el
+  resolver (sus lados ya tienen el tipo de cada mundo, porque el draft las filtra
+  por los tipos elegidos).
+
+### Composición del starter deck (autorada por el menú)
+`RunCombatConfig_Act1.starterDeck` queda con **9 entradas single** (la 10ª es la
+dual drafteada, inyectada por `InitializeDeck` vía `PendingStarterCard`):
+
+| Cuerpo SO        | `affinity` | `elementType` | upgrade            | × |
+|------------------|:---------:|:-------------:|--------------------|:-:|
+| `Strike_Affine`  | true      | None          | +3 daño (6→9)      | 3 |
+| `Strike_Neutral` | false     | None          | +3 daño (6→9)      | 2 |
+| `Defend_Affine`  | true      | None          | +5 bloqueo (5→10)  | 2 |
+| `Defend_Neutral` | false     | None          | +5 bloqueo (5→10)  | 2 |
+
+- Cuerpo Strike = `Attack`, coste 1, `Damage 6`. Cuerpo Defend = `Skill`, coste 1,
+  `Block 5` (espejo de los `StrikeBasic`/`DefendBasic` actuales).
+- Los upgrades reusan los valores placeholder ya probados en `CardUpgradeSetup`
+  (Strike 6→9, Defend 5→10).
+
+## Reuso
+- **Mecanismo dual completo**: `DualCardDefinition.InitRuntimeSides`,
+  `GetSide`, `CardDeckEntry.CreateDual/GetActiveCard`, `CreateUpgradedClone` (dual
+  mejora ambos lados). La afinidad NO inventa un camino nuevo; usa el de las duales.
+- **Camino neutro 90 %**: `ApplyPlayerToEnemyEffectiveness` (tipo `None`), ya en
+  producción y cubierto por `NeutralCardDamageTests`.
+- **Patrón de helper puro testeable**: `AffinityResolver` espeja `StarterDraft` /
+  `ShopNodeController.BuildStock`.
+- **Patrón de menú editor idempotente + `EditorPopulate*`**: `NewRunConfigSetup`,
+  `ShopConfigSetup`, `CardUpgradeSetup`.
+- **Render automático**: `CardDisplay.EntryToken` / `DeckViewerView` /
+  `CardHandView` ya saben mostrar duales y conmutar tinte/arte por mundo. Las
+  cartas afines (= duales) se renderizan sin código nuevo: el visor muestra
+  `[TipoA] Strike / [TipoB] Strike` (no colapsa porque los tipos difieren).
+
+## Casos de prueba (EditMode)
+
+### Afinidad — `AffinityTests.cs`
+1. **Resolución afín→dual:** `AffinityResolver.Resolve` sobre una entrada single
+   con `Affinity=true` devuelve una entrada **dual** cuyo `SideA.ElementType ==
+   typeA` y `SideB.ElementType == typeB`.
+2. **Preservación de cuerpo:** la variante afín conserva effects, cost, name,
+   `Type`, target, art idénticos al cuerpo; solo difiere `ElementType` (y
+   `Affinity=false`).
+3. **Preservación de upgrade:** la dual resuelta tiene `CanUpgrade()==true`; tras
+   `ApplyUpgrade()` ambos lados quedan mejorados (daño/bloqueo nuevo).
+4. **Neutra pasa sin tocar:** entrada single con `Affinity=false` y
+   `elementType=None` vuelve como single con `None` (no se convierte en dual).
+5. **Integración con `CardDeckEntry`:** sobre la dual resuelta,
+   `GetActiveCard(WorldSide.A).ElementType == typeA` y `(...B) == typeB`.
+6. **Composición de mazo completo:** `ResolveDeck` sobre el starter autorado
+   (3 afín + 2 neutra Strike, 2 afín + 2 neutra Defend) → 9 entradas: 5 con nombre
+   "Strike" (3 dual + 2 single) y 4 "Defend" (2 dual + 2 single).
+7. **Integración con `TurnManager` real (prueba que el protegido no cambia):**
+   con un `TurnManager` configurado (estilo `RelicGrantEffectsOnTurnManagerTests`),
+   jugar una Strike **afín** en Mundo A contra un enemigo de tipo SuperEficaz por
+   el tipo A → daño = base × 1.5 y `StyleCharges` sube; jugar una Strike **neutra**
+   → daño = 90 % y `StyleCharges` no cambia.
+8. **Flag round-trip:** `CreateUpgradedClone` de un afín single preserva
+   `Affinity`; `CreateAffinityVariant` produce `Affinity=false`.
+
+### Cobertura de mejoras — `CardUpgradeCoverageTests.cs` (el guard DD-023)
+9. **Guard global:** `AssetDatabase.FindAssets("t:CardDefinition")` → cargar cada
+   SO → `Assert` que `card.Upgrade.HasUpgrade == true`. El fallo lista por nombre
+   los SOs sin upgrade (mensaje accionable). *Nota de implementación:* es un test
+   editor-only (usa `UnityEditor.AssetDatabase`); confirmar que
+   `EditModeTests.asmdef` corre en plataforma Editor (lo hace) — envolver el
+   `using UnityEditor;` en `#if UNITY_EDITOR` por higiene.
+10. **Caras drafteables:** una `DualCardDefinition` compuesta de 2 caras (vía
+    `StarterDraft.ComposeDualCard`) tiene `CanUpgrade()==true` (consecuencia de
+    poblar las 18 caras).
+
+## Validación manual (BattleScene + NewRunScene)
+1. Correr `Roguelike > Setup Starter Deck (4a)` en Unity → 0 errores; los 4 SOs de
+   cuerpo existen, `RunCombatConfig_Act1.starterDeck` tiene 9 entradas, las 18
+   caras y los 4 cuerpos muestran upgrade en el inspector.
+2. NewRunScene: elegir A=Rojo, B=Azul, draftear una dual. Entrar a combate.
+3. Abrir el **visor de mazo**: 10 cartas. Las 3 Strike afines se ven
+   `[Rojo] Strike / [Azul] Strike`; las 2 neutras se ven `Strike` sin tinte; la
+   dual drafteada con sus dos caras.
+4. En Mundo A, jugar una Strike afín contra enemigo: el daño refleja la
+   efectividad Rojo→tipo-enemigo; el HUD de la mano la tinta de Rojo. **Cambiar de
+   mundo** → la misma carta en mano pasa a tinte Azul y su daño usa Azul.
+5. Jugar una Strike **neutra**: daño = 90 % fijo, sin popup WEAK/RESIST y sin
+   mover el Contador de Estilo.
+6. En la Hoguera, mejorar la dual drafteada (antes no se podía) y una Strike afín:
+   ambas reflejan los números mejorados en el HUD, en ambos mundos.
+7. **Resultado esperado:** sin errores de consola; afinidad conmuta en vivo;
+   neutras al 90 %; toda carta mejorable.
+
+## Decisiones cerradas
+- **DD-022 (opción A):** afinidad implementada tal cual el GDD. Flag en
+  `CardDefinition`. (Cerrada 2026-06-10.)
+- **DD-023:** mejora autorada por carta (sin fallback genérico runtime) + test
+  guard. (Cerrada 2026-06-10.)
+- **Mecanismo de afinidad = dual runtime.** Decisión técnica de este spec:
+  la carta afín se resuelve a una `DualCardDefinition` runtime por-mundo. Es el
+  único camino que conmuta tipo por mundo sin tocar TurnManager, y reusa el
+  mecanismo dual ya probado.
+- **BattleFocus sale del mazo inicial.** El GDD §5 fija exactamente 5 Strike +
+  4 Defend + 1 dual. BattleFocus no se borra (queda como SO para recompensas).
+- **Flag de afinidad por `CardDefinition`, no por `CardDeckEntry`** (lo pide
+  DD-022). Implica 2 SOs por carta de cuerpo (afín / neutra).
+- **Resolución detrás del guard `Deck.Count==0`** en `ConfigureCombat` para no
+  filtrar SOs runtime cada combate.
+- **`RunState` y `InitializeDeck` no cambian de contrato** (siguen siendo capa de
+  datos: reciben y clonan). La lógica de resolución vive en `RunSession` (capa de
+  flujo) + helper puro.
+- **Autorado vía menú editor**, no edición manual de inspector (consistente con
+  el patrón `*Setup.cs` y con "no manual editor setup").
+
+## Decisiones abiertas (REQUIEREN cierre antes de implementar)
+- Ninguna. (Observación no bloqueante, NO decisión: la afinidad en cartas
+  **Defend** es estructural pero hoy mecánicamente inerte — el bloqueo no pasa por
+  la tabla de efectividad y las cartas no cambian `PlayerActiveType`. Importa para
+  el tinte en UI y para futuros Retazos que lean `ActiveCard.ElementType`. Se
+  implementa igual el 2+2 del GDD; queda anotado para no sorprender en playtest.)
+
+## Alternativas consideradas
+- **Resolver el tipo dentro de TurnManager** (flag afín + override de tipo en
+  `GetActiveCardDefinition`): descartada — toca archivo protegido y exige inyectar
+  los tipos del jugador en una ruta que hoy lee un SO inmutable. El camino dual no
+  toca nada protegido.
+- **Campo de tipo runtime mutado en cambio de mundo:** descartada — el cambio de
+  mundo vive en TurnManager (protegido) y mutar un SO compartido tiene efectos
+  laterales globales.
+- **Flag de afinidad por `CardDeckEntry`** (permitiría 1 solo SO Strike usado como
+  afín o neutra): más económico en SOs, pero contradice DD-022 ("flag en
+  `CardDefinition`") y mezcla la afinidad con la semántica de 90 % que hoy depende
+  de `elementType==None` en la carta resuelta. Descartada por DD-022.
+- **Reutilizar `StrikeBasic`/`StrikeSideB`/`DefendBasic`/`DefendSideB` como los 4
+  cuerpos:** posible (ya tienen upgrade), pero el naming ("Basic" = afín?) es
+  confuso y esos SOs son los lados de los duales de recompensa (`StrikeDual`).
+  Descartada a favor de 4 SOs nuevos con nombre explícito; los viejos quedan
+  intactos para el `rewardPool`.
+
+## Estimación
+- **Complejidad: baja-media** (coincide con el roadmap). El código nuevo es chico:
+  ~1 campo + 1 método en `CardDefinition`, 1 helper puro (~40 loc), 1 guard en
+  `ConfigureCombat`. El grueso es **autorado de SOs** (4 cuerpos + 18 upgrades +
+  starter deck) vía menú, y los tests.
+- **Sub-tareas:**
+  1. `CardDefinition`: flag + `CreateAffinityVariant` + propagación en
+     `SetDebugData`/`CreateUpgradedClone`.
+  2. `AffinityResolver` + guard en `RunSession.ConfigureCombat`.
+  3. `RunCombatConfig.EditorPopulateStarterDeck` + menú `StarterDeckSetup`
+     (cuerpos, upgrades de las 18 caras, recomposición del starter).
+  4. Tests: `AffinityTests` (8) + `CardUpgradeCoverageTests` (2).
+  5. Validación en Unity (menú + E2E NewRunScene→combate→Hoguera).
+- **Riesgos:**
+  - **Leak de `ScriptableObject` runtime** si la resolución no queda detrás del
+    guard `Deck.Count==0` (mitigado en el contrato).
+  - El guard global de upgrades fuerza a que **todo** `CardDefinition` del proyecto
+    tenga upgrade — al correr el menú la primera vez puede destapar SOs viejos sin
+    upgrade; el test lista cuáles (accionable).
+  - Acceso a `UnityEditor.AssetDatabase` desde el test (editor-only; envolver en
+    `#if UNITY_EDITOR`).
+
+## Prompt de handoff para `modo:implementacion`
+
+```text
+modo:implementacion
+
+Implementá M4 Bloque 4a (Integridad del sistema de cartas). El spec cerrado está
+en `Docs/dev/specs/m4_4a_card_integrity_spec.md` — leelo completo antes de tocar
+código; todas las decisiones de diseño ya están cerradas (DD-022 afinidad opción A,
+DD-023 mejora autorada + guard), no abras ninguna.
+
+Setup de branch (depende de PR #123 "visor de mazo": confirmá que está MERGED a
+main antes de arrancar; si no, avisá):
+  git fetch --all --prune
+  git checkout -b feat/m4-4a-card-integrity origin/main
+
+Qué construir (el detalle y los contratos están en el spec):
+Crear:
+- Assets/Scripts/Gameplay/Cards/AffinityResolver.cs (static puro: Resolve/ResolveDeck)
+- Assets/Editor/StarterDeckSetup.cs (menú "Roguelike > Setup Starter Deck (4a)")
+- Assets/Tests/EditMode/AffinityTests.cs (8 casos)
+- Assets/Tests/EditMode/CardUpgradeCoverageTests.cs (guard DD-023, 2 casos)
+Modificar:
+- Assets/Scripts/Gameplay/Cards/CardDefinition.cs (flag affinity + getter,
+  CreateAffinityVariant, propagar affinity en SetDebugData y CreateUpgradedClone)
+- Assets/Scripts/Run/RunSession.cs (ConfigureCombat: resolver afinidad detrás del
+  guard State.Deck.Count==0, pasar mazo resuelto a InitializeDeck)
+- Assets/Scripts/Run/RunCombatConfig.cs (EditorPopulateStarterDeck, #if UNITY_EDITOR)
+Autorar (vía el menú, NO a mano en inspector):
+- 4 SOs de cuerpo (Strike_Affine/Strike_Neutral/Defend_Affine/Defend_Neutral) con
+  upgrade (Strike 6→9, Defend 5→10)
+- upgrades en las 18 caras de Assets/ScriptableObjects/Cards/NewRunFaces/
+- RunCombatConfig_Act1.starterDeck = 3 Strike_Affine + 2 Strike_Neutral +
+  2 Defend_Affine + 2 Defend_Neutral (9 entradas; la 10ª es la dual drafteada)
+
+Reglas no negociables:
+- NO tocar archivos protegidos (TurnManager, ActionQueue, PlayerCombatActor). El
+  spec confirma que NO hacen falta cambios ahí — si creés que sí, PARÁ y avisá.
+- No manual editor setup: SOs y starter deck se autoran por el menú editor.
+- BattleFocus sale del mazo inicial pero NO se borra (queda para recompensas).
+- Afinidad = dual runtime tipada por mundo (reusar InitRuntimeSides/GetSide). La
+  variante afín preserva el payload de upgrade (a diferencia de CreateUpgradedClone).
+- Resolución detrás del guard Deck.Count==0 para no filtrar ScriptableObjects.
+
+Validación obligatoria antes de cerrar:
+- Compilación limpia (zero console errors).
+- Tests EditMode nuevos en verde (AffinityTests + CardUpgradeCoverageTests) +
+  suite completa sin regresiones (parte de 181).
+- Correr el menú "Setup Starter Deck (4a)" en Unity (crea SOs + starter deck +
+  upgrades).
+- Flujo E2E: NewRunScene (elegir 2 tipos + draft) → combate → visor muestra 10
+  cartas (afines como [A]/[B], neutras sin tinte) → afín conmuta tipo/tinte al
+  cambiar de mundo → neutra al 90 % sin mover Estilo → Hoguera mejora dual
+  drafteada y afín.
+- Validar en Unity-MCP (tests-run EditMode + screenshot del visor si aplica).
+
+Al cerrar: actualizá `_roadmap.md` (checkboxes de los 2 bullets de 4a) y
+`_tech_snapshot.md` (campo affinity en CardDefinition, AffinityResolver, guard de
+upgrades, recomposición del starter), commit + push + PR a main.
+```

--- a/Docs/dev/specs/m4_4b_events_quests_spec.md
+++ b/Docs/dev/specs/m4_4b_events_quests_spec.md
@@ -1,0 +1,332 @@
+# Spec — M4 bloque 4b: Eventos + Quests (DD-005, DD-021)
+
+> **ESTADO: PROPUESTA.** (Al implementarse, cambiar a `IMPLEMENTADO — PR #N
+> (YYYY-MM-DD)` por sub-PR. Lo actualiza `/cierre-sesion` al cerrar el spec en
+> código.)
+>
+> Spec cerrado el 2026-06-18 en sesión `modo:diseno`. Las 4 decisiones abiertas
+> quedaron cerradas por Sebastián (ver §Decisiones cerradas). Dividido en **2
+> sub-PRs**: **4b-1** (motor de eventos + eventos simples) y **4b-2** (eventos
+> multidimensionales + quest/MCguffin).
+
+## Origen
+- GDD §DD-005 (sistema de nodos — tipo Event; eventos multidimensionales que
+  dejan elegir mundo) y §DD-021 (representación del MCguffin de quests,
+  explícitamente diferida "al diseño de M4 Eventos" → se cierra aquí).
+- GOLDEN_RULES §7 (Event: encuentros con decisiones, algunos multidimensionales),
+  §8 (eventos otorgan oro variable), §10 (Retazos por evento).
+- `_roadmap.md` → M4 bloque 4b.
+
+## Objetivo
+Convertir el nodo Event (hoy stub: panel genérico "Contenido placeholder" en
+`RunFlowController.ShowResolvePanel`) en un sistema de encuentros con decisiones
+y consecuencias data-driven, incluyendo eventos multidimensionales (elegir
+mundo) y el quest con MCguffin (objeto = un Retazo que da un pasivo + un nodo
+destino a alcanzar en el mapa que otorga recompensa final).
+
+## Comportamiento esperado (perspectiva del jugador)
+1. Click en un nodo Event → se abre un **panel de evento** (espejo estructural de
+   Hoguera/Tienda: panel runtime sobre RunScene, fondo opaco, fallback de color
+   sin arte).
+2. **Evento simple:** título + texto narrativo + N botones de decisión. Cada
+   decisión aplica consecuencias (dar/quitar carta, ±oro, ±HP, dar Retazo) y
+   muestra un texto de resultado → botón "Continuar" cierra el nodo.
+3. **Evento multidimensional:** primero una pantalla de **elección de mundo**
+   (A medieval / B futurista). El enunciado y las recompensas cambian según el
+   mundo elegido; la estructura de decisiones es la misma.
+4. **Quest (MCguffin):** una decisión "Aceptar" entrega el objeto (un **Retazo**
+   con pasivo según el mundo) y marca un **nodo destino resaltado** en el mapa.
+   Completar ese nodo otorga la recompensa final (oro). La decisión alternativa
+   ("Robar") da +100 oro inmediato y destruye el objeto (no hay quest).
+
+## Sistemas afectados
+- **ScriptableObjects:** nuevo `EventDefinition` + `EventPoolConfig`.
+- **Run/Flujo:** `RunFlowController` ramifica `NodeType.Event` a un nuevo
+  `EventNodeController` (hoy cae al `ShowResolvePanel` genérico).
+- **RunState:** estado del quest activo (`QuestState`) + helpers de mutación.
+- **Mapa:** `RunMapView` resalta el nodo destino del quest; `MapNode` porta el
+  `EventDefinition` asignado (determinismo por seed); `RunMapGenerator.AssignEvents`.
+- **Retazos:** el MCguffin reusa el sistema de Retazos (consecuencia "dar
+  Retazo"); 1 efecto nuevo (`OnCardPlayed`) para el pasivo Mundo B.
+- **Combate:** **NINGUNO** — cero cambios en archivos protegidos. Los pasivos del
+  MCguffin corren por hooks de Retazos ya existentes (`OnCombatEnd`, `OnCardPlayed`).
+
+---
+
+## División en sub-PRs
+
+### Sub-PR 4b-1 — Motor de eventos + eventos simples
+Construye toda la infraestructura del nodo Event y los eventos NO
+multidimensionales. Entregable jugable: nodos Event abren un panel con
+decisiones que dan/quitan cartas, oro, HP y Retazos.
+
+**Archivos a crear:**
+- `Assets/Scripts/Run/Events/EventDefinition.cs`
+- `Assets/Scripts/Run/Events/EventChoice.cs`
+- `Assets/Scripts/Run/Events/EventConsequence.cs`
+- `Assets/Scripts/Run/Events/EventResolver.cs`
+- `Assets/Scripts/Run/Events/EventNodeController.cs`
+- `Assets/Scripts/Run/Events/EventPoolConfig.cs`
+- `Assets/Editor/EventConfigSetup.cs`
+- `Assets/Tests/EditMode/EventTests.cs`
+
+**Archivos a modificar:**
+- `RunFlowController.cs` — `BuildEventController()` en `BuildUI()`;
+  `EnterNode` ramifica `NodeType.Event` → `ShowEventPanel`; `OnEventComplete`;
+  `_eventController` field; cleanup en transiciones de escena.
+- `MapNode.cs` — `EventDefinition AssignedEvent { get; set; }` (paralelo a
+  `SpecificEnemy`).
+- `RunMapGenerator.cs` — `AssignEvents(map, pool, seed)` (espejo de `AssignEnemies`).
+- `RunSession.cs` — pasar/asignar el `EventPoolConfig` (donde hoy resuelve
+  enemigos/config; verificar el punto exacto en implementación).
+
+### Sub-PR 4b-2 — Eventos multidimensionales + quest/MCguffin
+Agrega la elección de mundo y el sistema de quests sobre el motor de 4b-1.
+
+**Archivos a crear:**
+- `Assets/Scripts/Run/Quests/QuestState.cs`
+- `Assets/Scripts/Gameplay/Relics/Effects/RelicCardPlayedBlockEffect.cs`
+  (pasivo MCguffin Mundo B — efecto `OnCardPlayed`)
+- `Assets/Tests/EditMode/QuestTests.cs`
+
+**Archivos a modificar:**
+- `EventDefinition.cs` — flag `IsMultidimensional` + variantes `WorldA`/`WorldB`.
+- `EventConsequence.cs` — tipo `StartQuest` + payload.
+- `EventNodeController.cs` — pantalla de elección de mundo previa; render de la
+  variante elegida.
+- `EventResolver.cs` — `ResolveVariant(def, world)`.
+- `RunState.cs` — `QuestState ActiveQuest` + `StartQuest` / `CompleteQuestIfDestination`.
+- `RunFlowController.cs` — al completar cualquier nodo, chequear destino del quest.
+- `RunMapView.cs` — resaltar el nodo destino.
+- `EventConfigSetup.cs` — sumar el evento quest multidimensional placeholder.
+- `Docs/design/DESIGN_DECISIONS.md` — cerrar DD-021 (transcripción, autoridad de
+  Sebastián; ya confirmada la representación).
+
+**Dependencia interna dura:** 4b-2 requiere 4b-1 cerrado (mergeado).
+
+---
+
+## Archivos protegidos involucrados
+- [x] **Ninguno.** El MCguffin corre sobre hooks de Retazos ya expuestos
+  (`OnCombatEnd`, `OnCardPlayed`). El pasivo Mundo B es un `IRelicEffect` nuevo
+  sobre `OnCardPlayed` (hook existente) — NO toca TurnManager/ActionQueue/PlayerCombatActor.
+
+## Contratos
+
+### Datos
+
+```csharp
+enum ConsequenceType {
+    GiveCard, RemoveCard, GiveGold, LoseGold, ModifyHP, GiveRelic, StartQuest
+}
+
+// EventConsequence — datos puros (serializable)
+ConsequenceType Type;
+int Amount;                      // oro / HP delta (signo según Type)
+CardDefinition Card;             // GiveCard
+RelicDefinition Relic;           // GiveRelic / MCguffin (pasivo)
+QuestData Quest;                 // StartQuest
+
+// EventChoice — serializable
+string Label;
+string ResultText;               // texto mostrado tras elegir
+List<EventConsequence> Consequences;
+int MinGoldRequired;             // 0 = sin condición; botón gris si no alcanza
+
+// EventVariant — usado solo en multidimensionales (4b-2)
+string Body;                     // enunciado del mundo
+List<EventChoice> Choices;
+
+// EventDefinition (SO)
+string Id, Title, Body;
+bool IsMultidimensional;         // 4b-2
+EventVariant WorldA, WorldB;     // 4b-2; usados si IsMultidimensional
+List<EventChoice> Choices;       // usados si NO es multidimensional
+// (tags/pesos de filtrado si EventPoolConfig los necesita)
+
+// QuestData — payload de StartQuest (en EventConsequence)
+RelicDefinition CarriedRelic;    // el "objeto"/pasivo entregado al aceptar
+int FinalRewardGold;             // recompensa al llegar al destino (~75)
+// (destino se RESUELVE en runtime al aceptar, no se autora; ver Nota de destino)
+
+// QuestState — runtime en RunState (4b-2)
+bool Active;
+int DestinationNodeId;           // nodo resaltado a alcanzar
+int FinalRewardGold;
+string SourceWorldLabel;         // "A"/"B" para flavor del resaltado
+```
+
+### APIs públicas
+- `EventConsequence.Apply(RunState state, RelicHookDispatcher dispatcher, EventConsequence c)`
+  — **static, sin UI.** Muta RunState. Reusa `state.AddCardToDeck`,
+  `state.RemoveCardFromDeck`, `state.AddRelic`, `state.StartQuest`. Clamp: oro ≥0,
+  HP en `[0, PlayerMaxHP]`.
+- `EventResolver.SelectEvent(EventPoolConfig pool, int nodeId, int seed)` →
+  `EventDefinition` determinista (mismo seed/nodo = mismo evento).
+- `EventResolver.ResolveVariant(EventDefinition def, int world)` → `List<EventChoice>`
+  (4b-2; `world` 0=A / 1=B).
+- `RunState.StartQuest(QuestState quest)` — activa el quest.
+- `RunState.CompleteQuestIfDestination(int nodeId)` → `bool` — si `nodeId` es el
+  destino activo, otorga `FinalRewardGold`, desactiva el quest y devuelve true.
+- `EventNodeController.Initialize(Canvas, RunState, RelicHookDispatcher, EventPoolConfig, Action<int> onComplete)`
+  + `Show(int nodeId)` — firma espejo de `CampfireNodeController`.
+
+### Eventos / Hooks
+- **Sin hooks nuevos en TurnManager.** El MCguffin Mundo A reusa
+  `RelicEndGoldEffect` (Amount=2). El Mundo B usa el nuevo
+  `RelicCardPlayedBlockEffect` sobre `OnCardPlayed` (suma bloqueo al jugador
+  cuando la carta jugada es de tipo Block — vía `RelicHookContext.GrantBlock`).
+- **Sin hook de nodo de evento** (a diferencia de Hoguera/Tienda): en esta
+  versión los Retazos no mutan los eventos. Diferido (Insight 4) hasta que un
+  Retazo concreto lo justifique.
+
+### Nota de destino del quest (alcanzabilidad)
+El nodo destino se resuelve en runtime al aceptar (no se autora en el SO). Debe
+ser **alcanzable** desde el nodo del quest en el DAG. Regla `[PROPUESTA]`:
+BFS forward desde el nodo del quest y elegir un nodo a profundidad +2/+3 sobre un
+camino alcanzable; fallback robusto = el nodo de convergencia pre-boss (siempre
+alcanzable porque todo converge al end). Validar con `RunMapGeneratorTests`-style
+que el destino elegido es alcanzable.
+
+## Reuso
+- Patrón node-controller: `CampfireNodeController` (panel runtime, `BuildPanel`/
+  `Show`/`CompleteX`/`CreateButtonRaw`, fallback de color sin arte, `ClearSpawnedButtons`).
+- Helpers de label de carta: `CardDisplay` (`public static`) para mostrar cartas
+  que se dan/quitan.
+- Mazo/economía: `RunState.AddCardToDeck/RemoveCardFromDeck/AddRelic`, `state.Gold`,
+  `PlayerCurrentHP/MaxHP`.
+- MCguffin pasivo Mundo A: `RelicEndGoldEffect` (ya existe).
+- `RelicHookContext.GrantBlock` para el efecto Mundo B (ya existe en la API limitada).
+- Editor setup idempotente: `ShopConfigSetup` / `NewRunConfigSetup`.
+- Determinismo por seed: `RunMapGenerator.AssignEnemies` como plantilla de `AssignEvents`.
+
+## Casos de prueba (EditMode)
+
+### 4b-1 (`EventTests.cs`)
+1. `Apply(GiveGold)` suma oro; `Apply(LoseGold)` resta con clamp ≥0.
+2. `Apply(ModifyHP)` positivo respeta cap `PlayerMaxHP`; negativo no baja de 0.
+3. `Apply(GiveCard)` clona la carta al mazo; `Apply(RemoveCard)` quita por referencia.
+4. `Apply(GiveRelic)` agrega Retazo con `AcquisitionOrder` correcto (orden de lista).
+5. `EventResolver.SelectEvent` determinista por seed (misma seed = mismo evento por nodo;
+   distinta seed diverge).
+6. Choice con `MinGoldRequired` > oro actual → no disponible.
+7. `AssignEvents` asigna `EventDefinition` solo a nodos `NodeType.Event`, determinista.
+
+### 4b-2 (`QuestTests.cs`)
+8. `ResolveVariant` devuelve choices de A vs B distintas en un evento multidimensional.
+9. Quest aceptar → `ActiveQuest.Active` + `DestinationNodeId` seteado + Retazo entregado;
+   destino alcanzable desde el nodo del quest.
+10. `CompleteQuestIfDestination(destino)` → otorga `FinalRewardGold`, `Active=false`, true.
+11. `CompleteQuestIfDestination(otroNodo)` → false, no otorga, quest sigue activo.
+12. Quest "Robar" → +100 oro, sin quest activo, Retazo NO entregado.
+13. `RunState.Reset()` limpia `ActiveQuest`.
+14. `RelicCardPlayedBlockEffect` sobre `OnCardPlayed` con carta Block → suma bloqueo;
+    con carta no-Block → no-op.
+
+## Validación manual (RunScene)
+1. Correr `Roguelike > Setup Event Config` → `EventPoolConfig.asset` + EventDefinitions creados.
+2. **(4b-1)** Entrar a un nodo Event simple → decisiones aplican (verificar oro/HP/mazo
+   en el visor de mazo y el HUD).
+3. **(4b-2)** Entrar a un evento multidimensional → elegir A vs B muestra enunciados y
+   recompensas distintos.
+4. **(4b-2)** Aceptar el quest → nodo destino resaltado en el mapa; el pasivo aplica en
+   combate (oro extra A / bloqueo extra B); llegar al destino otorga la recompensa final.
+   Robar → +100 oro y sin quest.
+5. Zero console errors; suite EditMode completa en verde.
+
+## Decisiones cerradas (no se discuten)
+- **División:** 2 sub-PRs (4b-1 motor + simples; 4b-2 multidim + quest). *(Q1)*
+- **DD-021 / MCguffin:** el "objeto" ES un **Retazo** (RelicDefinition) entregado al
+  Aceptar → reusa el sistema de Retazos completo (pasivo, inventario, hooks). El
+  "llevarlo a destino" es tracking en RunState (`QuestState` con `DestinationNodeId`).
+  Cero infra de items nueva. *(Q2 — transcribir a DESIGN_DECISIONS.md en 4b-2.)*
+- **Recompensa de quest:** llegar al destino otorga oro (~75, afinable en balance). Si
+  no se llega (muerte / ruta alterna), el pasivo ya se disfrutó durante el trayecto y
+  NO hay recompensa final (riesgo/decisión real). *(Q3)*
+- **Pasivo Mundo B:** se autora `RelicCardPlayedBlockEffect` (nuevo `IRelicEffect` sobre
+  `OnCardPlayed`, hook existente, NO toca protegidos): +1 bloqueo al jugar una carta de
+  escudo. *(Q4)*
+- Event node = panel runtime sobre RunScene (no escena nueva), espejo Hoguera/Tienda.
+- Consecuencias data-driven por enum (no subclases por consecuencia).
+- El "mundo" del evento es elección **local** del encuentro (flavor + recompensa); NO
+  existe ni se introduce estado de mundo persistente fuera de combate.
+- Determinismo por seed: los eventos por nodo se fijan al generar el mapa.
+
+## Alternativas consideradas
+- **Mundo persistente en el run** (que el evento fije el mundo del próximo combate) —
+  descartado: el mundo es mecánica de combate (`TurnManager.CurrentWorld`); el GDD dice
+  que el evento solo cambia "el enunciado y la recompensa". Expandiría scope a combate
+  (protegido).
+- **MCguffin como carta-maldición en el mazo** — descartado: el GDD lo describe como
+  objeto pasivo ("te da X"), que es exactamente la semántica de Retazo.
+- **Ítem de quest dedicado (clase QuestItem)** — descartado (Q2): duplica la infra que ya
+  da el sistema de Retazos.
+- **Hook `OnEventResolved` para Retazos** — diferido (Insight 4: ningún Retazo lo justifica aún).
+- **Destino del quest autorado en el SO** — descartado: el destino depende del mapa
+  generado por seed; debe resolverse en runtime garantizando alcanzabilidad.
+
+## Estimación
+- Complejidad: **alta** (lo grande de M4). 4b-1 media · 4b-2 alta (tracking + marcado en
+  mapa + recompensa diferida + alcanzabilidad en DAG).
+- Riesgo principal: selección del nodo destino debe garantizar alcanzabilidad (BFS
+  forward o convergencia pre-boss). Blindar con test.
+
+---
+
+## Prompt de handoff para `modo:implementacion` — Sub-PR 4b-1
+
+```
+modo:implementacion
+
+Implementá el Sub-PR 4b-1 (motor de eventos + eventos simples) de M4 bloque 4b.
+El spec cerrado está en `Docs/dev/specs/m4_4b_events_quests_spec.md` — leelo
+completo antes de tocar código; todas las decisiones de diseño ya están cerradas,
+no abras ninguna. Implementás SOLO el alcance de 4b-1 (eventos NO
+multidimensionales y sin quests; eso es 4b-2).
+
+Setup de branch (4b-1 no depende de PRs abiertos; verificá el estado de main):
+  git fetch --all --prune
+  git checkout -b feat/m4-4b1-events-engine origin/main
+
+Qué construir (resumen; los contratos están en el spec §Sub-PR 4b-1):
+- Crear: Assets/Scripts/Run/Events/{EventDefinition, EventChoice, EventConsequence,
+  EventResolver, EventNodeController, EventPoolConfig}.cs
+- Crear: Assets/Editor/EventConfigSetup.cs (menú `Roguelike > Setup Event Config`,
+  idempotente — patrón ShopConfigSetup; crea el pool + EventDefinitions simples placeholder)
+- Crear: Assets/Tests/EditMode/EventTests.cs (casos 1-7 del spec)
+- Modificar: RunFlowController.cs (BuildEventController + EnterNode ramifica
+  NodeType.Event → ShowEventPanel + OnEventComplete + cleanup), MapNode.cs
+  (AssignedEvent), RunMapGenerator.cs (AssignEvents), RunSession.cs (cablear EventPoolConfig)
+
+Reglas no negociables:
+- NO tocar archivos protegidos (TurnManager, ActionQueue, PlayerCombatActor). 4b-1 NO los toca.
+- No manual editor setup: todo se auto-crea en runtime / por el menú editor.
+- Eventos multidimensionales y quest/MCguffin quedan FUERA de 4b-1 (son 4b-2).
+- EventConsequence.Apply y EventResolver.SelectEvent son static puros y testeables sin UI
+  (espejo de CampfireNodeController.ApplyRest / ShopNodeController.BuildStock).
+- EventNodeController es panel runtime sobre RunScene, espejo de CampfireNodeController
+  (fallback de color sin arte).
+- Reusar CardDisplay (helpers de label), RunState.AddCardToDeck/RemoveCardFromDeck/AddRelic.
+
+Validación obligatoria antes de cerrar:
+- Compilación limpia (zero console errors).
+- EventTests (casos 1-7) en verde + suite EditMode completa sin regresiones (hoy 193/193).
+- Correr el menú `Roguelike > Setup Event Config` en Unity (crea los assets).
+- Flujo end-to-end en RunScene: entrar a un nodo Event → decisión da/quita carta, ±oro,
+  ±HP, Retazo → verificar en el visor de mazo y HUD.
+- Validación de datos en Unity-MCP donde aplique.
+
+Al cerrar: actualizá `_roadmap.md` (checkbox de 4b-1) y `_tech_snapshot.md` (nuevo
+subsistema Events), commit + push + PR a main.
+```
+
+## Prompt de handoff — Sub-PR 4b-2
+
+> Se genera/afina al cerrar 4b-1 (depende de su motor mergeado). Resumen de scope
+> para esa sesión: agregar `IsMultidimensional` + variantes A/B a `EventDefinition`,
+> pantalla de elección de mundo en `EventNodeController`, `QuestState` en RunState
+> (`StartQuest`/`CompleteQuestIfDestination`), resolución del nodo destino con
+> alcanzabilidad + resaltado en `RunMapView`, `RelicCardPlayedBlockEffect`
+> (`OnCardPlayed`), el evento quest multidimensional placeholder en `EventConfigSetup`,
+> casos 8-14 en `QuestTests.cs`, y la transcripción de DD-021 a `DESIGN_DECISIONS.md`.
+> Branch: `feat/m4-4b2-events-quests` desde `origin/main` con 4b-1 ya mergeado.


### PR DESCRIPTION
## M4 Bloque 4a — Integridad del sistema de cartas

Cierra el bloque 4a del roadmap (spec `Docs/dev/specs/m4_4a_card_integrity_spec.md`).
**DD-022** (afinidad de cartas, opción A) + **DD-023** (mejora autorada por carta + guard).

### Decisión técnica clave: CERO cambios en archivos protegidos
La afinidad se monta sobre el mecanismo **dual** existente — una carta afín se resuelve a una `DualCardDefinition` runtime cuyos lados son el mismo cuerpo tipado por mundo. `TurnManager` ya lee `GetActiveCard(CurrentWorld).ElementType`, así que conmuta tipo/tinte al cambiar de mundo sin tocar `TurnManager`/`ActionQueue`/`PlayerCombatActor`.

### Afinidad (DD-022)
- `CardDefinition`: flag `affinity` + getter + `CreateAffinityVariant(ElementType)` — clona el cuerpo tipado para un mundo y **preserva el payload de upgrade** (a diferencia de `CreateUpgradedClone`), así la dual afín resuelta sigue mejorable. Propagado en `SetDebugData`/`CreateUpgradedClone`.
- `AffinityResolver` (static puro, espejo de `StarterDraft`): `Resolve`/`ResolveDeck`. Afín single → dual tipada; neutra (None)/dual → `Clone()`.
- `RunSession.ConfigureCombat`: resuelve afinidad detrás del guard `Deck.Count==0` (evita leak de SOs runtime por combate). `RunState`/`InitializeDeck` no cambian de contrato.

### Cobertura de mejoras (DD-023)
- `Assets/Editor/StarterDeckSetup.cs` — menú `Roguelike > Setup Starter Deck (4a)` (idempotente): 4 cuerpos (`Strike`/`Defend` × afín/neutra; upg Strike 6→9 / Defend 5→10), upgrade en las 18 caras de `NewRunFaces/`, y recomposición de `RunCombatConfig_Act1.starterDeck` a GDD §5.
- `RunCombatConfig.EditorPopulateStarterDeck` (`#if UNITY_EDITOR`).
- La dual drafteada se vuelve mejorable (sus 2 caras ahora tienen upgrade).

### Mazo inicial (GDD §5)
3 `Strike_Affine` + 2 `Strike_Neutral` + 2 `Defend_Affine` + 2 `Defend_Neutral` = **9** entradas single; la 10ª es la dual drafteada (inyectada por `PendingStarterCard`). BattleFocus sale del starter, queda en `rewardPool`.

### Tests / validación
- `AffinityTests.cs` (8 casos, incl. integración con `TurnManager` real: afín SuperEficaz vs neutra 90%) + `CardUpgradeCoverageTests.cs` (guard DD-023: todo `CardDefinition` tiene upgrade; dual de caras es mejorable).
- Suite EditMode **181 → 191/191**, compilación limpia.
- Validado en Unity-MCP: menú corrido (4 cuerpos + 18 caras + starter de 9) + E2E data-layer (config real → 9 entradas: 5 afines tipadas A/B + 4 neutras None → mazo de 10, todas mejorables).

### Pendiente
- **E2E visual manual por Sebastián** en escena (NewRunScene → combate → visor muestra afines como `[A]`/`[B]` y neutras sin tinte → conmutación de tipo/tinte al cambiar de mundo → Hoguera mejora dual drafteada y afín). El game view no repinta sin foco vía CLI, así que el flujo visual queda para confirmación manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)