### PR TITLE
feat(events): M4 4b-2 — eventos multidimensionales + quest/MCguffin

### DIFF
--- a/Assets/Editor/EventConfigSetup.cs
+++ b/Assets/Editor/EventConfigSetup.cs
@@ -3,20 +3,18 @@ using UnityEditor;
 using UnityEngine;
 using RoguelikeCardBattler.Gameplay.Cards;
 using RoguelikeCardBattler.Gameplay.Relics;
+using RoguelikeCardBattler.Gameplay.Relics.Effects;
 using RoguelikeCardBattler.Run.Events;
 
 namespace RoguelikeCardBattler.Editor
 {
     /// <summary>
-    /// Crea (o reutiliza) el EventPoolConfig.asset (4b-1) y un set de
-    /// EventDefinitions simples placeholder, poblando sus decisiones con cartas y
-    /// Retazos existentes en el proyecto. Idempotente: re-ejecutable sin limpieza
-    /// manual (carga-o-crea cada asset por ruta y reescribe su contenido). Patrón
+    /// Crea (o reutiliza) el EventPoolConfig.asset y todos los EventDefinitions del
+    /// acto: 3 simples (4b-1) + 3 multidimensionales (4b-2). Idempotente. Patrón
     /// espejo de <c>ShopConfigSetup</c>.
     ///
-    /// Los 3 eventos placeholder cubren todas las consecuencias de 4b-1
-    /// (GiveCard / RemoveCard / GiveGold / LoseGold / ModifyHP / GiveRelic) para
-    /// permitir la validación end-to-end en RunScene.
+    /// Los 2 Retazos MCguffin se crean en <c>Assets/ScriptableObjects/Relics/Quest/</c>
+    /// (subcarpeta dedicada, NO entran a ningún drop pool).
     /// </summary>
     public static class EventConfigSetup
     {
@@ -25,6 +23,7 @@ namespace RoguelikeCardBattler.Editor
         private const string EventsFolder = "Assets/ScriptableObjects/Events";
         private const string CardsFolder = "Assets/ScriptableObjects/Cards";
         private const string RelicsFolder = "Assets/ScriptableObjects/Relics";
+        private const string QuestRelicsFolder = "Assets/ScriptableObjects/Relics/Quest";
         private const string EventArtFolder = "Assets/Art/Events";
 
         [MenuItem("Roguelike/Setup Event Config")]
@@ -32,18 +31,40 @@ namespace RoguelikeCardBattler.Editor
         {
             EnsureFolder("Assets/ScriptableObjects", "Configs", ConfigFolder);
             EnsureFolder("Assets/ScriptableObjects", "Events", EventsFolder);
+            EnsureFolder(RelicsFolder, "Quest", QuestRelicsFolder);
 
-            // Payloads desde assets existentes. Los placeholders degradan con gracia
-            // si falta algún asset (la consecuencia con payload null es no-op).
+            // Payloads para eventos simples
             CardDefinition giveCard = FindCard("BattleFocus") ?? FindAnyCard();
             CardDefinition removeCard = FindCard("Strike_Neutral") ?? FindCard("Defend_Neutral") ?? FindAnyCard();
             RelicDefinition relic = FindAnyRelic();
 
+            // Retazos MCguffin (4b-2) — creados antes que los eventos que los referencian
+            RelicDefinition mcguffinA = CreateOrUpdateMcguffinRelic(
+                "R-MCG-A_CalizDelMensajero",
+                "Cáliz del mensajero",
+                "+2 oro al ganar cada combate.",
+                "Lacrado con cera de otra época. Pesa como una promesa.",
+                RelicHook.OnCombatEnd,
+                new RelicEndGoldEffect { Amount = 2 });
+
+            RelicDefinition mcguffinB = CreateOrUpdateMcguffinRelic(
+                "R-MCG-B_DiscoDeLaResistencia",
+                "Disco de la resistencia",
+                "+1 escudo al jugar una carta de escudo.",
+                "Late con datos que alguien murió por proteger.",
+                RelicHook.OnCardPlayed,
+                new RelicCardPlayedBlockEffect { Amount = 1 });
+
+            // Eventos simples (4b-1)
             List<EventDefinition> pool = new List<EventDefinition>
             {
                 BuildMerchantEvent(giveCard),
                 BuildAltarEvent(relic),
                 BuildChestEvent(removeCard),
+                // Eventos multidimensionales (4b-2)
+                BuildForgeEvent(giveCard),
+                BuildRelicEvent(relic),
+                BuildQuestEvent(mcguffinA, mcguffinB),
             };
 
             EventPoolConfig config = AssetDatabase.LoadAssetAtPath<EventPoolConfig>(ConfigPath);
@@ -59,38 +80,27 @@ namespace RoguelikeCardBattler.Editor
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();
 
-            Debug.Log($"[EventConfigSetup] events={pool.Count} (giveCard={(giveCard != null ? giveCard.name : "null")}, " +
-                      $"removeCard={(removeCard != null ? removeCard.name : "null")}, relic={(relic != null ? relic.name : "null")})");
+            Debug.Log($"[EventConfigSetup] pool={pool.Count} (3 simples + 3 multidim). " +
+                      $"MCguffin A={mcguffinA?.name}, B={mcguffinB?.name}.");
         }
 
         // ──────────────────────────────────────────────
-        // Eventos placeholder
+        // Eventos simples (4b-1)
         // ──────────────────────────────────────────────
 
         private static EventDefinition BuildMerchantEvent(CardDefinition giveCard)
         {
             var choices = new List<EventChoice>
             {
-                new EventChoice(
-                    "Comprar una carta",
-                    "Guardas la carta en tu mazo.",
+                new EventChoice("Comprar una carta", "Guardas la carta en tu mazo.",
                     new List<EventConsequence>
                     {
                         new EventConsequence(ConsequenceType.LoseGold, 20),
                         new EventConsequence(ConsequenceType.GiveCard, card: giveCard),
-                    },
-                    minGoldRequired: 20),
-                new EventChoice(
-                    "Pedir indicaciones",
-                    "El mercader agradece tu compañía y te da 15 de oro.",
-                    new List<EventConsequence>
-                    {
-                        new EventConsequence(ConsequenceType.GiveGold, 15),
-                    }),
-                new EventChoice(
-                    "Seguir tu camino",
-                    "Continúas tu viaje.",
-                    new List<EventConsequence>()),
+                    }, minGoldRequired: 20),
+                new EventChoice("Pedir indicaciones", "El mercader agradece tu compañía y te da 15 de oro.",
+                    new List<EventConsequence> { new EventConsequence(ConsequenceType.GiveGold, 15) }),
+                new EventChoice("Seguir tu camino", "Continúas tu viaje.", new List<EventConsequence>()),
             };
             return CreateOrUpdateEvent("evt_merchant", "El mercader errante",
                 "Un mercader ambulante extiende su manta de trueques frente a ti.", choices);
@@ -100,25 +110,16 @@ namespace RoguelikeCardBattler.Editor
         {
             var choices = new List<EventChoice>
             {
-                new EventChoice(
-                    "Rezar ante el altar",
-                    "Una calidez recorre tu cuerpo (+12 HP).",
-                    new List<EventConsequence>
-                    {
-                        new EventConsequence(ConsequenceType.ModifyHP, 12),
-                    }),
-                new EventChoice(
-                    "Profanar el altar",
+                new EventChoice("Rezar ante el altar", "Una calidez recorre tu cuerpo (+12 HP).",
+                    new List<EventConsequence> { new EventConsequence(ConsequenceType.ModifyHP, 12) }),
+                new EventChoice("Profanar el altar",
                     "Arrancas el Retazo incrustado, pero una astilla te hiere (-8 HP).",
                     new List<EventConsequence>
                     {
                         new EventConsequence(ConsequenceType.GiveRelic, relic: relic),
                         new EventConsequence(ConsequenceType.ModifyHP, -8),
                     }),
-                new EventChoice(
-                    "Ignorarlo",
-                    "Te alejas del altar en silencio.",
-                    new List<EventConsequence>()),
+                new EventChoice("Ignorarlo", "Te alejas del altar en silencio.", new List<EventConsequence>()),
             };
             return CreateOrUpdateEvent("evt_altar", "Altar misterioso",
                 "Un altar de cartón craquelado emite un brillo tenue.", choices);
@@ -128,34 +129,218 @@ namespace RoguelikeCardBattler.Editor
         {
             var choices = new List<EventChoice>
             {
-                new EventChoice(
-                    "Abrir el cofre",
-                    "El cofre contenía 30 de oro.",
-                    new List<EventConsequence>
-                    {
-                        new EventConsequence(ConsequenceType.GiveGold, 30),
-                    }),
-                new EventChoice(
-                    "Quemar una carta gastada",
+                new EventChoice("Abrir el cofre", "El cofre contenía 30 de oro.",
+                    new List<EventConsequence> { new EventConsequence(ConsequenceType.GiveGold, 30) }),
+                new EventChoice("Quemar una carta gastada",
                     "Echas una carta vieja a la hoguera del campamento.",
-                    new List<EventConsequence>
-                    {
-                        new EventConsequence(ConsequenceType.RemoveCard, card: removeCard),
-                    }),
-                new EventChoice(
-                    "Dejarlo cerrado",
-                    "Dejas el cofre intacto.",
-                    new List<EventConsequence>()),
+                    new List<EventConsequence> { new EventConsequence(ConsequenceType.RemoveCard, card: removeCard) }),
+                new EventChoice("Dejarlo cerrado", "Dejas el cofre intacto.", new List<EventConsequence>()),
             };
             return CreateOrUpdateEvent("evt_chest", "Cofre del trotamundos",
                 "Encuentras un cofre polvoriento junto al sendero.", choices);
         }
 
         // ──────────────────────────────────────────────
+        // Eventos multidimensionales (4b-2)
+        // ──────────────────────────────────────────────
+
+        private static EventDefinition BuildForgeEvent(CardDefinition giveCard)
+        {
+            var variantA = BuildForgeVariantA(giveCard);
+            var variantB = BuildForgeVariantB(giveCard);
+            return CreateOrUpdateMultidimEvent(
+                "evt_md_forge", "El artesano y su yunque",
+                "Un artesano trabaja en silencio.", variantA, variantB);
+        }
+
+        private static EventVariant BuildForgeVariantA(CardDefinition giveCard)
+        {
+            var v = new EventVariant();
+            v.SetData(
+                "Un herrero ermitaño aviva las brasas de su fragua. " +
+                "'Dame algo de oro y tu acero saldrá más afilado', murmura sin mirarte.",
+                new List<EventChoice>
+                {
+                    new EventChoice("Pagar al herrero",
+                        "El herrero te entrega una hoja recién templada.",
+                        new List<EventConsequence>
+                        {
+                            new EventConsequence(ConsequenceType.LoseGold, 25),
+                            new EventConsequence(ConsequenceType.GiveCard, card: giveCard),
+                        }, minGoldRequired: 25),
+                    new EventChoice("Curar tus heridas",
+                        "El calor de la fragua reconforta tu cuerpo (+10 HP).",
+                        new List<EventConsequence> { new EventConsequence(ConsequenceType.ModifyHP, 10) }),
+                    new EventChoice("Dejar la fragua",
+                        "Te alejas del calor de las brasas.",
+                        new List<EventConsequence>()),
+                });
+            return v;
+        }
+
+        private static EventVariant BuildForgeVariantB(CardDefinition giveCard)
+        {
+            var v = new EventVariant();
+            v.SetData(
+                "Un técnico de chatarra calibra su soldadora de plasma. " +
+                "'Unos créditos y recalibro tu equipo', zumba su vocoder.",
+                new List<EventChoice>
+                {
+                    new EventChoice("Pagar al técnico",
+                        "El técnico imprime un módulo y lo acopla a tu equipo.",
+                        new List<EventConsequence>
+                        {
+                            new EventConsequence(ConsequenceType.LoseGold, 25),
+                            new EventConsequence(ConsequenceType.GiveCard, card: giveCard),
+                        }, minGoldRequired: 25),
+                    new EventChoice("Pedir un parche",
+                        "El nanogel sella tus heridas (+14 HP).",
+                        new List<EventConsequence> { new EventConsequence(ConsequenceType.ModifyHP, 14) }),
+                    new EventChoice("Salir del taller",
+                        "Las compuertas se cierran tras de ti.",
+                        new List<EventConsequence>()),
+                });
+            return v;
+        }
+
+        private static EventDefinition BuildRelicEvent(RelicDefinition relic)
+        {
+            var variantA = BuildRelicVariantA(relic);
+            var variantB = BuildRelicVariantB(relic);
+            return CreateOrUpdateMultidimEvent(
+                "evt_md_relic", "El relicario sellado",
+                "Algo antiguo espera ser abierto.", variantA, variantB);
+        }
+
+        private static EventVariant BuildRelicVariantA(RelicDefinition relic)
+        {
+            var v = new EventVariant();
+            v.SetData(
+                "Un relicario de hierro descansa sobre un altar agrietado. " +
+                "Un susurro promete poder a quien se atreva a abrirlo.",
+                new List<EventChoice>
+                {
+                    new EventChoice("Romper el sello",
+                        "Arrancas la reliquia; las púas del relicario te hieren (-8 HP).",
+                        new List<EventConsequence>
+                        {
+                            new EventConsequence(ConsequenceType.GiveRelic, relic: relic),
+                            new EventConsequence(ConsequenceType.ModifyHP, -8),
+                        }),
+                    new EventChoice("Llevarte las ofrendas",
+                        "Recoges 30 de oro de entre las ofrendas.",
+                        new List<EventConsequence> { new EventConsequence(ConsequenceType.GiveGold, 30) }),
+                    new EventChoice("No arriesgarte",
+                        "Retrocedes sin tocar el altar.",
+                        new List<EventConsequence>()),
+                });
+            return v;
+        }
+
+        private static EventVariant BuildRelicVariantB(RelicDefinition relic)
+        {
+            var v = new EventVariant();
+            v.SetData(
+                "Una cápsula de contención parpadea en rojo. " +
+                "Una voz sintética ofrece su carga a quien acepte el riesgo.",
+                new List<EventChoice>
+                {
+                    new EventChoice("Forzar la cápsula",
+                        "Extraes el núcleo; una descarga te recorre (-6 HP).",
+                        new List<EventConsequence>
+                        {
+                            new EventConsequence(ConsequenceType.GiveRelic, relic: relic),
+                            new EventConsequence(ConsequenceType.ModifyHP, -6),
+                        }),
+                    new EventChoice("Vaciar la reserva",
+                        "Transfieres 35 créditos de la reserva.",
+                        new List<EventConsequence> { new EventConsequence(ConsequenceType.GiveGold, 35) }),
+                    new EventChoice("No arriesgarte",
+                        "Te apartas de la cápsula parpadeante.",
+                        new List<EventConsequence>()),
+                });
+            return v;
+        }
+
+        private static EventDefinition BuildQuestEvent(RelicDefinition mcguffinA, RelicDefinition mcguffinB)
+        {
+            var variantA = BuildQuestVariantA(mcguffinA);
+            var variantB = BuildQuestVariantB(mcguffinB);
+            return CreateOrUpdateMultidimEvent(
+                "evt_md_quest_courier", "Un encargo en el camino",
+                "Alguien necesita tu ayuda para llevar algo al otro lado del mapa.", variantA, variantB);
+        }
+
+        private static EventVariant BuildQuestVariantA(RelicDefinition mcguffinA)
+        {
+            var questData = new QuestData { CarriedRelic = mcguffinA, FinalRewardGold = 75 };
+            var v = new EventVariant();
+            v.SetData(
+                "Un hombre moribundo, con las ropas raídas de la legión de magos, te aferra el brazo. " +
+                "Te ruega llevar un objeto místico hasta un punto lejano del mapa; si lo logras, promete recompensarte.",
+                new List<EventChoice>
+                {
+                    new EventChoice("Aceptar el encargo",
+                        "El mago te confía un cáliz lacrado. Un punto del mapa queda resaltado.",
+                        new List<EventConsequence> { new EventConsequence(ConsequenceType.StartQuest, quest: questData) }),
+                    new EventChoice("Robar al moribundo",
+                        "Le arrebatas la bolsa y huyes. El objeto se hace añicos. +100 de oro.",
+                        new List<EventConsequence> { new EventConsequence(ConsequenceType.GiveGold, 100) }),
+                });
+            return v;
+        }
+
+        private static EventVariant BuildQuestVariantB(RelicDefinition mcguffinB)
+        {
+            var questData = new QuestData { CarriedRelic = mcguffinB, FinalRewardGold = 75 };
+            var v = new EventVariant();
+            v.SetData(
+                "Un robot con las piezas rotas chisporrotea en el suelo. Dice pertenecer a una facción " +
+                "revolucionaria y te pide llevar un disco duro con información vital hasta un punto lejano del mapa.",
+                new List<EventChoice>
+                {
+                    new EventChoice("Aceptar el encargo",
+                        "El robot te transfiere un disco sellado. Un punto del mapa queda resaltado.",
+                        new List<EventConsequence> { new EventConsequence(ConsequenceType.StartQuest, quest: questData) }),
+                    new EventChoice("Robar al robot",
+                        "Le arrancas el disco y sus créditos. El disco se desintegra. +100 de oro.",
+                        new List<EventConsequence> { new EventConsequence(ConsequenceType.GiveGold, 100) }),
+                });
+            return v;
+        }
+
+        // ──────────────────────────────────────────────
+        // MCguffin relics
+        // ──────────────────────────────────────────────
+
+        private static RelicDefinition CreateOrUpdateMcguffinRelic(
+            string assetName, string displayName, string description,
+            string flavorText, RelicHook hook, IRelicEffect effect)
+        {
+            string path = $"{QuestRelicsFolder}/{assetName}.asset";
+            RelicDefinition def = AssetDatabase.LoadAssetAtPath<RelicDefinition>(path);
+            if (def == null)
+            {
+                def = ScriptableObject.CreateInstance<RelicDefinition>();
+                AssetDatabase.CreateAsset(def, path);
+                Debug.Log($"[EventConfigSetup] MCguffin relic creado: {path}");
+            }
+            def.DisplayName = displayName;
+            def.Description = description;
+            def.FlavorText = flavorText;
+            def.Category = RelicCategory.World;
+            def.Hooks = new[] { hook };
+            def.Effect = effect;
+            EditorUtility.SetDirty(def);
+            return def;
+        }
+
+        // ──────────────────────────────────────────────
         // Helpers
         // ──────────────────────────────────────────────
 
-        private static EventDefinition CreateOrUpdateEvent(string id, string title, string body, List<EventChoice> choices)
+        private static EventDefinition CreateOrUpdateEvent(
+            string id, string title, string body, List<EventChoice> choices)
         {
             string path = $"{EventsFolder}/{id}.asset";
             EventDefinition def = AssetDatabase.LoadAssetAtPath<EventDefinition>(path);
@@ -164,10 +349,26 @@ namespace RoguelikeCardBattler.Editor
                 def = ScriptableObject.CreateInstance<EventDefinition>();
                 AssetDatabase.CreateAsset(def, path);
             }
-            // Fondo por-evento si existe el PNG (Assets/Art/Events/fondo_<id>.png).
-            // Null-safe: sin arte, el panel usa el color de fallback.
             Sprite background = FindBackground(id);
             def.SetDebugData(id, title, body, choices, background);
+            EditorUtility.SetDirty(def);
+            return def;
+        }
+
+        private static EventDefinition CreateOrUpdateMultidimEvent(
+            string id, string title, string bodyFallback,
+            EventVariant variantA, EventVariant variantB)
+        {
+            string path = $"{EventsFolder}/{id}.asset";
+            EventDefinition def = AssetDatabase.LoadAssetAtPath<EventDefinition>(path);
+            if (def == null)
+            {
+                def = ScriptableObject.CreateInstance<EventDefinition>();
+                AssetDatabase.CreateAsset(def, path);
+            }
+            Sprite background = FindBackground(id);
+            def.SetDebugData(id, title, bodyFallback, null, background,
+                multidim: true, newWorldA: variantA, newWorldB: variantB);
             EditorUtility.SetDirty(def);
             return def;
         }
@@ -181,9 +382,7 @@ namespace RoguelikeCardBattler.Editor
         private static void EnsureFolder(string parent, string newFolder, string fullPath)
         {
             if (!AssetDatabase.IsValidFolder(fullPath))
-            {
                 AssetDatabase.CreateFolder(parent, newFolder);
-            }
         }
 
         private static CardDefinition FindCard(string assetName)
@@ -193,9 +392,7 @@ namespace RoguelikeCardBattler.Editor
             {
                 string path = AssetDatabase.GUIDToAssetPath(guid);
                 if (System.IO.Path.GetFileNameWithoutExtension(path) == assetName)
-                {
                     return AssetDatabase.LoadAssetAtPath<CardDefinition>(path);
-                }
             }
             return null;
         }
@@ -209,9 +406,15 @@ namespace RoguelikeCardBattler.Editor
 
         private static RelicDefinition FindAnyRelic()
         {
+            // Solo en la carpeta principal de Relics (excluye Quest/) para no capturar MCguffins.
             string[] guids = AssetDatabase.FindAssets("t:RelicDefinition", new[] { RelicsFolder });
-            if (guids.Length == 0) return null;
-            return AssetDatabase.LoadAssetAtPath<RelicDefinition>(AssetDatabase.GUIDToAssetPath(guids[0]));
+            foreach (string guid in guids)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(guid);
+                if (!path.Contains("/Quest/"))
+                    return AssetDatabase.LoadAssetAtPath<RelicDefinition>(path);
+            }
+            return null;
         }
     }
 }

--- a/Assets/ScriptableObjects/Configs/EventPoolConfig.asset
+++ b/Assets/ScriptableObjects/Configs/EventPoolConfig.asset
@@ -16,4 +16,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 6d594f8e194596242a7f1cc52b71d207, type: 2}
   - {fileID: 11400000, guid: 2167c5bfa5328f6498750e4033324558, type: 2}
   - {fileID: 11400000, guid: 61e26769470cf80488a82826f3c9b752, type: 2}
+  - {fileID: 11400000, guid: 1e7272fbd0671cc42be94e52b30d3900, type: 2}
+  - {fileID: 11400000, guid: e9d7266e8de9bc54191d2b587c26b5d1, type: 2}
+  - {fileID: 11400000, guid: 8b2477a4b644f1f49ae5c94e959491ba, type: 2}
   backgroundSprite: {fileID: 0}

--- a/Assets/ScriptableObjects/Events/evt_altar.asset
+++ b/Assets/ScriptableObjects/Events/evt_altar.asset
@@ -25,6 +25,9 @@ MonoBehaviour:
       amount: 12
       card: {fileID: 0}
       relic: {fileID: 0}
+      quest:
+        CarriedRelic: {fileID: 0}
+        FinalRewardGold: 0
   - label: Profanar el altar
     resultText: Arrancas el Retazo incrustado, pero una astilla te hiere (-8 HP).
     minGoldRequired: 0
@@ -33,11 +36,24 @@ MonoBehaviour:
       amount: 0
       card: {fileID: 0}
       relic: {fileID: 11400000, guid: de6bce18941a74a4b9cecd63bac0b3ec, type: 2}
+      quest:
+        CarriedRelic: {fileID: 0}
+        FinalRewardGold: 0
     - type: 4
       amount: -8
       card: {fileID: 0}
       relic: {fileID: 0}
+      quest:
+        CarriedRelic: {fileID: 0}
+        FinalRewardGold: 0
   - label: Ignorarlo
     resultText: Te alejas del altar en silencio.
     minGoldRequired: 0
     consequences: []
+  isMultidimensional: 0
+  worldA:
+    body: 
+    choices: []
+  worldB:
+    body: 
+    choices: []

--- a/Assets/ScriptableObjects/Events/evt_chest.asset
+++ b/Assets/ScriptableObjects/Events/evt_chest.asset
@@ -25,6 +25,9 @@ MonoBehaviour:
       amount: 30
       card: {fileID: 0}
       relic: {fileID: 0}
+      quest:
+        CarriedRelic: {fileID: 0}
+        FinalRewardGold: 0
   - label: Quemar una carta gastada
     resultText: Echas una carta vieja a la hoguera del campamento.
     minGoldRequired: 0
@@ -33,7 +36,17 @@ MonoBehaviour:
       amount: 0
       card: {fileID: 11400000, guid: 3fe0f3064d148024389c15328f3635e0, type: 2}
       relic: {fileID: 0}
+      quest:
+        CarriedRelic: {fileID: 0}
+        FinalRewardGold: 0
   - label: Dejarlo cerrado
     resultText: Dejas el cofre intacto.
     minGoldRequired: 0
     consequences: []
+  isMultidimensional: 0
+  worldA:
+    body: 
+    choices: []
+  worldB:
+    body: 
+    choices: []

--- a/Assets/ScriptableObjects/Events/evt_md_forge.asset
+++ b/Assets/ScriptableObjects/Events/evt_md_forge.asset
@@ -1,0 +1,94 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2319b0164a650064dac7df34b4e37e50, type: 3}
+  m_Name: evt_md_forge
+  m_EditorClassIdentifier: RoguelikeCardBattler::RoguelikeCardBattler.Run.Events.EventDefinition
+  id: evt_md_forge
+  title: El artesano y su yunque
+  body: Un artesano trabaja en silencio.
+  backgroundSprite: {fileID: 0}
+  choices: []
+  isMultidimensional: 1
+  worldA:
+    body: "Un herrero ermita\xF1o aviva las brasas de su fragua. 'Dame algo de oro
+      y tu acero saldr\xE1 m\xE1s afilado', murmura sin mirarte."
+    choices:
+    - label: Pagar al herrero
+      resultText: "El herrero te entrega una hoja reci\xE9n templada."
+      minGoldRequired: 25
+      consequences:
+      - type: 3
+        amount: 25
+        card: {fileID: 0}
+        relic: {fileID: 0}
+        quest:
+          CarriedRelic: {fileID: 0}
+          FinalRewardGold: 0
+      - type: 0
+        amount: 0
+        card: {fileID: 11400000, guid: 3d528c055ad84181a6d0bfaae6a0c97c, type: 2}
+        relic: {fileID: 0}
+        quest:
+          CarriedRelic: {fileID: 0}
+          FinalRewardGold: 0
+    - label: Curar tus heridas
+      resultText: El calor de la fragua reconforta tu cuerpo (+10 HP).
+      minGoldRequired: 0
+      consequences:
+      - type: 4
+        amount: 10
+        card: {fileID: 0}
+        relic: {fileID: 0}
+        quest:
+          CarriedRelic: {fileID: 0}
+          FinalRewardGold: 0
+    - label: Dejar la fragua
+      resultText: Te alejas del calor de las brasas.
+      minGoldRequired: 0
+      consequences: []
+  worldB:
+    body: "Un t\xE9cnico de chatarra calibra su soldadora de plasma. 'Unos cr\xE9ditos
+      y recalibro tu equipo', zumba su vocoder."
+    choices:
+    - label: "Pagar al t\xE9cnico"
+      resultText: "El t\xE9cnico imprime un m\xF3dulo y lo acopla a tu equipo."
+      minGoldRequired: 25
+      consequences:
+      - type: 3
+        amount: 25
+        card: {fileID: 0}
+        relic: {fileID: 0}
+        quest:
+          CarriedRelic: {fileID: 0}
+          FinalRewardGold: 0
+      - type: 0
+        amount: 0
+        card: {fileID: 11400000, guid: 3d528c055ad84181a6d0bfaae6a0c97c, type: 2}
+        relic: {fileID: 0}
+        quest:
+          CarriedRelic: {fileID: 0}
+          FinalRewardGold: 0
+    - label: Pedir un parche
+      resultText: El nanogel sella tus heridas (+14 HP).
+      minGoldRequired: 0
+      consequences:
+      - type: 4
+        amount: 14
+        card: {fileID: 0}
+        relic: {fileID: 0}
+        quest:
+          CarriedRelic: {fileID: 0}
+          FinalRewardGold: 0
+    - label: Salir del taller
+      resultText: Las compuertas se cierran tras de ti.
+      minGoldRequired: 0
+      consequences: []

--- a/Assets/ScriptableObjects/Events/evt_md_forge.asset.meta
+++ b/Assets/ScriptableObjects/Events/evt_md_forge.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1e7272fbd0671cc42be94e52b30d3900
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Events/evt_md_quest_courier.asset
+++ b/Assets/ScriptableObjects/Events/evt_md_quest_courier.asset
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2319b0164a650064dac7df34b4e37e50, type: 3}
+  m_Name: evt_md_quest_courier
+  m_EditorClassIdentifier: RoguelikeCardBattler::RoguelikeCardBattler.Run.Events.EventDefinition
+  id: evt_md_quest_courier
+  title: Un encargo en el camino
+  body: Alguien necesita tu ayuda para llevar algo al otro lado del mapa.
+  backgroundSprite: {fileID: 0}
+  choices: []
+  isMultidimensional: 1
+  worldA:
+    body: "Un hombre moribundo, con las ropas ra\xEDdas de la legi\xF3n de magos,
+      te aferra el brazo. Te ruega llevar un objeto m\xEDstico hasta un punto lejano
+      del mapa; si lo logras, promete recompensarte."
+    choices:
+    - label: Aceptar el encargo
+      resultText: "El mago te conf\xEDa un c\xE1liz lacrado. Un punto del mapa queda
+        resaltado."
+      minGoldRequired: 0
+      consequences:
+      - type: 6
+        amount: 0
+        card: {fileID: 0}
+        relic: {fileID: 0}
+        quest:
+          CarriedRelic: {fileID: 11400000, guid: 3582e637a00dc9a44a445461492a8f05, type: 2}
+          FinalRewardGold: 75
+    - label: Robar al moribundo
+      resultText: "Le arrebatas la bolsa y huyes. El objeto se hace a\xF1icos. +100
+        de oro."
+      minGoldRequired: 0
+      consequences:
+      - type: 2
+        amount: 100
+        card: {fileID: 0}
+        relic: {fileID: 0}
+        quest:
+          CarriedRelic: {fileID: 0}
+          FinalRewardGold: 0
+  worldB:
+    body: "Un robot con las piezas rotas chisporrotea en el suelo. Dice pertenecer
+      a una facci\xF3n revolucionaria y te pide llevar un disco duro con informaci\xF3n
+      vital hasta un punto lejano del mapa."
+    choices:
+    - label: Aceptar el encargo
+      resultText: El robot te transfiere un disco sellado. Un punto del mapa queda
+        resaltado.
+      minGoldRequired: 0
+      consequences:
+      - type: 6
+        amount: 0
+        card: {fileID: 0}
+        relic: {fileID: 0}
+        quest:
+          CarriedRelic: {fileID: 11400000, guid: e05e7267d08eb0e469dca14eef712352, type: 2}
+          FinalRewardGold: 75
+    - label: Robar al robot
+      resultText: "Le arrancas el disco y sus cr\xE9ditos. El disco se desintegra.
+        +100 de oro."
+      minGoldRequired: 0
+      consequences:
+      - type: 2
+        amount: 100
+        card: {fileID: 0}
+        relic: {fileID: 0}
+        quest:
+          CarriedRelic: {fileID: 0}
+          FinalRewardGold: 0

--- a/Assets/ScriptableObjects/Events/evt_md_quest_courier.asset.meta
+++ b/Assets/ScriptableObjects/Events/evt_md_quest_courier.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8b2477a4b644f1f49ae5c94e959491ba
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Events/evt_md_relic.asset
+++ b/Assets/ScriptableObjects/Events/evt_md_relic.asset
@@ -1,0 +1,95 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2319b0164a650064dac7df34b4e37e50, type: 3}
+  m_Name: evt_md_relic
+  m_EditorClassIdentifier: RoguelikeCardBattler::RoguelikeCardBattler.Run.Events.EventDefinition
+  id: evt_md_relic
+  title: El relicario sellado
+  body: Algo antiguo espera ser abierto.
+  backgroundSprite: {fileID: 0}
+  choices: []
+  isMultidimensional: 1
+  worldA:
+    body: Un relicario de hierro descansa sobre un altar agrietado. Un susurro promete
+      poder a quien se atreva a abrirlo.
+    choices:
+    - label: Romper el sello
+      resultText: "Arrancas la reliquia; las p\xFAas del relicario te hieren (-8
+        HP)."
+      minGoldRequired: 0
+      consequences:
+      - type: 5
+        amount: 0
+        card: {fileID: 0}
+        relic: {fileID: 11400000, guid: de6bce18941a74a4b9cecd63bac0b3ec, type: 2}
+        quest:
+          CarriedRelic: {fileID: 0}
+          FinalRewardGold: 0
+      - type: 4
+        amount: -8
+        card: {fileID: 0}
+        relic: {fileID: 0}
+        quest:
+          CarriedRelic: {fileID: 0}
+          FinalRewardGold: 0
+    - label: Llevarte las ofrendas
+      resultText: Recoges 30 de oro de entre las ofrendas.
+      minGoldRequired: 0
+      consequences:
+      - type: 2
+        amount: 30
+        card: {fileID: 0}
+        relic: {fileID: 0}
+        quest:
+          CarriedRelic: {fileID: 0}
+          FinalRewardGold: 0
+    - label: No arriesgarte
+      resultText: Retrocedes sin tocar el altar.
+      minGoldRequired: 0
+      consequences: []
+  worldB:
+    body: "Una c\xE1psula de contenci\xF3n parpadea en rojo. Una voz sint\xE9tica
+      ofrece su carga a quien acepte el riesgo."
+    choices:
+    - label: "Forzar la c\xE1psula"
+      resultText: "Extraes el n\xFAcleo; una descarga te recorre (-6 HP)."
+      minGoldRequired: 0
+      consequences:
+      - type: 5
+        amount: 0
+        card: {fileID: 0}
+        relic: {fileID: 11400000, guid: de6bce18941a74a4b9cecd63bac0b3ec, type: 2}
+        quest:
+          CarriedRelic: {fileID: 0}
+          FinalRewardGold: 0
+      - type: 4
+        amount: -6
+        card: {fileID: 0}
+        relic: {fileID: 0}
+        quest:
+          CarriedRelic: {fileID: 0}
+          FinalRewardGold: 0
+    - label: Vaciar la reserva
+      resultText: "Transfieres 35 cr\xE9ditos de la reserva."
+      minGoldRequired: 0
+      consequences:
+      - type: 2
+        amount: 35
+        card: {fileID: 0}
+        relic: {fileID: 0}
+        quest:
+          CarriedRelic: {fileID: 0}
+          FinalRewardGold: 0
+    - label: No arriesgarte
+      resultText: "Te apartas de la c\xE1psula parpadeante."
+      minGoldRequired: 0
+      consequences: []

--- a/Assets/ScriptableObjects/Events/evt_md_relic.asset.meta
+++ b/Assets/ScriptableObjects/Events/evt_md_relic.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e9d7266e8de9bc54191d2b587c26b5d1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Events/evt_merchant.asset
+++ b/Assets/ScriptableObjects/Events/evt_merchant.asset
@@ -25,10 +25,16 @@ MonoBehaviour:
       amount: 20
       card: {fileID: 0}
       relic: {fileID: 0}
+      quest:
+        CarriedRelic: {fileID: 0}
+        FinalRewardGold: 0
     - type: 0
       amount: 0
       card: {fileID: 11400000, guid: 3d528c055ad84181a6d0bfaae6a0c97c, type: 2}
       relic: {fileID: 0}
+      quest:
+        CarriedRelic: {fileID: 0}
+        FinalRewardGold: 0
   - label: Pedir indicaciones
     resultText: "El mercader agradece tu compa\xF1\xEDa y te da 15 de oro."
     minGoldRequired: 0
@@ -37,7 +43,17 @@ MonoBehaviour:
       amount: 15
       card: {fileID: 0}
       relic: {fileID: 0}
+      quest:
+        CarriedRelic: {fileID: 0}
+        FinalRewardGold: 0
   - label: Seguir tu camino
     resultText: "Contin\xFAas tu viaje."
     minGoldRequired: 0
     consequences: []
+  isMultidimensional: 0
+  worldA:
+    body: 
+    choices: []
+  worldB:
+    body: 
+    choices: []

--- a/Assets/ScriptableObjects/Relics/Quest.meta
+++ b/Assets/ScriptableObjects/Relics/Quest.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 787ce1419017c894f8fe7a4123968c96
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Relics/Quest/R-MCG-A_CalizDelMensajero.asset
+++ b/Assets/ScriptableObjects/Relics/Quest/R-MCG-A_CalizDelMensajero.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5e9460e14f04d5b4395c28ee75c95a52, type: 3}
+  m_Name: R-MCG-A_CalizDelMensajero
+  m_EditorClassIdentifier: RoguelikeCardBattler::RoguelikeCardBattler.Gameplay.Relics.RelicDefinition
+  DisplayName: "C\xE1liz del mensajero"
+  Description: +2 oro al ganar cada combate.
+  FlavorText: "Lacrado con cera de otra \xE9poca. Pesa como una promesa."
+  Icon: {fileID: 0}
+  Category: 2
+  Hooks: 05000000
+  Effect:
+    rid: 7516954637181124675
+  references:
+    version: 2
+    RefIds:
+    - rid: 7516954637181124675
+      type: {class: RelicEndGoldEffect, ns: RoguelikeCardBattler.Gameplay.Relics.Effects, asm: RoguelikeCardBattler}
+      data:
+        Amount: 2

--- a/Assets/ScriptableObjects/Relics/Quest/R-MCG-A_CalizDelMensajero.asset.meta
+++ b/Assets/ScriptableObjects/Relics/Quest/R-MCG-A_CalizDelMensajero.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3582e637a00dc9a44a445461492a8f05
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Relics/Quest/R-MCG-B_DiscoDeLaResistencia.asset
+++ b/Assets/ScriptableObjects/Relics/Quest/R-MCG-B_DiscoDeLaResistencia.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5e9460e14f04d5b4395c28ee75c95a52, type: 3}
+  m_Name: R-MCG-B_DiscoDeLaResistencia
+  m_EditorClassIdentifier: RoguelikeCardBattler::RoguelikeCardBattler.Gameplay.Relics.RelicDefinition
+  DisplayName: Disco de la resistencia
+  Description: +1 escudo al jugar una carta de escudo.
+  FlavorText: "Late con datos que alguien muri\xF3 por proteger."
+  Icon: {fileID: 0}
+  Category: 2
+  Hooks: 06000000
+  Effect:
+    rid: 7516954637181124676
+  references:
+    version: 2
+    RefIds:
+    - rid: 7516954637181124676
+      type: {class: RelicCardPlayedBlockEffect, ns: RoguelikeCardBattler.Gameplay.Relics.Effects, asm: RoguelikeCardBattler}
+      data:
+        Amount: 1

--- a/Assets/ScriptableObjects/Relics/Quest/R-MCG-B_DiscoDeLaResistencia.asset.meta
+++ b/Assets/ScriptableObjects/Relics/Quest/R-MCG-B_DiscoDeLaResistencia.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e05e7267d08eb0e469dca14eef712352
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Relics/Effects/RelicCardPlayedBlockEffect.cs
+++ b/Assets/Scripts/Gameplay/Relics/Effects/RelicCardPlayedBlockEffect.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq;
+using RoguelikeCardBattler.Gameplay.Cards;
+using RoguelikeCardBattler.Gameplay.Relics.Hooks;
+
+namespace RoguelikeCardBattler.Gameplay.Relics.Effects
+{
+    // MCguffin Mundo B — "Disco de la resistencia": +Amount bloqueo al jugar una carta
+    // de escudo. Pasivo incondicional al mundo (PlayedInWorld no se filtra: el mundo del
+    // evento es elección local del encuentro, no estado persistente; spec §RelicCardPlayedBlockEffect).
+    // Detección de "carta de escudo": convención del codebase = EffectType.Block en Effects.
+    [Serializable]
+    public class RelicCardPlayedBlockEffect : IRelicEffect
+    {
+        public int Amount = 1;
+
+        public void OnHook(RelicHook hook, RelicHookContext ctx)
+        {
+            if (hook != RelicHook.OnCardPlayed || ctx.TurnManager == null) return;
+            CardPlayedHookData cp = ctx as CardPlayedHookData;
+            if (cp?.Card == null) return;
+            bool isBlockCard = cp.Card.Effects.Any(e => e.effectType == EffectType.Block);
+            if (!isBlockCard) return;
+            ctx.GrantBlock(ctx.TurnManager.Player, Amount);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Relics/Effects/RelicCardPlayedBlockEffect.cs.meta
+++ b/Assets/Scripts/Gameplay/Relics/Effects/RelicCardPlayedBlockEffect.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a76cd43721394fdba0e0509332a1ee3b

--- a/Assets/Scripts/Run/Events/EventConsequence.cs
+++ b/Assets/Scripts/Run/Events/EventConsequence.cs
@@ -57,7 +57,10 @@ namespace RoguelikeCardBattler.Run.Events
         [Tooltip("Retazo para GiveRelic.")]
         [SerializeField] private RelicDefinition relic;
         [Tooltip("Payload para StartQuest (4b-2).")]
-        [SerializeReference] private QuestData quest;
+        // QuestData es una clase [Serializable] plana (no polimórfica) → SerializeField
+        // inline, consistente con card/relic arriba. Evita el acoplamiento al type-name
+        // de SerializeReference (que rompería referencias en assets si se renombra el tipo).
+        [SerializeField] private QuestData quest;
 
         public ConsequenceType Type => type;
         public int Amount => amount;

--- a/Assets/Scripts/Run/Events/EventConsequence.cs
+++ b/Assets/Scripts/Run/Events/EventConsequence.cs
@@ -11,9 +11,8 @@ namespace RoguelikeCardBattler.Run.Events
     /// aplicación vive en <see cref="EventConsequence.Apply"/> (static puro,
     /// testeable sin UI).
     ///
-    /// 4b-1 cubre las consecuencias de eventos simples. El tipo <c>StartQuest</c>
-    /// (quest/MCguffin) se AGREGA en 4b-2 al final del enum para no renumerar los
-    /// valores ya serializados.
+    /// StartQuest va AL FINAL del enum (4b-2) para no renumerar los valores ya
+    /// serializados de 4b-1.
     /// </summary>
     public enum ConsequenceType
     {
@@ -22,7 +21,23 @@ namespace RoguelikeCardBattler.Run.Events
         GiveGold,
         LoseGold,
         ModifyHP,
-        GiveRelic
+        GiveRelic,
+        StartQuest     // 4b-2 — al final del enum, no renumera los 6 anteriores
+    }
+
+    /// <summary>
+    /// Payload del tipo <see cref="ConsequenceType.StartQuest"/>: el Retazo entregado
+    /// al aceptar (pasivo durante el trayecto) y la recompensa final en oro. El nodo
+    /// destino NO se autora aquí — se resuelve en runtime por BFS forward al aceptar
+    /// (ver <c>QuestDestinationResolver</c>).
+    /// </summary>
+    [Serializable]
+    public class QuestData
+    {
+        [Tooltip("Retazo entregado al aceptar el quest (pasivo durante el trayecto).")]
+        [SerializeField] public RelicDefinition CarriedRelic;
+        [Tooltip("Oro otorgado al llegar al nodo destino.")]
+        [SerializeField] public int FinalRewardGold;
     }
 
     /// <summary>
@@ -41,11 +56,14 @@ namespace RoguelikeCardBattler.Run.Events
         [SerializeField] private CardDefinition card;
         [Tooltip("Retazo para GiveRelic.")]
         [SerializeField] private RelicDefinition relic;
+        [Tooltip("Payload para StartQuest (4b-2).")]
+        [SerializeReference] private QuestData quest;
 
         public ConsequenceType Type => type;
         public int Amount => amount;
         public CardDefinition Card => card;
         public RelicDefinition Relic => relic;
+        public QuestData Quest => quest;
 
         public EventConsequence() { }
 
@@ -53,12 +71,14 @@ namespace RoguelikeCardBattler.Run.Events
             ConsequenceType type,
             int amount = 0,
             CardDefinition card = null,
-            RelicDefinition relic = null)
+            RelicDefinition relic = null,
+            QuestData quest = null)
         {
             this.type = type;
             this.amount = amount;
             this.card = card;
             this.relic = relic;
+            this.quest = quest;
         }
 
         /// <summary>
@@ -103,6 +123,12 @@ namespace RoguelikeCardBattler.Run.Events
 
                 case ConsequenceType.GiveRelic:
                     if (c.relic != null) state.AddRelic(c.relic);
+                    break;
+
+                case ConsequenceType.StartQuest:
+                    // StartQuest NO se resuelve aquí: necesita el mapa (BFS forward)
+                    // que la firma static no tiene. Lo maneja EventNodeController al
+                    // detectar este tipo en la choice (spec §Wiring de StartQuest).
                     break;
             }
         }

--- a/Assets/Scripts/Run/Events/EventDefinition.cs
+++ b/Assets/Scripts/Run/Events/EventDefinition.cs
@@ -1,15 +1,38 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
 namespace RoguelikeCardBattler.Run.Events
 {
     /// <summary>
-    /// ScriptableObject de un encuentro de evento. 4b-1 cubre los eventos NO
-    /// multidimensionales: título + texto narrativo + lista de decisiones
-    /// (<see cref="EventChoice"/>) con consecuencias data-driven.
-    ///
-    /// Los campos de multidimensionalidad (IsMultidimensional + variantes
-    /// WorldA/WorldB) los AGREGA 4b-2; en 4b-1 todo evento usa <see cref="Choices"/>.
+    /// Variante de un evento multidimensional: enunciado (Body) y decisiones propios
+    /// del mundo. 4b-2 agrega este tipo; los eventos NO multidimensionales ignoran
+    /// WorldA/WorldB y usan el <see cref="EventDefinition.Choices"/> raíz.
+    /// </summary>
+    [Serializable]
+    public class EventVariant
+    {
+        [SerializeField, TextArea] private string body;
+        [SerializeField] private List<EventChoice> choices = new List<EventChoice>();
+
+        public string Body => body;
+        public IReadOnlyList<EventChoice> Choices => choices;
+
+#if UNITY_EDITOR || UNITY_INCLUDE_TESTS
+        public void SetData(string newBody, List<EventChoice> newChoices)
+        {
+            body = newBody;
+            choices = newChoices ?? new List<EventChoice>();
+        }
+#endif
+    }
+
+    /// <summary>
+    /// ScriptableObject de un encuentro de evento. Cubre eventos simples (4b-1) y
+    /// multidimensionales (4b-2, <see cref="IsMultidimensional"/>=true).
+    /// Los multidimensionales muestran primero una pantalla de elección de mundo (A/B)
+    /// y luego la variante correspondiente (<see cref="WorldA"/> / <see cref="WorldB"/>).
+    /// Los simples usan <see cref="Choices"/> directamente.
     /// </summary>
     [CreateAssetMenu(menuName = "Roguelike/Event Definition", fileName = "EventDefinition")]
     public class EventDefinition : ScriptableObject
@@ -21,25 +44,39 @@ namespace RoguelikeCardBattler.Run.Events
         [SerializeField] private Sprite backgroundSprite;
         [SerializeField] private List<EventChoice> choices = new List<EventChoice>();
 
+        [Header("Multidimensional (4b-2)")]
+        [SerializeField] private bool isMultidimensional;
+        [SerializeField] private EventVariant worldA = new EventVariant();
+        [SerializeField] private EventVariant worldB = new EventVariant();
+
         public string Id => id;
         public string Title => title;
         public string Body => body;
         public Sprite BackgroundSprite => backgroundSprite;
         public IReadOnlyList<EventChoice> Choices => choices;
+        public bool IsMultidimensional => isMultidimensional;
+        public EventVariant WorldA => worldA;
+        public EventVariant WorldB => worldB;
 
 #if UNITY_EDITOR || UNITY_INCLUDE_TESTS
         /// <summary>
         /// Setter para tests EditMode y para el tooling editor (EventConfigSetup),
-        /// mismo patrón que <c>CardDefinition.SetDebugData</c>. Permite armar un
-        /// EventDefinition sin asset en disco.
+        /// mismo patrón que <c>CardDefinition.SetDebugData</c>. Los parámetros de
+        /// multidimensionalidad son opcionales (defecto = evento simple).
         /// </summary>
-        public void SetDebugData(string newId, string newTitle, string newBody, List<EventChoice> newChoices, Sprite newBackground = null)
+        public void SetDebugData(
+            string newId, string newTitle, string newBody, List<EventChoice> newChoices,
+            Sprite newBackground = null,
+            bool multidim = false, EventVariant newWorldA = null, EventVariant newWorldB = null)
         {
             id = newId;
             title = newTitle;
             body = newBody;
             choices = newChoices ?? new List<EventChoice>();
             backgroundSprite = newBackground;
+            isMultidimensional = multidim;
+            worldA = newWorldA ?? new EventVariant();
+            worldB = newWorldB ?? new EventVariant();
         }
 #endif
     }

--- a/Assets/Scripts/Run/Events/EventNodeController.cs
+++ b/Assets/Scripts/Run/Events/EventNodeController.cs
@@ -5,31 +5,35 @@ using UnityEngine;
 using UnityEngine.UI;
 using RoguelikeCardBattler.Gameplay.Cards;
 using RoguelikeCardBattler.Gameplay.Relics;
+using RoguelikeCardBattler.Run.Quests;
 
 namespace RoguelikeCardBattler.Run.Events
 {
     /// <summary>
-    /// Controlador del nodo Event (4b-1, eventos NO multidimensionales).
-    /// RunFlowController lo crea como hijo en runtime (no requiere setup manual).
-    /// Construye un panel sobre el canvas del run: título + texto narrativo +
-    /// botones de decisión; al elegir aplica las consecuencias y muestra un panel
-    /// de resultado con "Continuar". Espejo estructural de
-    /// <c>CampfireNodeController</c> / <c>ShopNodeController</c> (panel runtime,
-    /// fallback de color sin arte, ClearSpawnedButtons).
+    /// Controlador del nodo Event. Maneja eventos simples (4b-1) y multidimensionales
+    /// (4b-2). RunFlowController lo crea como hijo en runtime (no requiere setup manual).
     ///
-    /// La lógica de consecuencias vive en <see cref="EventConsequence.Apply"/>
-    /// (static puro, testeable sin UI); este controller sólo orquesta la UI.
+    /// Flujo multidimensional: Show → pantalla de elección de mundo (A/B) → variante
+    /// elegida (Body + Choices) → resultado → Continuar. La pantalla de mundo solo
+    /// aparece si <see cref="EventDefinition.IsMultidimensional"/>=true.
+    ///
+    /// StartQuest: al elegir una choice con consecuencia StartQuest, el controller
+    /// resuelve el destino via BFS (<see cref="QuestDestinationResolver"/>) y muestra
+    /// un resultText especial. Apply() no lo maneja porque necesita el mapa.
+    ///
+    /// Espejo estructural de <c>CampfireNodeController</c> (panel runtime, fallback
+    /// de color sin arte, ClearSpawnedButtons).
     /// </summary>
     public class EventNodeController : MonoBehaviour
     {
-        // Color de fallback cuando no hay sprite de fondo: tono morado oscuro que
-        // diferencia el evento de la Hoguera (azul) y la Tienda (marrón).
+        // Color de fallback cuando no hay sprite de fondo
         private static readonly Color FallbackBackground = new Color(0.14f, 0.10f, 0.18f, 1f); // #241A2E
 
         private Canvas _canvas;
         private RunState _state;
         private RelicHookDispatcher _dispatcher;
         private EventPoolConfig _pool;
+        private ActMap _map;
         private Action<int> _onComplete;
         private Font _uiFont;
 
@@ -37,6 +41,7 @@ namespace RoguelikeCardBattler.Run.Events
         private Image _background;
         private Text _titleText;
         private Text _bodyText;
+        private RectTransform _worldChoicePanel;  // pantalla de selección A/B (multidim)
         private RectTransform _choicesPanel;
         private RectTransform _resultPanel;
         private Text _resultText;
@@ -44,6 +49,7 @@ namespace RoguelikeCardBattler.Run.Events
 
         private int _activeNodeId = -1;
         private EventDefinition _activeDef;
+        private int _chosenWorld = -1;  // 0=A / 1=B / -1=no aplica o sin elegir
         private static Sprite _whiteSprite;
 
         public void Initialize(
@@ -51,12 +57,14 @@ namespace RoguelikeCardBattler.Run.Events
             RunState state,
             RelicHookDispatcher dispatcher,
             EventPoolConfig pool,
+            ActMap map,
             Action<int> onComplete)
         {
             _canvas = canvas;
             _state = state;
             _dispatcher = dispatcher;
             _pool = pool;
+            _map = map;
             _onComplete = onComplete;
             _uiFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
 
@@ -66,10 +74,8 @@ namespace RoguelikeCardBattler.Run.Events
 
         /// <summary>
         /// Abre el panel para el evento <paramref name="definition"/> del nodo
-        /// <paramref name="nodeId"/>. La definición viaja desde
-        /// <c>MapNode.AssignedEvent</c> (fijada por seed en la generación del mapa);
-        /// el controller no tiene referencia al mapa, así que RunFlowController la
-        /// pasa. Si la definición es nula, el caller hace fallback al panel genérico.
+        /// <paramref name="nodeId"/>. Si el evento es multidimensional, muestra
+        /// primero la pantalla de elección de mundo.
         /// </summary>
         public void Show(int nodeId, EventDefinition definition)
         {
@@ -77,23 +83,64 @@ namespace RoguelikeCardBattler.Run.Events
 
             _activeNodeId = nodeId;
             _activeDef = definition;
+            _chosenWorld = -1;
 
             _root.gameObject.SetActive(true);
             _root.SetAsLastSibling();
             _resultPanel.gameObject.SetActive(false);
-            _choicesPanel.gameObject.SetActive(true);
+            _choicesPanel.gameObject.SetActive(false);
+            _worldChoicePanel.gameObject.SetActive(false);
 
             ApplyBackground(definition);
             _titleText.text = string.IsNullOrEmpty(definition.Title) ? "Evento" : definition.Title;
-            _bodyText.text = definition.Body ?? string.Empty;
 
-            BuildChoices();
+            if (definition.IsMultidimensional)
+            {
+                ShowWorldChoiceScreen();
+            }
+            else
+            {
+                _bodyText.text = definition.Body ?? string.Empty;
+                _choicesPanel.gameObject.SetActive(true);
+                BuildChoicesFromList(definition.Choices);
+            }
         }
 
-        /// <summary>
-        /// Resuelve el fondo del panel para el evento: sprite del propio
-        /// EventDefinition → sprite del pool (fallback compartido) → color de fallback.
-        /// </summary>
+        // ──────────────────────────────────────────────
+        // Pantalla de elección de mundo (multidimensional)
+        // ──────────────────────────────────────────────
+
+        private void ShowWorldChoiceScreen()
+        {
+            ClearSpawnedButtons();
+            _bodyText.text = "Elige en qué versión del mundo transcurre este encuentro.";
+            _worldChoicePanel.gameObject.SetActive(true);
+
+            Button btnA = CreateButtonRaw(_worldChoicePanel, "WorldA", "Mundo A\n(medieval)", 0.05f, 0.35f, 0.45f, 0.65f, true);
+            btnA.onClick.AddListener(() => OnWorldChosen(0));
+            _spawnedButtons.Add(btnA.gameObject);
+
+            Button btnB = CreateButtonRaw(_worldChoicePanel, "WorldB", "Mundo B\n(futurista)", 0.55f, 0.35f, 0.95f, 0.65f, true);
+            btnB.onClick.AddListener(() => OnWorldChosen(1));
+            _spawnedButtons.Add(btnB.gameObject);
+        }
+
+        private void OnWorldChosen(int world)
+        {
+            _chosenWorld = world;
+            _worldChoicePanel.gameObject.SetActive(false);
+            ClearSpawnedButtons();
+
+            EventVariant variant = EventResolver.ResolveVariantFull(_activeDef, world);
+            _bodyText.text = variant?.Body ?? (_activeDef.Body ?? string.Empty);
+            _choicesPanel.gameObject.SetActive(true);
+            BuildChoicesFromList(variant?.Choices);
+        }
+
+        // ──────────────────────────────────────────────
+        // Fondo
+        // ──────────────────────────────────────────────
+
         private void ApplyBackground(EventDefinition definition)
         {
             if (_background == null) return;
@@ -113,11 +160,10 @@ namespace RoguelikeCardBattler.Run.Events
             }
         }
 
-        /// <summary>
-        /// Una decisión está disponible si el jugador alcanza su requisito de oro.
-        /// Static y sin UI para que los tests lo validen sin instanciar el panel
-        /// (la UI sólo lo consume para deshabilitar el botón).
-        /// </summary>
+        // ──────────────────────────────────────────────
+        // Gate de disponibilidad de choices (static, testeable sin UI)
+        // ──────────────────────────────────────────────
+
         public static bool IsChoiceAvailable(RunState state, EventChoice choice)
         {
             if (state == null || choice == null) return false;
@@ -128,23 +174,19 @@ namespace RoguelikeCardBattler.Run.Events
         // Choices flow
         // ──────────────────────────────────────────────
 
-        private void BuildChoices()
+        private void BuildChoicesFromList(IReadOnlyList<EventChoice> choices)
         {
             ClearSpawnedButtons();
 
-            IReadOnlyList<EventChoice> choices = _activeDef.Choices;
             int count = choices != null ? choices.Count : 0;
             if (count == 0)
             {
-                // Evento sin decisiones autoradas: ofrecer salida para no bloquear.
                 Button leave = CreateButtonRaw(_choicesPanel, "Continue", "Continuar", 0.3f, 0.04f, 0.7f, 0.14f, true);
                 leave.onClick.AddListener(CompleteEvent);
                 _spawnedButtons.Add(leave.gameObject);
                 return;
             }
 
-            // Reparto vertical adaptativo en la franja inferior del panel (el texto
-            // narrativo vive arriba). Mismo enfoque que ShopNodeController.DrawStock.
             const float top = 0.62f;
             const float bottom = 0.04f;
             const float gap = 0.02f;
@@ -174,17 +216,47 @@ namespace RoguelikeCardBattler.Run.Events
         {
             if (choice == null) return;
 
-            // Aplicar todas las consecuencias en orden (los GiveRelic respetan el
-            // AcquisitionOrder por orden de la lista).
             if (choice.Consequences != null)
             {
                 foreach (EventConsequence consequence in choice.Consequences)
                 {
-                    EventConsequence.Apply(_state, _dispatcher, consequence);
+                    if (consequence == null) continue;
+                    if (consequence.Type == ConsequenceType.StartQuest)
+                    {
+                        HandleStartQuest(consequence);
+                    }
+                    else
+                    {
+                        EventConsequence.Apply(_state, _dispatcher, consequence);
+                    }
                 }
             }
 
             ShowResult(choice.ResultText);
+        }
+
+        /// <summary>
+        /// Resuelve el destino del quest via BFS, entrega el Retazo MCguffin y activa
+        /// el quest en RunState. No pasa por Apply() porque necesita el mapa.
+        /// </summary>
+        private void HandleStartQuest(EventConsequence consequence)
+        {
+            if (consequence?.Quest == null) return;
+            QuestData questData = consequence.Quest;
+
+            int dest = QuestDestinationResolver.SelectDestination(_map, _activeNodeId, _state.CompletedNodes);
+
+            if (questData.CarriedRelic != null)
+                _state.AddRelic(questData.CarriedRelic);
+
+            string worldLabel = _chosenWorld == 0 ? "A" : (_chosenWorld == 1 ? "B" : "?");
+            _state.StartQuest(new QuestState
+            {
+                Active = true,
+                DestinationNodeId = dest,
+                FinalRewardGold = questData.FinalRewardGold,
+                SourceWorldLabel = worldLabel
+            });
         }
 
         private void ShowResult(string resultText)
@@ -206,11 +278,12 @@ namespace RoguelikeCardBattler.Run.Events
             int nodeId = _activeNodeId;
             _activeNodeId = -1;
             _activeDef = null;
+            _chosenWorld = -1;
             _onComplete?.Invoke(nodeId);
         }
 
         // ──────────────────────────────────────────────
-        // Label building (reusa CardDisplay para tokens de carta)
+        // Labels (reusa CardDisplay para tokens de carta)
         // ──────────────────────────────────────────────
 
         private string BuildChoiceLabel(EventChoice choice, bool affordable)
@@ -219,17 +292,11 @@ namespace RoguelikeCardBattler.Run.Events
             string summary = BuildConsequenceSummary(choice.Consequences);
 
             if (!affordable && choice.MinGoldRequired > 0)
-            {
                 return $"{title} (necesitas {choice.MinGoldRequired} oro)";
-            }
+
             return string.IsNullOrEmpty(summary) ? title : $"{title}\n<{summary}>";
         }
 
-        /// <summary>
-        /// Resumen legible de las consecuencias para mostrar bajo la etiqueta de la
-        /// decisión. Reusa <c>CardDisplay.CardToken</c> para los tokens de carta
-        /// (tipo coloreado) en vez de duplicar el helper.
-        /// </summary>
         private static string BuildConsequenceSummary(IReadOnlyList<EventConsequence> consequences)
         {
             if (consequences == null || consequences.Count == 0) return string.Empty;
@@ -261,6 +328,9 @@ namespace RoguelikeCardBattler.Run.Events
                             : (string.IsNullOrEmpty(c.Relic.DisplayName) ? c.Relic.name : c.Relic.DisplayName);
                         parts.Add($"+Retazo: {relicName}");
                         break;
+                    case ConsequenceType.StartQuest:
+                        parts.Add("+Quest (pasivo)");
+                        break;
                 }
             }
 
@@ -289,10 +359,10 @@ namespace RoguelikeCardBattler.Run.Events
 
             Image rootImage = rootGo.GetComponent<Image>();
             rootImage.sprite = GetWhiteSprite();
-            rootImage.color = new Color(0f, 0f, 0f, 1f); // tapa el canvas detrás
+            rootImage.color = new Color(0f, 0f, 0f, 1f);
             rootImage.raycastTarget = true;
 
-            // Capa de fondo: sprite del pool si existe, si no color de fallback.
+            // Capa de fondo
             GameObject bgGo = new GameObject("Background", typeof(RectTransform), typeof(Image));
             bgGo.transform.SetParent(_root, false);
             RectTransform bgRect = bgGo.GetComponent<RectTransform>();
@@ -301,8 +371,6 @@ namespace RoguelikeCardBattler.Run.Events
             bgRect.offsetMin = Vector2.zero;
             bgRect.offsetMax = Vector2.zero;
             _background = bgGo.GetComponent<Image>();
-            // Fondo inicial = color de fallback. El sprite real se resuelve por-evento
-            // en Show (cada EventDefinition puede traer el suyo).
             _background.sprite = GetWhiteSprite();
             _background.color = FallbackBackground;
             _background.raycastTarget = false;
@@ -319,6 +387,12 @@ namespace RoguelikeCardBattler.Run.Events
             RectTransform bodyRect = _bodyText.GetComponent<RectTransform>();
             bodyRect.anchorMin = new Vector2(0.12f, 0.66f);
             bodyRect.anchorMax = new Vector2(0.88f, 0.84f);
+
+            // Panel de selección de mundo (multidimensional, inicialmente oculto)
+            _worldChoicePanel = CreateSubPanel("WorldChoicePanel", _root);
+            _worldChoicePanel.anchorMin = new Vector2(0.05f, 0.15f);
+            _worldChoicePanel.anchorMax = new Vector2(0.95f, 0.64f);
+            _worldChoicePanel.gameObject.SetActive(false);
 
             // Panel de decisiones
             _choicesPanel = CreateSubPanel("ChoicesPanel", _root);
@@ -348,7 +422,8 @@ namespace RoguelikeCardBattler.Run.Events
             return rect;
         }
 
-        private Button CreateButtonRaw(RectTransform parent, string name, string label, float xMin, float yMin, float xMax, float yMax, bool interactable)
+        private Button CreateButtonRaw(RectTransform parent, string name, string label,
+            float xMin, float yMin, float xMax, float yMax, bool interactable)
         {
             GameObject buttonGO = new GameObject(name, typeof(RectTransform), typeof(Image), typeof(Button));
             buttonGO.transform.SetParent(parent, false);

--- a/Assets/Scripts/Run/Events/EventResolver.cs
+++ b/Assets/Scripts/Run/Events/EventResolver.cs
@@ -1,10 +1,10 @@
+using System.Collections.Generic;
+
 namespace RoguelikeCardBattler.Run.Events
 {
     /// <summary>
-    /// Selección determinista de eventos por nodo. Static y sin UI (testeable):
-    /// la misma seed fija el evento de cada nodo al generar el mapa (mismo patrón
-    /// que <c>RunMapGenerator.AssignEnemies</c>), una seed distinta produce otra
-    /// distribución.
+    /// Selección determinista de eventos por nodo y resolución de variantes
+    /// multidimensionales. Static y sin UI (testeable).
     /// </summary>
     public static class EventResolver
     {
@@ -27,6 +27,29 @@ namespace RoguelikeCardBattler.Run.Events
             System.Random rng = new System.Random(combined);
             int index = rng.Next(events.Count);
             return events[index];
+        }
+
+        /// <summary>
+        /// Devuelve las choices de la variante elegida para un evento multidimensional.
+        /// <paramref name="world"/> 0=A / 1=B. Si la definición no es multidimensional o
+        /// es null, devuelve las Choices raíz del EventDefinition.
+        /// </summary>
+        public static IReadOnlyList<EventChoice> ResolveVariant(EventDefinition def, int world)
+        {
+            if (def == null) return null;
+            if (!def.IsMultidimensional) return def.Choices;
+            EventVariant variant = world == 0 ? def.WorldA : def.WorldB;
+            return variant?.Choices;
+        }
+
+        /// <summary>
+        /// Devuelve la variante completa (Body + Choices) para un evento multidimensional.
+        /// Null si la definición no es multidimensional.
+        /// </summary>
+        public static EventVariant ResolveVariantFull(EventDefinition def, int world)
+        {
+            if (def == null || !def.IsMultidimensional) return null;
+            return world == 0 ? def.WorldA : def.WorldB;
         }
     }
 }

--- a/Assets/Scripts/Run/Map/UI/RunMapNodeView.cs
+++ b/Assets/Scripts/Run/Map/UI/RunMapNodeView.cs
@@ -19,6 +19,8 @@ namespace RoguelikeCardBattler.Run
         private static readonly Color CompletedBg = new Color(0.2f, 0.45f, 0.25f, 1f);
         private static readonly Color BossAvailableBg = new Color(0.55f, 0.12f, 0.12f, 1f);
         private static readonly Color BossLockedBg = new Color(0.3f, 0.1f, 0.1f, 0.6f);
+        // Color ámbar para nodo destino del quest activo (diferenciado de Available=azul)
+        private static readonly Color QuestDestBg = new Color(0.70f, 0.52f, 0.08f, 1f);
 
         public int NodeId { get; }
         public NodeType Type { get; }
@@ -30,6 +32,7 @@ namespace RoguelikeCardBattler.Run
         private readonly Text _label;
         private readonly CanvasGroup _canvasGroup;
         private bool _entrancePlaying;
+        private bool _questHighlighted;
 
         public RunMapNodeView(int nodeId, NodeType type, RectTransform parent,
             Vector2 position, Vector2 size, Font font, Sprite whiteSprite,
@@ -117,6 +120,16 @@ namespace RoguelikeCardBattler.Run
                 return;
             }
 
+            // Quest destination: ámbar pulsante sobre el estado normal.
+            // Solo si no está completado (completar = verde con punch, más informativo).
+            if (_questHighlighted && state != NodeState.Completed)
+            {
+                _bgImage.color = QuestDestBg;
+                UIAnimationHelper.StopPulse(Rect);
+                UIAnimationHelper.PulseLoop(Rect, 1.10f, 0.6f);
+                return;
+            }
+
             if (previous == NodeState.Available && state == NodeState.Completed)
             {
                 UIAnimationHelper.StopPulse(Rect);
@@ -130,6 +143,17 @@ namespace RoguelikeCardBattler.Run
             {
                 UIAnimationHelper.StopPulse(Rect);
             }
+        }
+
+        /// <summary>
+        /// Marca o desmarca el nodo como destino del quest activo (ámbar pulsante).
+        /// El Refresh del mapa llama esto cada vez que vuelve al mapa.
+        /// </summary>
+        public void SetQuestHighlight(bool highlight)
+        {
+            _questHighlighted = highlight;
+            // Re-aplicar estado para que el color y animación se actualicen.
+            if (!_entrancePlaying) ApplyState(CurrentState);
         }
 
         /// <summary>

--- a/Assets/Scripts/Run/Map/UI/RunMapView.cs
+++ b/Assets/Scripts/Run/Map/UI/RunMapView.cs
@@ -127,6 +127,11 @@ namespace RoguelikeCardBattler.Run
         /// </summary>
         public void Refresh(RunState state)
         {
+            // Id del nodo destino del quest activo (-1 si no hay quest).
+            int questDestId = (state.ActiveQuest != null && state.ActiveQuest.Active)
+                ? state.ActiveQuest.DestinationNodeId
+                : -1;
+
             foreach (KeyValuePair<int, RunMapNodeView> kvp in _nodeViews)
             {
                 NodeState newState;
@@ -156,6 +161,10 @@ namespace RoguelikeCardBattler.Run
                         }
                     }
                 }
+
+                // Resaltar nodo destino del quest (ámbar pulsante, persistente entre
+                // redibujos hasta que CompleteQuestIfDestination desactiva ActiveQuest).
+                kvp.Value.SetQuestHighlight(kvp.Key == questDestId);
             }
         }
 

--- a/Assets/Scripts/Run/Quests.meta
+++ b/Assets/Scripts/Run/Quests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 75d671bcb0fc4908aeef8773e15b9d20
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Run/Quests/QuestDestinationResolver.cs
+++ b/Assets/Scripts/Run/Quests/QuestDestinationResolver.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+
+namespace RoguelikeCardBattler.Run.Quests
+{
+    /// <summary>
+    /// Resuelve el nodo destino del quest mediante BFS forward desde el nodo del evento.
+    /// Static puro (testeable sin UI). Golden Rule §7: RunState no calcula BFS.
+    ///
+    /// Regla de selección (spec §Resolución del nodo destino):
+    ///   1. BFS forward desde questNodeId por MapNode.Connections.
+    ///   2. Candidatos = alcanzables, != questNodeId, ∉ completedNodes, tipo != Boss.
+    ///   3. Preferido: mayor forwardDepth; desempate = menor Id (determinista, sin RNG).
+    ///   4. Fallback (sin candidatos): el Boss, siempre alcanzable por construcción.
+    /// </summary>
+    public static class QuestDestinationResolver
+    {
+        public static int SelectDestination(ActMap map, int questNodeId, ISet<int> completedNodes)
+        {
+            if (map == null) return -1;
+
+            // BFS forward desde questNodeId
+            var forwardDepth = new Dictionary<int, int>();
+            var queue = new Queue<int>();
+            forwardDepth[questNodeId] = 0;
+            queue.Enqueue(questNodeId);
+
+            while (queue.Count > 0)
+            {
+                int current = queue.Dequeue();
+                MapNode node = map.GetNode(current);
+                if (node == null) continue;
+                int nextDepth = forwardDepth[current] + 1;
+                foreach (int conn in node.Connections)
+                {
+                    if (!forwardDepth.ContainsKey(conn))
+                    {
+                        forwardDepth[conn] = nextDepth;
+                        queue.Enqueue(conn);
+                    }
+                }
+            }
+
+            // Candidatos: alcanzables, != questNodeId, no completados, no Boss
+            int bestId = -1;
+            int bestDepth = -1;
+            foreach (KeyValuePair<int, int> kvp in forwardDepth)
+            {
+                int nodeId = kvp.Key;
+                int depth = kvp.Value;
+                if (nodeId == questNodeId) continue;
+                if (completedNodes != null && completedNodes.Contains(nodeId)) continue;
+                MapNode candidate = map.GetNode(nodeId);
+                if (candidate == null || candidate.Type == NodeType.Boss) continue;
+
+                // Preferir el más lejano (mayor depth); desempatar por menor Id
+                if (depth > bestDepth || (depth == bestDepth && (bestId < 0 || nodeId < bestId)))
+                {
+                    bestDepth = depth;
+                    bestId = nodeId;
+                }
+            }
+
+            // Fallback al Boss (siempre alcanzable)
+            if (bestId < 0)
+            {
+                foreach (MapNode node in map.Nodes)
+                {
+                    if (node.Type == NodeType.Boss) return node.Id;
+                }
+                return 7; // convención del proyecto: nodo 7 = Boss/end
+            }
+
+            return bestId;
+        }
+    }
+}

--- a/Assets/Scripts/Run/Quests/QuestDestinationResolver.cs.meta
+++ b/Assets/Scripts/Run/Quests/QuestDestinationResolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eede0eba58e44075b42e89c712b7745b

--- a/Assets/Scripts/Run/Quests/QuestState.cs
+++ b/Assets/Scripts/Run/Quests/QuestState.cs
@@ -1,0 +1,19 @@
+namespace RoguelikeCardBattler.Run.Quests
+{
+    /// <summary>
+    /// Estado runtime del quest activo en el run. Solo datos — la BFS de resolución
+    /// del destino vive en <see cref="QuestDestinationResolver"/> (Golden Rule §7:
+    /// RunState = solo datos). Reset en <c>RunState.Reset</c>.
+    /// </summary>
+    public class QuestState
+    {
+        public bool Active { get; set; }
+        // Id del nodo que el jugador debe alcanzar para completar el quest.
+        // Resuelto en runtime al aceptar (no autorado en el SO), garantizado alcanzable
+        // por BFS forward. -1 = sin quest activo.
+        public int DestinationNodeId { get; set; } = -1;
+        public int FinalRewardGold { get; set; }
+        // "A" o "B" según el mundo elegido al aceptar el quest (flavor para el mapa).
+        public string SourceWorldLabel { get; set; }
+    }
+}

--- a/Assets/Scripts/Run/Quests/QuestState.cs.meta
+++ b/Assets/Scripts/Run/Quests/QuestState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6f92efa7d1704a13af8165b6822f8616

--- a/Assets/Scripts/Run/RunFlowController.cs
+++ b/Assets/Scripts/Run/RunFlowController.cs
@@ -189,11 +189,9 @@ namespace RoguelikeCardBattler.Run
             go.transform.SetParent(transform, false);
             _eventController = go.AddComponent<EventNodeController>();
             RunSession session = RunSession.GetOrCreate();
-            // El pool vive en RunSession (lo usa también la generación del mapa) →
-            // fuente única, sin doble cableado en el inspector. Aquí sólo lo lee para
-            // el fondo del panel; el evento concreto de cada nodo viaja en
-            // MapNode.AssignedEvent.
-            _eventController.Initialize(_canvas, _state, session.RelicDispatcher, session.EventPoolConfig, OnEventComplete);
+            // _map se pasa para que el controller resuelva el destino del quest via
+            // QuestDestinationResolver.SelectDestination (necesita el grafo de nodos).
+            _eventController.Initialize(_canvas, _state, session.RelicDispatcher, session.EventPoolConfig, _map, OnEventComplete);
         }
 
         private void EnsureEventSystem()
@@ -507,6 +505,11 @@ namespace RoguelikeCardBattler.Run
             {
                 return;
             }
+
+            // Si este nodo es el destino del quest activo, otorga FinalRewardGold
+            // y desactiva el quest (RunState.CompleteQuestIfDestination). El refresh
+            // visual del mapa ocurre en ShowMap() que sigue al CompleteNode.
+            _state.CompleteQuestIfDestination(nodeId);
 
             _state.CompletedNodes.Add(nodeId);
             _state.AvailableNodes.Clear();

--- a/Assets/Scripts/Run/RunState.cs
+++ b/Assets/Scripts/Run/RunState.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using RoguelikeCardBattler.Gameplay.Cards;
 using RoguelikeCardBattler.Gameplay.Combat;
 using RoguelikeCardBattler.Gameplay.Relics;
+using RoguelikeCardBattler.Run.Quests;
 
 namespace RoguelikeCardBattler.Run
 {
@@ -57,6 +58,32 @@ namespace RoguelikeCardBattler.Run
         // de cada instance (asc = adquirido primero = corre primero en cadena).
         public List<RelicInstance> Relics { get; } = new List<RelicInstance>();
 
+        // Quest activo del run (MCguffin). Solo datos: la BFS de resolución del
+        // destino vive en QuestDestinationResolver (Golden Rule §7). Reset en Reset().
+        public QuestState ActiveQuest { get; private set; } = new QuestState();
+
+        /// <summary>
+        /// Activa el quest. El <paramref name="quest"/> ya tiene el DestinationNodeId
+        /// resuelto por el caller (QuestDestinationResolver); RunState solo almacena.
+        /// </summary>
+        public void StartQuest(QuestState quest)
+        {
+            ActiveQuest = quest ?? new QuestState();
+        }
+
+        /// <summary>
+        /// Si <paramref name="nodeId"/> es el nodo destino del quest activo, otorga
+        /// FinalRewardGold, desactiva el quest y devuelve true. De lo contrario false.
+        /// </summary>
+        public bool CompleteQuestIfDestination(int nodeId)
+        {
+            if (ActiveQuest == null || !ActiveQuest.Active) return false;
+            if (ActiveQuest.DestinationNodeId != nodeId) return false;
+            Gold += ActiveQuest.FinalRewardGold;
+            ActiveQuest.Active = false;
+            return true;
+        }
+
         /// <summary>
         /// Helper para sumar un Retazo al run respetando la convención de
         /// AcquisitionOrder (orden de la lista). Lo usan drops post-victoria
@@ -106,6 +133,7 @@ namespace RoguelikeCardBattler.Run
             PlayerWorldBType = ElementType.Amarillo;
             PendingStarterCard = null;
             Relics.Clear();
+            ActiveQuest = new QuestState();
             EnsureInitialized(map);
         }
 

--- a/Assets/Tests/EditMode/QuestTests.cs
+++ b/Assets/Tests/EditMode/QuestTests.cs
@@ -1,0 +1,354 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using RoguelikeCardBattler.Run;
+using RoguelikeCardBattler.Run.Events;
+using RoguelikeCardBattler.Run.Quests;
+using RoguelikeCardBattler.Gameplay.Relics;
+using RoguelikeCardBattler.Gameplay.Relics.Effects;
+using RoguelikeCardBattler.Gameplay.Relics.Hooks;
+using RoguelikeCardBattler.Gameplay.Cards;
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Gameplay.Enemies;
+
+namespace RoguelikeCardBattler.Tests.EditMode
+{
+    /// <summary>
+    /// Casos 8-16 del spec M4 4b-2 (QuestTests).
+    /// </summary>
+    public class QuestTests : CombatTestBase
+    {
+        // ──────────────────────────────────────────────
+        // Helpers de construcción de mapas (topologías del proyecto)
+        // ──────────────────────────────────────────────
+
+        // Topo A: 0→(1,2)→3→(4,5)→6→7
+        private static ActMap BuildTopoA()
+        {
+            var map = new ActMap(0);
+            for (int i = 0; i < 8; i++)
+                map.Nodes.Add(new MapNode(i, i == 7 ? NodeType.Boss : NodeType.Event));
+            map.GetNode(0).Connections.AddRange(new[] { 1, 2 });
+            map.GetNode(1).Connections.Add(3);
+            map.GetNode(2).Connections.Add(3);
+            map.GetNode(3).Connections.AddRange(new[] { 4, 5 });
+            map.GetNode(4).Connections.Add(6);
+            map.GetNode(5).Connections.Add(6);
+            map.GetNode(6).Connections.Add(7);
+            return map;
+        }
+
+        // Topo B: 0→1→(2,3)→4→(5,6)→7
+        private static ActMap BuildTopoB()
+        {
+            var map = new ActMap(0);
+            for (int i = 0; i < 8; i++)
+                map.Nodes.Add(new MapNode(i, i == 7 ? NodeType.Boss : NodeType.Event));
+            map.GetNode(0).Connections.Add(1);
+            map.GetNode(1).Connections.AddRange(new[] { 2, 3 });
+            map.GetNode(2).Connections.Add(4);
+            map.GetNode(3).Connections.Add(4);
+            map.GetNode(4).Connections.AddRange(new[] { 5, 6 });
+            map.GetNode(5).Connections.Add(7);
+            map.GetNode(6).Connections.Add(7);
+            return map;
+        }
+
+        // Topo C: 0→(1,2,3), 1→4, 2→4, 3→5, 4→6, 5→6, 6→7
+        private static ActMap BuildTopoC()
+        {
+            var map = new ActMap(0);
+            for (int i = 0; i < 8; i++)
+                map.Nodes.Add(new MapNode(i, i == 7 ? NodeType.Boss : NodeType.Event));
+            map.GetNode(0).Connections.AddRange(new[] { 1, 2, 3 });
+            map.GetNode(1).Connections.Add(4);
+            map.GetNode(2).Connections.Add(4);
+            map.GetNode(3).Connections.Add(5);
+            map.GetNode(4).Connections.Add(6);
+            map.GetNode(5).Connections.Add(6);
+            map.GetNode(6).Connections.Add(7);
+            return map;
+        }
+
+        private static bool IsForwardReachable(ActMap map, int from, int target)
+        {
+            var visited = new HashSet<int>();
+            var queue = new Queue<int>();
+            queue.Enqueue(from);
+            while (queue.Count > 0)
+            {
+                int cur = queue.Dequeue();
+                if (cur == target) return true;
+                if (!visited.Add(cur)) continue;
+                var node = map.GetNode(cur);
+                if (node == null) continue;
+                foreach (int conn in node.Connections) queue.Enqueue(conn);
+            }
+            return false;
+        }
+
+        private TurnManager CreateManager()
+        {
+            var enemy = CreateEnemyDefinition("dummy", "Dummy", 30,
+                EnemyAIPattern.Sequence, new List<EnemyMove>(), ElementType.None);
+            var card = CreateCard("card0", CardType.Attack, CardTarget.SingleEnemy, 1,
+                new EffectRef { effectType = EffectType.Damage, value = 5, target = EffectTarget.SingleEnemy });
+            var deck = new List<CardDeckEntry> { CreateSingleCardEntry(card) };
+
+            GameObject go = CreateGameObject("TurnManager");
+            TurnManager manager = AddComponent<TurnManager>(go);
+            manager.SetTestConfig(30, 3, 1, 1);
+            manager.ConfigureCombat(deck, enemy,
+                playerCurrentHpOverride: 30,
+                playerMaxHpOverride: 30,
+                initializeImmediately: true);
+            return manager;
+        }
+
+        // ──────────────────────────────────────────────
+        // Caso 8: ResolveVariant devuelve choices distintas para A vs B
+        // ──────────────────────────────────────────────
+
+        [Test]
+        public void Test08_ResolveVariant_ReturnsDifferentChoicesForAAndB()
+        {
+            var choiceA = new EventChoice("ChoiceA", "ResultA", new List<EventConsequence>());
+            var choiceB = new EventChoice("ChoiceB", "ResultB", new List<EventConsequence>());
+
+            var varA = new EventVariant();
+            varA.SetData("Texto mundo A", new List<EventChoice> { choiceA });
+            var varB = new EventVariant();
+            varB.SetData("Texto mundo B", new List<EventChoice> { choiceB });
+
+            EventDefinition def = ScriptableObject.CreateInstance<EventDefinition>();
+            def.SetDebugData("test_md", "Test", "body", null,
+                multidim: true, newWorldA: varA, newWorldB: varB);
+
+            var choicesA = EventResolver.ResolveVariant(def, 0);
+            var choicesB = EventResolver.ResolveVariant(def, 1);
+
+            Assert.IsNotNull(choicesA, "Choices A no deben ser null");
+            Assert.IsNotNull(choicesB, "Choices B no deben ser null");
+            Assert.AreEqual("ChoiceA", choicesA[0].Label, "Mundo A debe tener ChoiceA");
+            Assert.AreEqual("ChoiceB", choicesB[0].Label, "Mundo B debe tener ChoiceB");
+            Assert.AreNotEqual(choicesA[0].Label, choicesB[0].Label, "A y B deben ser distintos");
+
+            Object.DestroyImmediate(def);
+        }
+
+        // ──────────────────────────────────────────────
+        // Caso 9: SelectDestination — alcanzable, != questNodeId, ∉ completedNodes
+        //         para todas las topologías × nodos intermedios 1..6
+        // ──────────────────────────────────────────────
+
+        [Test]
+        public void Test09_SelectDestination_AlwaysReachableAndValid_AllTopologies()
+        {
+            var maps = new[] { BuildTopoA(), BuildTopoB(), BuildTopoC() };
+            string[] topoNames = { "TopoA", "TopoB", "TopoC" };
+
+            for (int m = 0; m < maps.Length; m++)
+            {
+                ActMap map = maps[m];
+                for (int questNode = 1; questNode <= 6; questNode++)
+                {
+                    var completed = new HashSet<int>();
+                    int dest = QuestDestinationResolver.SelectDestination(map, questNode, completed);
+
+                    Assert.IsTrue(IsForwardReachable(map, questNode, dest),
+                        $"{topoNames[m]}: destino {dest} no alcanzable desde quest={questNode}");
+                    Assert.AreNotEqual(questNode, dest,
+                        $"{topoNames[m]}: destino == questNodeId={questNode}");
+                    Assert.IsFalse(completed.Contains(dest),
+                        $"{topoNames[m]}: destino {dest} está en completedNodes");
+                }
+            }
+        }
+
+        // ──────────────────────────────────────────────
+        // Caso 10: CompleteQuestIfDestination(destino) → otorga gold, Active=false, true
+        // ──────────────────────────────────────────────
+
+        [Test]
+        public void Test10_CompleteQuestIfDestination_Awards_Gold_And_Deactivates()
+        {
+            RunState state = new RunState();
+            state.StartQuest(new QuestState
+            {
+                Active = true,
+                DestinationNodeId = 5,
+                FinalRewardGold = 75
+            });
+            int goldBefore = state.Gold;
+
+            bool result = state.CompleteQuestIfDestination(5);
+
+            Assert.IsTrue(result, "Debe devolver true al completar el quest");
+            Assert.AreEqual(goldBefore + 75, state.Gold, "Debe otorgar FinalRewardGold");
+            Assert.IsFalse(state.ActiveQuest.Active, "Quest debe quedar inactivo");
+        }
+
+        // ──────────────────────────────────────────────
+        // Caso 11: CompleteQuestIfDestination(otroNodo) → false, sin gold, quest activo
+        // ──────────────────────────────────────────────
+
+        [Test]
+        public void Test11_CompleteQuestIfDestination_WrongNode_DoesNothing()
+        {
+            RunState state = new RunState();
+            state.StartQuest(new QuestState
+            {
+                Active = true,
+                DestinationNodeId = 5,
+                FinalRewardGold = 75
+            });
+            int goldBefore = state.Gold;
+
+            bool result = state.CompleteQuestIfDestination(3);
+
+            Assert.IsFalse(result, "Debe devolver false para nodo incorrecto");
+            Assert.AreEqual(goldBefore, state.Gold, "No debe dar oro");
+            Assert.IsTrue(state.ActiveQuest.Active, "Quest debe seguir activo");
+        }
+
+        // ──────────────────────────────────────────────
+        // Caso 12: Quest "Robar" → +100 oro, sin quest activo, Retazo NO entregado
+        // ──────────────────────────────────────────────
+
+        [Test]
+        public void Test12_RobChoice_GivesGold_NoQuest_NoRelic()
+        {
+            RunState state = new RunState();
+            state.Gold = 0;
+
+            // La choice "Robar" solo tiene GiveGold — sin StartQuest ni GiveRelic
+            var robConsequence = new EventConsequence(ConsequenceType.GiveGold, 100);
+            EventConsequence.Apply(state, null, robConsequence);
+
+            Assert.AreEqual(100, state.Gold, "Debe dar +100 oro");
+            Assert.IsFalse(state.ActiveQuest.Active, "No debe activar quest");
+            Assert.AreEqual(0, state.Relics.Count, "No debe dar Retazo");
+        }
+
+        // ──────────────────────────────────────────────
+        // Caso 13: RunState.Reset() limpia ActiveQuest
+        // ──────────────────────────────────────────────
+
+        [Test]
+        public void Test13_Reset_ClearsActiveQuest()
+        {
+            RunState state = new RunState();
+            state.StartQuest(new QuestState
+            {
+                Active = true,
+                DestinationNodeId = 4,
+                FinalRewardGold = 75
+            });
+            Assert.IsTrue(state.ActiveQuest.Active, "Setup: quest debe estar activo");
+
+            state.Reset(null);
+
+            Assert.IsFalse(state.ActiveQuest.Active, "Reset debe desactivar el quest");
+            Assert.AreEqual(-1, state.ActiveQuest.DestinationNodeId, "DestinationNodeId debe ser -1");
+        }
+
+        // ──────────────────────────────────────────────
+        // Caso 14: RelicCardPlayedBlockEffect — carta Block da bloqueo; no-Block no-op
+        // ──────────────────────────────────────────────
+
+        [Test]
+        public void Test14_RelicCardPlayedBlockEffect_BlockCard_GrantsBlock_NonBlock_NoOp()
+        {
+            TurnManager manager = CreateManager();
+
+            RelicDefinition relicDef = ScriptableObject.CreateInstance<RelicDefinition>();
+            relicDef.DisplayName = "Test MCguffin B";
+            relicDef.Hooks = new[] { RelicHook.OnCardPlayed };
+            relicDef.Effect = new RelicCardPlayedBlockEffect { Amount = 1 };
+
+            RunState rs = new RunState();
+            rs.Relics.Add(new RelicInstance(relicDef, 0));
+            RelicHookDispatcher dispatcher = new RelicHookDispatcher(rs);
+
+            // Carta con EffectType.Block
+            CardDefinition blockCard = ScriptableObject.CreateInstance<CardDefinition>();
+            blockCard.SetDebugData("test_block", "Block", "desc", 1,
+                CardType.Defense, CardRarity.Common, CardTarget.Self, null,
+                new List<EffectRef> { new EffectRef { effectType = EffectType.Block, value = 5 } });
+
+            // Carta sin EffectType.Block
+            CardDefinition attackCard = ScriptableObject.CreateInstance<CardDefinition>();
+            attackCard.SetDebugData("test_attack", "Attack", "desc", 1,
+                CardType.Attack, CardRarity.Common, CardTarget.SingleEnemy, null,
+                new List<EffectRef> { new EffectRef { effectType = EffectType.Damage, value = 5 } });
+
+            int blockBefore = manager.Player.CurrentBlock;
+
+            // Disparar OnCardPlayed con carta Block
+            var hookBlock = new CardPlayedHookData(rs, manager, dispatcher,
+                blockCard, TurnManager.WorldSide.A, 1);
+            dispatcher.Dispatch(RelicHook.OnCardPlayed, hookBlock);
+
+            Assert.AreEqual(blockBefore + 1, manager.Player.CurrentBlock,
+                "Carta Block debe dar +1 bloqueo");
+
+            int blockAfterBlock = manager.Player.CurrentBlock;
+
+            // Disparar OnCardPlayed con carta no-Block: sin cambio
+            var hookAttack = new CardPlayedHookData(rs, manager, dispatcher,
+                attackCard, TurnManager.WorldSide.A, 1);
+            dispatcher.Dispatch(RelicHook.OnCardPlayed, hookAttack);
+
+            Assert.AreEqual(blockAfterBlock, manager.Player.CurrentBlock,
+                "Carta no-Block NO debe cambiar el bloqueo");
+
+            Object.DestroyImmediate(relicDef);
+            Object.DestroyImmediate(blockCard);
+            Object.DestroyImmediate(attackCard);
+        }
+
+        // ──────────────────────────────────────────────
+        // Caso 15: Fallback al Boss cuando el event está en penúltima capa
+        // ──────────────────────────────────────────────
+
+        [Test]
+        public void Test15_SelectDestination_Fallback_ToBoss_WhenPenultimateLayer()
+        {
+            // Topo A: nodo 6 tiene solo nodo 7 (Boss) como forward
+            ActMap mapA = BuildTopoA();
+            int destA = QuestDestinationResolver.SelectDestination(mapA, 6, new HashSet<int>());
+            Assert.AreEqual(7, destA, "TopoA nodo 6: destino debe ser Boss (7)");
+            Assert.AreEqual(NodeType.Boss, mapA.GetNode(destA).Type, "Destino debe ser Boss");
+
+            // Topo B: nodos 5 y 6 tienen solo el Boss como forward
+            ActMap mapB = BuildTopoB();
+            Assert.AreEqual(7, QuestDestinationResolver.SelectDestination(mapB, 5, new HashSet<int>()),
+                "TopoB nodo 5: destino debe ser Boss");
+            Assert.AreEqual(7, QuestDestinationResolver.SelectDestination(mapB, 6, new HashSet<int>()),
+                "TopoB nodo 6: destino debe ser Boss");
+
+            // Topo C: nodo 6 tiene solo el Boss como forward
+            ActMap mapC = BuildTopoC();
+            Assert.AreEqual(7, QuestDestinationResolver.SelectDestination(mapC, 6, new HashSet<int>()),
+                "TopoC nodo 6: destino debe ser Boss");
+        }
+
+        // ──────────────────────────────────────────────
+        // Caso 16: Determinismo — misma (map, questNodeId) → mismo destino en llamadas repetidas
+        // ──────────────────────────────────────────────
+
+        [Test]
+        public void Test16_SelectDestination_Deterministic_SameInputSameResult()
+        {
+            ActMap map = BuildTopoA();
+            var completed = new HashSet<int>();
+
+            int dest1 = QuestDestinationResolver.SelectDestination(map, 1, completed);
+            int dest2 = QuestDestinationResolver.SelectDestination(map, 1, completed);
+            int dest3 = QuestDestinationResolver.SelectDestination(map, 1, completed);
+
+            Assert.AreEqual(dest1, dest2, "Llamada 1 vs 2: mismo destino");
+            Assert.AreEqual(dest1, dest3, "Llamada 1 vs 3: mismo destino");
+        }
+    }
+}

--- a/Assets/Tests/EditMode/QuestTests.cs
+++ b/Assets/Tests/EditMode/QuestTests.cs
@@ -270,10 +270,12 @@ namespace RoguelikeCardBattler.Tests.EditMode
             rs.Relics.Add(new RelicInstance(relicDef, 0));
             RelicHookDispatcher dispatcher = new RelicHookDispatcher(rs);
 
-            // Carta con EffectType.Block
+            // Carta con EffectType.Block. La "carta de escudo" se detecta por
+            // EffectType.Block en Effects (no por CardType); las cartas defensivas
+            // son CardType.Skill en este codebase (no existe CardType.Defense).
             CardDefinition blockCard = ScriptableObject.CreateInstance<CardDefinition>();
             blockCard.SetDebugData("test_block", "Block", "desc", 1,
-                CardType.Defense, CardRarity.Common, CardTarget.Self, null,
+                CardType.Skill, CardRarity.Common, CardTarget.Self, null,
                 new List<EffectRef> { new EffectRef { effectType = EffectType.Block, value = 5 } });
 
             // Carta sin EffectType.Block
@@ -282,24 +284,24 @@ namespace RoguelikeCardBattler.Tests.EditMode
                 CardType.Attack, CardRarity.Common, CardTarget.SingleEnemy, null,
                 new List<EffectRef> { new EffectRef { effectType = EffectType.Damage, value = 5 } });
 
-            int blockBefore = manager.Player.CurrentBlock;
+            int blockBefore = manager.PlayerBlock;
 
             // Disparar OnCardPlayed con carta Block
             var hookBlock = new CardPlayedHookData(rs, manager, dispatcher,
                 blockCard, TurnManager.WorldSide.A, 1);
             dispatcher.Dispatch(RelicHook.OnCardPlayed, hookBlock);
 
-            Assert.AreEqual(blockBefore + 1, manager.Player.CurrentBlock,
+            Assert.AreEqual(blockBefore + 1, manager.PlayerBlock,
                 "Carta Block debe dar +1 bloqueo");
 
-            int blockAfterBlock = manager.Player.CurrentBlock;
+            int blockAfterBlock = manager.PlayerBlock;
 
             // Disparar OnCardPlayed con carta no-Block: sin cambio
             var hookAttack = new CardPlayedHookData(rs, manager, dispatcher,
                 attackCard, TurnManager.WorldSide.A, 1);
             dispatcher.Dispatch(RelicHook.OnCardPlayed, hookAttack);
 
-            Assert.AreEqual(blockAfterBlock, manager.Player.CurrentBlock,
+            Assert.AreEqual(blockAfterBlock, manager.PlayerBlock,
                 "Carta no-Block NO debe cambiar el bloqueo");
 
             Object.DestroyImmediate(relicDef);

--- a/Assets/Tests/EditMode/QuestTests.cs.meta
+++ b/Assets/Tests/EditMode/QuestTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 666864b3ee8e40b8a7c4d675e361dfd2

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -224,7 +224,9 @@ protegidos.**
       `EventConfigSetup` extendido: 2 Retazos MCguffin (R-MCG-A RelicEndGoldEffect{2} /
       R-MCG-B RelicCardPlayedBlockEffect{1}) en `Relics/Quest/` + 3 eventos multidim
       (evt_md_forge, evt_md_relic, evt_md_quest_courier) → pool total 6 eventos.
-      `QuestTests.cs` (casos 8-16). **Validación pendiente en Unity.**
+      `QuestTests.cs` (casos 8-16). **Validado en Unity-MCP 2026-06-19:** suite EditMode **221/221**,
+      compilación limpia, menú `Setup Event Config` corrido (2 MCguffin + 6 eventos, serialización
+      de StartQuest verificada). E2E visual en RunScene pendiente de confirmación por Sebastián.
 - Dependencia interna: 4a cerrado (eventos que otorgan mejoras necesitan que
   toda carta sea mejorable) + visor pre-M4 (verificación en playtest)
 

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -212,10 +212,19 @@ protegidos.**
       EditMode **197 → 212/212**. Cero archivos protegidos. E2E data-path validado en assets
       reales (Unity-MCP). E2E visual en play **confirmado por Sebastián 2026-06-18**: eventos +
       fondos por-evento + labels afín/neutra diferenciadas en panel de recompensa.
-- [ ] **Sub-PR 4b-2 — Multidimensionales + quest/MCguffin:** elección de mundo + variantes
-      A/B; `QuestState` en RunState (`StartQuest`/`CompleteQuestIfDestination`); nodo destino
-      resaltado en `RunMapView` (alcanzabilidad en DAG); `RelicCardPlayedBlockEffect`.
-      Depende de 4b-1 mergeado. (DD-021 ya transcripta en DESIGN_DECISIONS.md 2026-06-18.)
+- [x] **Sub-PR 4b-2 — Multidimensionales + quest/MCguffin:** ✅ IMPLEMENTADO 2026-06-19
+      (branch `feat/m4-4b2-events-quests`). Nuevos: `QuestState.cs` + `QuestDestinationResolver.cs`
+      (`Assets/Scripts/Run/Quests/`), `RelicCardPlayedBlockEffect.cs`. Modificados:
+      `EventDefinition` (EventVariant + IsMultidimensional + WorldA/WorldB), `EventConsequence`
+      (StartQuest + QuestData), `EventResolver.ResolveVariant`, `EventNodeController`
+      (pantalla de elección de mundo A/B, maneja StartQuest via BFS forward), `RunState`
+      (ActiveQuest + StartQuest + CompleteQuestIfDestination + Reset), `RunFlowController`
+      (pasa `_map` al EventNodeController, llama CompleteQuestIfDestination en CompleteNode),
+      `RunMapNodeView/RunMapView` (highlight ámbar del nodo destino, SetQuestHighlight).
+      `EventConfigSetup` extendido: 2 Retazos MCguffin (R-MCG-A RelicEndGoldEffect{2} /
+      R-MCG-B RelicCardPlayedBlockEffect{1}) en `Relics/Quest/` + 3 eventos multidim
+      (evt_md_forge, evt_md_relic, evt_md_quest_courier) → pool total 6 eventos.
+      `QuestTests.cs` (casos 8-16). **Validación pendiente en Unity.**
 - Dependencia interna: 4a cerrado (eventos que otorgan mejoras necesitan que
   toda carta sea mejorable) + visor pre-M4 (verificación en playtest)
 

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -7,12 +7,25 @@
 > En `modo:implementacion` se lee al inicio para saber qué milestone está activo
 > y qué sub-tareas quedan.
 >
-> **Fase actual:** M4 activo. Pre-M4 visor de mazo: ✅ CERRADO (2026-06-17). Bloque 4a: ✅ CERRADO (2026-06-17). Bloque 4b-1: ✅ CERRADO (2026-06-18).
+> **Fase actual:** M4 activo. Pre-M4 visor de mazo: ✅ CERRADO (2026-06-17). Bloque 4a: ✅ CERRADO (2026-06-17). Bloque 4b-1: ✅ CERRADO (2026-06-18). Bloque 4b-2: ✅ CERRADO (2026-06-19). **Bloque 4b COMPLETO.**
 > **Milestone activo:** M4 — Resto del Acto 1 (bloques: 4a integridad de cartas, 4b eventos+quests, 4c transdim+ancla)
-> **Próximo bloque:** M4 bloque **4b-2** — Eventos multidimensionales + quest/MCguffin. **Spec ✅ CERRADO (2026-06-18)** →
-> `Docs/dev/specs/m4_4b_events_quests_spec.md` (§Sub-PR 4b-2). Depende de 4b-1 mergeado.
-> Próximo paso: implementar 4b-2 con `modo:implementacion`.
-> **Última actualización:** 2026-06-18 (`modo:implementacion`: **Sub-PR 4b-1 CERRADO** — motor de
+> **Próximo bloque:** M4 bloque **4c** — Transdimensionales + Ancla (mecánico, patrón para M5). **ÚNICO bloque de M4 que toca archivos protegidos** (TurnManager). Arranca con sesión `modo:diseno` para su spec.
+> Próximo paso: spec de 4c con `modo:diseno` (campo `TypeWorldB` + flag `IsAnchor` en `EnemyDefinition`, resolución de tipo activo por mundo, ficha del enemigo con ambos tipos).
+> **Última actualización:** 2026-06-19 (`modo:implementacion` + `/cierre-sesion`: **Sub-PR 4b-2 CERRADO → bloque 4b COMPLETO** —
+> eventos multidimensionales + quest/MCguffin (branch `feat/m4-4b2-events-quests`, **PR #126**). Nuevo subsistema
+> `Assets/Scripts/Run/Quests/` (`QuestState` + `QuestDestinationResolver` BFS forward static puro) +
+> `RelicCardPlayedBlockEffect` (MCguffin Mundo B, `OnCardPlayed`). `EventDefinition` gana `EventVariant`
+> (Body+Choices por mundo) + `IsMultidimensional`/`WorldA`/`WorldB`; `EventConsequence` gana `QuestData` +
+> `ConsequenceType.StartQuest` (al final del enum); `EventResolver.ResolveVariant`; `EventNodeController`
+> con pantalla de elección de mundo A/B + `HandleStartQuest` (BFS); `RunState` con `ActiveQuest`/`StartQuest`/
+> `CompleteQuestIfDestination`/`Reset`; `RunFlowController` pasa `_map` + completa quest en `CompleteNode`;
+> `RunMapNodeView`/`RunMapView` resaltan el nodo destino en ámbar (`SetQuestHighlight`). `EventConfigSetup`
+> extendido: 2 Retazos MCguffin en `Relics/Quest/` (R-MCG-A `RelicEndGoldEffect{2}` / R-MCG-B
+> `RelicCardPlayedBlockEffect{1}`) + 3 eventos multidim (evt_md_forge/relic/quest_courier) → pool 6 eventos.
+> `QuestTests.cs` (casos 8-16). Suite EditMode **212 → 221/221**, compilación limpia. **Cero archivos
+> protegidos.** Validado en Unity-MCP (221/221 + assets serializados verificados). Arte de los 3 fondos
+> multidim diferido a PR de pulido aparte (fallback de color funcional, no bloqueante).)
+> **Previa:** 2026-06-18 (`modo:implementacion`: **Sub-PR 4b-1 CERRADO** — motor de
 > eventos + eventos simples. Nuevo subsistema `Assets/Scripts/Run/Events/` (6 archivos) +
 > `EventConfigSetup` + `EventTests` (12 casos). `RunFlowController` ramifica `NodeType.Event`;
 > `MapNode.AssignedEvent` + `RunMapGenerator.AssignEvents` por seed; `RunSession` cablea

--- a/Docs/dev/_tech_snapshot.md
+++ b/Docs/dev/_tech_snapshot.md
@@ -8,7 +8,7 @@
 > afecte arquitectura o componentes críticos.
 >
 > **Última actualización:** 2026-06-19 — **M4 bloque 4b-2: eventos multidimensionales + quest/MCguffin**
-> (branch `feat/m4-4b2-events-quests`). Nuevo subsistema `Assets/Scripts/Run/Quests/`
+> (branch `feat/m4-4b2-events-quests`, **PR #126** → **bloque 4b COMPLETO**). Nuevo subsistema `Assets/Scripts/Run/Quests/`
 > (`QuestState.cs` datos del quest activo; `QuestDestinationResolver.cs` BFS forward static puro).
 > `RelicCardPlayedBlockEffect.cs` (MCguffin Mundo B: +1 bloqueo al jugar carta de escudo vía
 > `OnCardPlayed`, incondicional al mundo). Modificaciones: `EventDefinition` (+ `EventVariant`
@@ -30,8 +30,10 @@
 > Unity-MCP (2026-06-19):** suite 221/221 verde; menú `Setup Event Config` corrido (2 MCguffin en
 > `Relics/Quest/`: R-MCG-A OnCombatEnd+`RelicEndGoldEffect{2}`, R-MCG-B OnCardPlayed+`RelicCardPlayedBlockEffect{1}`;
 > 6 eventos en el pool; evt_md_quest_courier serializa `isMultidimensional:1` + worldA/worldB con
-> StartQuest (type 6) inline apuntando a su MCguffin + FinalRewardGold 75). E2E visual en RunScene
-> pendiente de confirmación por Sebastián.
+> StartQuest (type 6) inline apuntando a su MCguffin + FinalRewardGold 75). Merge a main aprobado por
+> Sebastián sobre la validación Unity-MCP (suite + assets); arte de los 3 fondos multidim diferido a un
+> PR de pulido aparte (el fallback de color #241A2E es funcional, no bloqueante). Conteos refrescados:
+> **120 scripts C#** en `Assets/Scripts` (era 109), **28 archivos de test** EditMode (era 26).
 >
 > **Última actualización previa:** 2026-06-18 — **M4 bloque 4b-1: motor de eventos + eventos simples**
 > (branch `feat/m4-4b1-events-engine`). Nuevo subsistema `Assets/Scripts/Run/Events/` (6 archivos),
@@ -380,7 +382,7 @@
 
 ### Tests
 - **Unity Test Framework** (NUnit) en EditMode
-- 26 archivos de test en `Assets/Tests/EditMode/` (suite 197/197)
+- 28 archivos de test en `Assets/Tests/EditMode/` (suite 221/221)
 - Helper compartido: `CombatTestBase.cs`
 
 ---
@@ -474,7 +476,7 @@ Exclusivamente vía `RunSession.State` (= `RunState`). Flags principales:
 
 ## Estructura de archivos
 
-### Scripts (`Assets/Scripts/`) — 109 archivos C#
+### Scripts (`Assets/Scripts/`) — 120 archivos C#
 
 ```
 Core/
@@ -505,6 +507,16 @@ Run/
     ShopNodeController.cs, ShopConfig.cs, ShopItem.cs
   Campfire/                      ← Sub-PR 3C — Hoguera
     CampfireNodeController.cs, CampfireConfig.cs, CampfireOption.cs
+  Events/                        ← M4 4b-1/4b-2 — eventos (simples + multidimensionales)
+    EventDefinition.cs           ← SO: Id/Title/Body + Choices; 4b-2: EventVariant + IsMultidimensional + WorldA/WorldB
+    EventChoice.cs               ← [Serializable]: Label/ResultText/MinGoldRequired + consecuencias
+    EventConsequence.cs          ← [Serializable]: enum ConsequenceType (+ StartQuest, 4b-2) + QuestData; Apply static puro
+    EventResolver.cs             ← static puro: SelectEvent(pool,nodeId,seed) + ResolveVariant(def,world) (4b-2)
+    EventNodeController.cs        ← MonoBehaviour: panel runtime; 4b-2: pantalla de elección A/B + HandleStartQuest (BFS)
+    EventPoolConfig.cs           ← SO: pool de eventos + backgroundSprite fallback
+  Quests/                        ← M4 4b-2 — quest/MCguffin
+    QuestState.cs                ← datos del quest activo (Active/DestinationNodeId/FinalRewardGold)
+    QuestDestinationResolver.cs  ← static puro: BFS forward desde el nodo del quest (más lejano no-Boss; fallback Boss)
   Map/
     ActMap.cs, MapNode.cs, NodeState.cs, NodeType.cs
     RunMapGenerator.cs
@@ -609,7 +621,7 @@ EditorCardAuthoring.cs                ← 4a: helper compartido (CloneEffectsBoo
 NewRunConfigSetup.cs / ShopConfigSetup.cs  ← menús de config (3E / 3D)
 ```
 
-### Tests (`Assets/Tests/EditMode/`) — 25 archivos (suite EditMode 193/193)
+### Tests (`Assets/Tests/EditMode/`) — 28 archivos (suite EditMode 221/221)
 
 ```
 CombatTestBase.cs                ← helper compartido
@@ -668,6 +680,13 @@ CardUpgradeCoverageTests.cs      ← M4 4a guard DD-023, editor-only #if UNITY_E
 RunStateAffinityTests.cs         ← M4 4a follow-up: afinidad en AddCardToDeck (4 casos: afín→dual
                                    tipada por mundo, neutra→None, dual ya-tipada pasa sin cambios,
                                    sin aliasing de entry)
+EventTests.cs                    ← M4 4b-1 (12 casos: SelectEvent determinista por seed, las 6
+                                   consecuencias de Apply, gate de oro IsChoiceAvailable, bordes de
+                                   RemoveCard —rama dual y carta ausente—)
+QuestTests.cs                    ← M4 4b-2 (casos 8-16: ResolveVariant A≠B, SelectDestination en las
+                                   3 topologías × nodos 1..6, CompleteQuestIfDestination hit/miss,
+                                   Robar=+100 sin quest, Reset limpia quest, RelicCardPlayedBlockEffect,
+                                   fallback al Boss, determinismo del BFS)
 ```
 
 ### ScriptableObjects (`Assets/ScriptableObjects/`)

--- a/Docs/dev/_tech_snapshot.md
+++ b/Docs/dev/_tech_snapshot.md
@@ -26,7 +26,12 @@
 > 2 Retazos MCguffin en `Assets/ScriptableObjects/Relics/Quest/` (R-MCG-A `RelicEndGoldEffect{2}` /
 > R-MCG-B `RelicCardPlayedBlockEffect{1}`); 3 eventos multidim (evt_md_forge/relic/quest_courier);
 > pool total 6 eventos. `QuestTests.cs` (9 casos: 8-16, incluyendo todas las topologías × nodos 1..6).
-> Suite EditMode **212 → 221/221** (pendiente validación en Unity). Cero archivos protegidos.
+> Suite EditMode **212 → 221/221**, compilación limpia. Cero archivos protegidos. **Validado en
+> Unity-MCP (2026-06-19):** suite 221/221 verde; menú `Setup Event Config` corrido (2 MCguffin en
+> `Relics/Quest/`: R-MCG-A OnCombatEnd+`RelicEndGoldEffect{2}`, R-MCG-B OnCardPlayed+`RelicCardPlayedBlockEffect{1}`;
+> 6 eventos en el pool; evt_md_quest_courier serializa `isMultidimensional:1` + worldA/worldB con
+> StartQuest (type 6) inline apuntando a su MCguffin + FinalRewardGold 75). E2E visual en RunScene
+> pendiente de confirmación por Sebastián.
 >
 > **Última actualización previa:** 2026-06-18 — **M4 bloque 4b-1: motor de eventos + eventos simples**
 > (branch `feat/m4-4b1-events-engine`). Nuevo subsistema `Assets/Scripts/Run/Events/` (6 archivos),

--- a/Docs/dev/_tech_snapshot.md
+++ b/Docs/dev/_tech_snapshot.md
@@ -7,7 +7,28 @@
 > En `modo:implementacion` se lee OBLIGATORIAMENTE antes de cualquier cambio que
 > afecte arquitectura o componentes críticos.
 >
-> **Última actualización:** 2026-06-18 — **M4 bloque 4b-1: motor de eventos + eventos simples**
+> **Última actualización:** 2026-06-19 — **M4 bloque 4b-2: eventos multidimensionales + quest/MCguffin**
+> (branch `feat/m4-4b2-events-quests`). Nuevo subsistema `Assets/Scripts/Run/Quests/`
+> (`QuestState.cs` datos del quest activo; `QuestDestinationResolver.cs` BFS forward static puro).
+> `RelicCardPlayedBlockEffect.cs` (MCguffin Mundo B: +1 bloqueo al jugar carta de escudo vía
+> `OnCardPlayed`, incondicional al mundo). Modificaciones: `EventDefinition` (+ `EventVariant`
+> serializable: Body+Choices por mundo; `IsMultidimensional`, `WorldA`, `WorldB`); `EventConsequence`
+> (+ `QuestData` serializable: CarriedRelic + FinalRewardGold; `ConsequenceType.StartQuest` al final del
+> enum); `EventResolver.ResolveVariant(def, world)` / `ResolveVariantFull(def, world)`; `EventNodeController`
+> (+ `ActMap _map` en Initialize; pantalla de elección de mundo A/B antes de mostrar choices multidim;
+> `HandleStartQuest` resuelve destino vía BFS + `state.AddRelic` + `state.StartQuest`); `RunState`
+> (+ `QuestState ActiveQuest`; `StartQuest(quest)`; `CompleteQuestIfDestination(nodeId)→bool` otorga oro
+> y desactiva; `Reset` limpia ActiveQuest); `RunFlowController` (`BuildEventController` pasa `_map`;
+> `CompleteNode` llama `CompleteQuestIfDestination` antes de avanzar el DAG); `RunMapNodeView`
+> (`SetQuestHighlight(bool)` + color ámbar `QuestDestBg` en `ApplyState`; no aplica si completado o
+> durante entrance); `RunMapView.Refresh` resalta nodo destino del quest activo (ámbar pulsante,
+> persistente hasta completar). `EventConfigSetup` extendido: helper `CreateOrUpdateMcguffinRelic`;
+> 2 Retazos MCguffin en `Assets/ScriptableObjects/Relics/Quest/` (R-MCG-A `RelicEndGoldEffect{2}` /
+> R-MCG-B `RelicCardPlayedBlockEffect{1}`); 3 eventos multidim (evt_md_forge/relic/quest_courier);
+> pool total 6 eventos. `QuestTests.cs` (9 casos: 8-16, incluyendo todas las topologías × nodos 1..6).
+> Suite EditMode **212 → 221/221** (pendiente validación en Unity). Cero archivos protegidos.
+>
+> **Última actualización previa:** 2026-06-18 — **M4 bloque 4b-1: motor de eventos + eventos simples**
 > (branch `feat/m4-4b1-events-engine`). Nuevo subsistema `Assets/Scripts/Run/Events/` (6 archivos),
 > **sin tocar archivos protegidos**. Datos: `EventDefinition` (SO: Id/Title/Body + `List<EventChoice>`),
 > `EventChoice` (`[Serializable]`: Label/ResultText/MinGoldRequired + `List<EventConsequence>`),

--- a/Docs/dev/specs/m4_4b_events_quests_spec.md
+++ b/Docs/dev/specs/m4_4b_events_quests_spec.md
@@ -188,11 +188,16 @@ string SourceWorldLabel;         // "A"/"B" para flavor del resaltado
 
 ### Nota de destino del quest (alcanzabilidad)
 El nodo destino se resuelve en runtime al aceptar (no se autora en el SO). Debe
-ser **alcanzable** desde el nodo del quest en el DAG. Regla `[PROPUESTA]`:
-BFS forward desde el nodo del quest y elegir un nodo a profundidad +2/+3 sobre un
-camino alcanzable; fallback robusto = el nodo de convergencia pre-boss (siempre
-alcanzable porque todo converge al end). Validar con `RunMapGeneratorTests`-style
-que el destino elegido es alcanzable.
+ser **alcanzable** por BFS forward desde el nodo del quest en el DAG.
+
+> ⚠️ **La regla `[PROPUESTA]` original ("+2/+3 con fallback a convergencia
+> pre-boss") quedó SUPERSEDED.** Validada contra el código real (2026-06-18) tiene
+> tres huecos: (1) para Events en penúltima capa no existe nodo a +2/+3; (2) la
+> "convergencia pre-boss única" no existe en una de las 3 topologías (el Boss tiene
+> 2 predecesores); (3) donde el predecesor del Boss es único, coincide con el propio
+> nodo del Event → destino degenerado. La regla corregida y blindada está en
+> **§Resolución del nodo destino del quest (regla corregida)** dentro de
+> §Contenido de Sub-PR 4b-2.
 
 ## Reuso
 - Patrón node-controller: `CampfireNodeController` (panel runtime, `BuildPanel`/
@@ -274,12 +279,281 @@ que el destino elegido es alcanzable.
 ## Estimación
 - Complejidad: **alta** (lo grande de M4). 4b-1 media · 4b-2 alta (tracking + marcado en
   mapa + recompensa diferida + alcanzabilidad en DAG).
-- Riesgo principal: selección del nodo destino debe garantizar alcanzabilidad (BFS
-  forward o convergencia pre-boss). Blindar con test.
+- Riesgo principal: selección del nodo destino debe garantizar alcanzabilidad. Resuelto
+  con BFS forward + fallback al Boss (único nodo siempre alcanzable). Blindado con test
+  exhaustivo por topología. Ver §Contenido de Sub-PR 4b-2.
 
 ---
 
-## Prompt de handoff para `modo:implementacion` — Sub-PR 4b-1
+# Contenido de Sub-PR 4b-2 (cerrado en sesión `modo:diseno` 2026-06-18)
+
+> Esta parte fija el **contenido placeholder** que `EventConfigSetup` autora en 4b-2 y
+> **corrige la regla de resolución del nodo destino** del quest (la nota `[PROPUESTA]`
+> previa tenía huecos). Todo lo de aquí está verificado contra el código real de 4b-1
+> y listo para implementación: no quedan decisiones de diseño abiertas. Los números de
+> oro/HP son placeholders **afinables en balance** (marcados ⚖️).
+
+## Realidad del mapa (verificada en código 2026-06-18) `[CÓDIGO ACTUAL]`
+
+- El DAG **no** es procedural: `RunMapGenerator.Topologies` (`int[][][]`) son **3
+  plantillas fijas** de aristas, elegidas por `rng.Next(3)`. `Act1MapConfig.TotalNodes = 8`
+  (ids 0..7). Nodo **0 = start** (Combat forzado, sin entrantes), nodo **7 = end = Boss**
+  (forzado, sin salientes). `MapNode.Connections` = lista de **sucesores** (adyacencia
+  forward); `MapNode.Id` es el índice; `ActMap.GetNode(id)` / `ActMap.Nodes`.
+- Un `NodeType.Event` puede caer en **cualquier** índice intermedio **1..6** (peso 20, sin
+  mínimo ni restricción por profundidad). El Boss queda excluido del pool de pesos.
+- Las 3 topologías y profundidades forward desde el start:
+
+  | Topo | Aristas | Profundidades (d) |
+  |------|---------|-------------------|
+  | **A** doble diamante | 0→(1,2)→3→(4,5)→6→7 | d1{1,2} d2{3} d3{4,5} d4{6} d5{7} |
+  | **B** split tardío | 0→1→(2,3)→4→(5,6)→7 | d1{1} d2{2,3} d3{4} d4{5,6} d5{7} |
+  | **C** triple temprano | 1→4, 2→4, 3→5, 4→6, 5→6, 6→7 (0→1,2,3) | d1{1,2,3} d2{4,5} d3{6} d4{7} |
+
+- **Invariante clave:** desde cualquier Event (1..6), el Boss/end (nodo 7) **siempre** es
+  alcanzable forward — todo camino converge al end. No existe ningún otro nodo con esa
+  garantía universal (la "convergencia pre-boss única" **no existe**: en B el Boss tiene
+  dos predecesores, 5 y 6).
+
+## Eventos multidimensionales placeholder
+
+Se autoran **3 eventos multidimensionales** (`IsMultidimensional = true`): **2 simples**
+(no-quest, para ejercitar la pantalla de elección de mundo con consecuencias normales) +
+**1 quest/MCguffin**. Estructura por GDD DD-005: *"la quest es exactamente la misma, solo
+cambia el enunciado y la recompensa"* → cada variante A/B comparte el **número y los tipos
+de consecuencia** de sus choices; difieren el flavor (Body/Label/ResultText) y los valores
+de recompensa. `Title` es único por `EventDefinition`; el `Body` y los `Choices` viven en
+`WorldA` / `WorldB` (`EventVariant`).
+
+> Modelo de datos que 4b-2 agrega (ya previsto en §Contratos): `EventVariant { string Body;
+> List<EventChoice> Choices; }`, `EventDefinition.IsMultidimensional` + `WorldA` + `WorldB`,
+> y `ConsequenceType.StartQuest` **al final del enum** (para no renumerar valores ya
+> serializados en 4b-1). `EventResolver.ResolveVariant(def, world)` devuelve `WorldA.Choices`
+> (world 0=A) o `WorldB.Choices` (world 1=B).
+
+### Evento simple 1 — `evt_md_forge` ("El artesano y su yunque")
+
+Tema: pagar por una carta o curarse. Cubre `LoseGold` + `GiveCard` + `ModifyHP`.
+
+**Variante A (medieval)** — Body: *"Un herrero ermitaño aviva las brasas de su fragua.
+'Dame algo de oro y tu acero saldrá más afilado', murmura sin mirarte."*
+
+| Label | minGold | Consecuencias | ResultText |
+|-------|---------|---------------|-----------|
+| Pagar al herrero | 25 | `LoseGold 25` + `GiveCard(afín)` | "El herrero te entrega una hoja recién templada." |
+| Curar tus heridas | 0 | `ModifyHP +10` ⚖️ | "El calor de la fragua reconforta tu cuerpo (+10 HP)." |
+| Dejar la fragua | 0 | — | "Te alejas del calor de las brasas." |
+
+**Variante B (futurista)** — Body: *"Un técnico de chatarra calibra su soldadora de
+plasma. 'Unos créditos y recalibro tu equipo', zumba su vocoder."*
+
+| Label | minGold | Consecuencias | ResultText |
+|-------|---------|---------------|-----------|
+| Pagar al técnico | 25 | `LoseGold 25` + `GiveCard(afín)` | "El técnico imprime un módulo y lo acopla a tu equipo." |
+| Pedir un parche | 0 | `ModifyHP +14` ⚖️ | "El nanogel sella tus heridas (+14 HP)." |
+| Salir del taller | 0 | — | "Las compuertas se cierran tras de ti." |
+
+*(La recompensa cambia por mundo: B cura +14 vs A +10. La carta dada se resuelve por
+`FindAnyCard()` placeholder y se rutea por `AffinityResolver` igual que cualquier
+recompensa — la elección de mundo del evento es flavor local, no altera el ruteo.)*
+
+### Evento simple 2 — `evt_md_relic` ("El relicario sellado")
+
+Tema: arriesgar HP por un Retazo, o saquear oro. Cubre `GiveRelic` + `ModifyHP` + `GiveGold`.
+
+**Variante A (medieval)** — Body: *"Un relicario de hierro descansa sobre un altar
+agrietado. Un susurro promete poder a quien se atreva a abrirlo."*
+
+| Label | minGold | Consecuencias | ResultText |
+|-------|---------|---------------|-----------|
+| Romper el sello | 0 | `GiveRelic(afín)` + `ModifyHP -8` ⚖️ | "Arrancas la reliquia; las púas del relicario te hieren (-8 HP)." |
+| Llevarte las ofrendas | 0 | `GiveGold 30` ⚖️ | "Recoges 30 de oro de entre las ofrendas." |
+| No arriesgarte | 0 | — | "Retrocedes sin tocar el altar." |
+
+**Variante B (futurista)** — Body: *"Una cápsula de contención parpadea en rojo. Una voz
+sintética ofrece su carga a quien acepte el riesgo."*
+
+| Label | minGold | Consecuencias | ResultText |
+|-------|---------|---------------|-----------|
+| Forzar la cápsula | 0 | `GiveRelic(afín)` + `ModifyHP -6` ⚖️ | "Extraes el núcleo; una descarga te recorre (-6 HP)." |
+| Vaciar la reserva | 0 | `GiveGold 35` ⚖️ | "Transfieres 35 créditos de la reserva." |
+| No arriesgarte | 0 | — | "Te apartas de la cápsula parpadeante." |
+
+*(El Retazo dado aquí es un Retazo de pool normal vía `FindAnyRelic()` — **no** un MCguffin.
+Recompensa cambia por mundo: B menos daño (-6) y más oro (35).)*
+
+### Evento quest/MCguffin — `evt_md_quest_courier` ("Un encargo en el camino")
+
+Texto **canónico del GDD** (DD-005) `[GDD]`. **Solo 2 choices por variante (Aceptar /
+Robar)** — el GDD no contempla una opción de salida, y es intencional (el quest es un
+compromiso). Usa el nuevo `ConsequenceType.StartQuest`.
+
+**Variante A (medieval)** — Body: *"Un hombre moribundo, con las ropas raídas de la legión
+de magos, te aferra el brazo. Te ruega llevar un objeto místico hasta un punto lejano del
+mapa; si lo logras, promete recompensarte."*
+
+| Label | Consecuencias | ResultText |
+|-------|---------------|-----------|
+| Aceptar el encargo | `StartQuest{ CarriedRelic = R-MCG-A, FinalRewardGold = 75 ⚖️ }` | "El mago te confía un cáliz lacrado. Un punto del mapa queda resaltado." |
+| Robar al moribundo | `GiveGold 100` `[GDD]` | "Le arrebatas la bolsa y huyes. El objeto se hace añicos. +100 de oro." |
+
+**Variante B (futurista)** — Body: *"Un robot con las piezas rotas chisporrotea en el
+suelo. Dice pertenecer a una facción revolucionaria y te pide llevar un disco duro con
+información vital hasta un punto lejano del mapa."*
+
+| Label | Consecuencias | ResultText |
+|-------|---------------|-----------|
+| Aceptar el encargo | `StartQuest{ CarriedRelic = R-MCG-B, FinalRewardGold = 75 ⚖️ }` | "El robot te transfiere un disco sellado. Un punto del mapa queda resaltado." |
+| Robar al robot | `GiveGold 100` `[GDD]` | "Le arrancas el disco y sus créditos. El disco se desintegra. +100 de oro." |
+
+> **Tensión de diseño (intencional, cerrada por Q3):** "Robar" da **+100 oro inmediato**;
+> "Aceptar" da el **pasivo durante el trayecto** + **75 oro al llegar** (si llegás). Robar
+> rinde más oro neto y sin riesgo; Aceptar apuesta por el pasivo + economía a futuro. Si no
+> se llega al destino (muerte o ruta alterna), el pasivo ya se disfrutó y no hay recompensa
+> final. Riesgo/decisión real. `FinalRewardGold = 75` está entre Elite (30-50) y Boss (100).
+
+## Los dos Retazos MCguffin (stats)
+
+Se autoran como `RelicDefinition` `.asset` en una **subcarpeta dedicada**
+`Assets/ScriptableObjects/Relics/Quest/` para dejar explícito que **NO entran al pool de
+drops** (no se agregan a `RelicSoGenerator.BuildSpecs` ni al reward pool de
+`RunCombatConfig`; solo los referencia el quest vía `CarriedRelic`). Los crea
+`EventConfigSetup` (helper `CreateOrUpdateMcguffinRelic`, espejo del patrón `RelicSpec` de
+`RelicSoGenerator`) para mantener el contenido del quest autocontenido.
+
+| Campo | R-MCG-A (Mundo A) | R-MCG-B (Mundo B) |
+|-------|-------------------|-------------------|
+| Asset | `R-MCG-A_CalizDelMensajero.asset` | `R-MCG-B_DiscoDeLaResistencia.asset` |
+| DisplayName | "Cáliz del mensajero" | "Disco de la resistencia" |
+| Description | "+2 oro al ganar cada combate." | "+1 escudo al jugar una carta de escudo." |
+| FlavorText | "Lacrado con cera de otra época. Pesa como una promesa." | "Late con datos que alguien murió por proteger." |
+| Category | `RelicCategory.World` | `RelicCategory.World` |
+| Hooks | `{ OnCombatEnd }` (byte `05000000`) | `{ OnCardPlayed }` (byte `06000000`) |
+| Effect | `RelicEndGoldEffect { Amount = 2 }` (reusa el existente; default es 5, setear 2) | `RelicCardPlayedBlockEffect { Amount = 1 }` (**clase nueva**, ver abajo) |
+
+### `RelicCardPlayedBlockEffect` (clase nueva — Mundo B) `[PROPUESTA]`
+
+Archivo nuevo `Assets/Scripts/Gameplay/Relics/Effects/RelicCardPlayedBlockEffect.cs`
+(molde: `RelicAccSkillStackerEffect` para el cast de `CardPlayedHookData` + `RelicTurnBlockEffect`
+para el `GrantBlock`). Cero archivos protegidos: corre sobre el hook `OnCardPlayed` ya
+existente vía `RelicHookContext.GrantBlock` (ya existe en la API limitada).
+
+```
+[Serializable] class RelicCardPlayedBlockEffect : IRelicEffect
+  public int Amount = 1;
+  OnHook(hook, ctx):
+    if (hook != RelicHook.OnCardPlayed || ctx.TurnManager == null) return;
+    var cp = ctx as CardPlayedHookData;
+    if (cp?.Card == null) return;
+    bool isBlockCard = cp.Card.Effects.Any(e => e.effectType == EffectType.Block);
+    if (!isBlockCard) return;
+    ctx.GrantBlock(ctx.TurnManager.Player, Amount);
+```
+
+- **Detección de "carta de escudo":** NO existe `CardType.Block`. La convención del codebase
+  (`StarterDeckSetup.cs`, `CardUpgradeSetup.cs`) es inspeccionar `Card.Effects` y buscar un
+  `EffectRef` con `effectType == EffectType.Block`. El efecto usa esa misma convención.
+- **Pasivo incondicional respecto al mundo:** el pasivo aplica al jugar cualquier carta de
+  escudo en **cualquier** combate/mundo. **No** se filtra por `CardPlayedHookData.PlayedInWorld`
+  — el GDD describe el efecto sin condición de mundo, y el "mundo" del evento es elección
+  local del encuentro, no estado persistente (decisión cerrada). El campo `PlayedInWorld`
+  existe pero no se usa aquí.
+
+## Resolución del nodo destino del quest (regla corregida) `[PROPUESTA]`
+
+Reemplaza la nota `[PROPUESTA]` original (superseded; ver §Nota de destino). El destino se
+resuelve **al aceptar**, no se autora. Garantía exigida: el `DestinationNodeId` debe ser
+**alcanzable por BFS forward** desde el nodo del quest, distinto del propio nodo y no
+ya completado.
+
+**Algoritmo** (static puro, testeable sin UI):
+
+1. **BFS forward** desde el nodo del quest (`questNodeId`, = `RunState.CurrentPositionNodeId`
+   al aceptar) usando `MapNode.Connections` como adyacencia (mismo patrón que
+   `RunMapGenerator.ComputeNodeDepths`, pero arrancando `depth = 0` en `questNodeId`).
+   Produce `Dictionary<int,int> forwardDepth` con todos los nodos alcanzables y su distancia.
+2. **Candidatos** = nodos alcanzables EXCLUYENDO: `questNodeId`, los de `RunState.CompletedNodes`,
+   y el **Boss** (`node.Type == NodeType.Boss`).
+3. **Selección preferida:** de los candidatos, elegir el de **mayor `forwardDepth`** (el
+   destino más lejano = más "trayecto" = mejor para un MCguffin que se "lleva por el mapa");
+   desempate por **menor `Id`**. Determinista sin RNG (el mapa ya es determinista por seed).
+4. **Fallback** (candidatos vacíos — p. ej. Event en penúltimo nodo, donde el único forward
+   es el Boss): usar el **Boss/end** como destino (siempre alcanzable por construcción; es el
+   único nodo con garantía universal). El "punto resaltado" coincide entonces con el combate
+   final — caso raro y aceptable.
+
+> Por qué "más lejano" y no "+2/+3": en topologías A y C el más lejano no-Boss suele ser el
+> nodo de convergencia pre-boss (todos los caminos pasan por él → solo se falla por muerte);
+> en B a veces cae en un nodo de rama (→ se puede fallar tomando la otra ruta). Esa mezcla
+> de "forzado salvo muerte" vs "evitable por ruta" es exactamente el espacio de riesgo que
+> pide Q3, y un destino lejano maximiza el trayecto del MCguffin.
+
+**Ubicación (no en RunState):** la BFS es lógica de flujo → va en un helper static nuevo
+`Assets/Scripts/Run/Quests/QuestDestinationResolver.cs`:
+
+```
+static int SelectDestination(ActMap map, int questNodeId, ISet<int> completedNodes)
+```
+
+Golden Rule §7: `RunState = solo datos`. `RunState.StartQuest(QuestState)` recibe el
+`DestinationNodeId` **ya resuelto**; no calcula la BFS.
+
+### Wiring de `StartQuest` (flujo)
+
+La consecuencia `StartQuest` necesita el mapa (para resolver el destino), que la firma static
+`EventConsequence.Apply(state, dispatcher, c)` **no** tiene. Por eso:
+
+- `EventConsequence.Apply` mantiene su firma y maneja los **6 tipos simples**. **No** maneja
+  `StartQuest` (resolver un grafo no es mutación pura de datos). *(Corrige el hint de la línea
+  ~158 que sugería que `Apply` reusa `state.StartQuest`: la resolución del destino vive en el
+  flujo, no en `Apply`.)*
+- El **controller de flujo** (`EventNodeController` / `RunFlowController`, que tienen el
+  `ActMap`) detecta `Type == StartQuest` en la choice elegida y ejecuta:
+  1. `int dest = QuestDestinationResolver.SelectDestination(map, currentNodeId, state.CompletedNodes);`
+  2. `state.AddRelic(c.Quest.CarriedRelic);`
+  3. `state.StartQuest(new QuestState { Active = true, DestinationNodeId = dest, FinalRewardGold = c.Quest.FinalRewardGold, SourceWorldLabel = chosenWorld });`  *(SourceWorldLabel = "A"/"B" según la variante elegida)*
+- `RunMapView` resalta `state.ActiveQuest.DestinationNodeId` (persistente entre redibujos
+  hasta completar el quest).
+- En `RunFlowController.CompleteNode` (donde hoy se avanza el DAG): tras completar cualquier
+  nodo, `state.CompleteQuestIfDestination(node.Id)` → si coincide con el destino activo,
+  otorga `FinalRewardGold`, `Active = false`, devuelve true.
+
+### `[ALTERNATIVA]` descartada
+- **Restringir el placement del quest event** (que nunca caiga en penúltima capa, para
+  garantizar un destino no-Boss): requiere lógica especial en `RunMapGenerator` (que no sabe
+  cuál Event es el quest) o un swap post-generación. Más invasivo y toca generación de mapa.
+  El fallback al Boss lo resuelve sin tocar el generador.
+- **Destino autorado en el SO:** descartado ya en el spec base (el destino depende del mapa
+  por seed).
+
+## Casos de prueba adicionales (4b-2, sobre `QuestTests.cs`)
+
+Refinan/extienden los casos 8-14 del spec base:
+
+- **Caso 9 (expandido):** `QuestDestinationResolver.SelectDestination` es **alcanzable** y
+  válido para **toda topología × toda posición de Event (1..6)**. Iterar las 3 topologías
+  (forzar cada plantilla por seed, o exponer `Topologies` para test) y cada nodo intermedio
+  como quest: assert que el destino resuelto está en el BFS forward del nodo del quest, es
+  `!= questNodeId`, y `∉ CompletedNodes`.
+- **Caso 15 (fallback al Boss):** Event en penúltima capa (A@6 / B@5 / B@6 / C@6) → el destino
+  resuelto es el Boss (`Type == NodeType.Boss`), y es alcanzable.
+- **Caso 16 (determinismo):** misma `(map, questNodeId)` → mismo `DestinationNodeId` en
+  llamadas repetidas (sin RNG).
+
+## Checklist de autoría para `EventConfigSetup` (4b-2)
+
+Lo que el menú `Roguelike > Setup Event Config` debe crear/actualizar (idempotente, patrón
+`CreateOrUpdateEvent` existente):
+
+1. **2 Retazos MCguffin** en `Assets/ScriptableObjects/Relics/Quest/` vía
+   `CreateOrUpdateMcguffinRelic` (R-MCG-A con `RelicEndGoldEffect{Amount=2}`; R-MCG-B con
+   `RelicCardPlayedBlockEffect{Amount=1}`). **No** agregarlos a ningún drop pool.
+2. **3 EventDefinitions multidimensionales** (`IsMultidimensional = true`, con `WorldA`/`WorldB`):
+   `evt_md_forge`, `evt_md_relic`, `evt_md_quest_courier` (este último referencia los 2
+   MCguffin en sus `StartQuest`).
+3. Agregar los 3 al pool (`EventPoolConfig`) junto a los 3 simples de 4b-1 → 6 eventos.
+4. Backgrounds opcionales `Assets/Art/Events/fondo_<id>.png` (cadena de fallback def→pool→color
+   ya existe; sin arte = color).
 
 ```
 modo:implementacion
@@ -326,13 +600,59 @@ Al cerrar: actualizá `_roadmap.md` (checkbox de 4b-1) y `_tech_snapshot.md` (nu
 subsistema Events), commit + push + PR a main.
 ```
 
-## Prompt de handoff — Sub-PR 4b-2
+## Prompt de handoff para `modo:implementacion` — Sub-PR 4b-2
 
-> Se genera/afina al cerrar 4b-1 (depende de su motor mergeado). Resumen de scope
-> para esa sesión: agregar `IsMultidimensional` + variantes A/B a `EventDefinition`,
-> pantalla de elección de mundo en `EventNodeController`, `QuestState` en RunState
-> (`StartQuest`/`CompleteQuestIfDestination`), resolución del nodo destino con
-> alcanzabilidad + resaltado en `RunMapView`, `RelicCardPlayedBlockEffect`
-> (`OnCardPlayed`), el evento quest multidimensional placeholder en `EventConfigSetup`,
-> casos 8-14 en `QuestTests.cs`, y la transcripción de DD-021 a `DESIGN_DECISIONS.md`.
-> Branch: `feat/m4-4b2-events-quests` desde `origin/main` con 4b-1 ya mergeado.
+```
+modo:implementacion
+
+Implementá el Sub-PR 4b-2 (eventos multidimensionales + quest/MCguffin) de M4 bloque 4b.
+El spec cerrado está en `Docs/dev/specs/m4_4b_events_quests_spec.md` — leelo COMPLETO antes
+de tocar código, en especial la §"Contenido de Sub-PR 4b-2" (eventos, Retazos MCguffin,
+regla de destino corregida, wiring de StartQuest, tests). Todas las decisiones de diseño
+están cerradas; no abras ninguna. El contenido (textos, choices, stats) ya está autorado en
+el spec listo para EventConfigSetup.
+
+Setup de branch (4b-2 DEPENDE de 4b-1 mergeado — confirmá primero que PR #125 está en main):
+  git fetch --all --prune
+  git checkout -b feat/m4-4b2-events-quests origin/main
+
+Qué construir (contratos completos en el spec):
+- Crear: Assets/Scripts/Run/Quests/{QuestState, QuestDestinationResolver}.cs
+- Crear: Assets/Scripts/Gameplay/Relics/Effects/RelicCardPlayedBlockEffect.cs
+  (IRelicEffect sobre OnCardPlayed; detecta carta de escudo por Card.Effects con
+  EffectType.Block; ctx.GrantBlock(ctx.TurnManager.Player, Amount); incondicional al mundo)
+- Crear: Assets/Tests/EditMode/QuestTests.cs (casos 8-16 del spec)
+- Modificar: EventDefinition.cs (IsMultidimensional + WorldA/WorldB:EventVariant),
+  EventConsequence.cs (ConsequenceType.StartQuest AL FINAL del enum + payload QuestData),
+  EventResolver.cs (ResolveVariant(def, world)), EventNodeController.cs (pantalla de elección
+  de mundo previa, sobre Show(int, EventDefinition)), RunState.cs (QuestState ActiveQuest +
+  StartQuest + CompleteQuestIfDestination + Reset limpia ActiveQuest),
+  RunFlowController.cs (resolver destino vía QuestDestinationResolver al elegir StartQuest;
+  CompleteQuestIfDestination en CompleteNode), RunMapView.cs (resaltar DestinationNodeId),
+  EventConfigSetup.cs (2 Retazos MCguffin + 3 eventos multidim; ver Checklist de autoría)
+- Transcribir: Docs/design/DESIGN_DECISIONS.md → cerrar DD-021 (autoridad de Sebastián;
+  representación ya confirmada: MCguffin = Retazo + QuestState. Pedir OK antes de escribir.)
+
+Reglas no negociables:
+- NO tocar archivos protegidos (TurnManager, ActionQueue, PlayerCombatActor). 4b-2 NO los
+  toca: el pasivo Mundo B corre por el hook OnCardPlayed ya existente vía GrantBlock.
+- No manual editor setup: todo se auto-crea por el menú Roguelike > Setup Event Config.
+- StartQuest NO se maneja en EventConsequence.Apply (necesita el mapa) — la resolución del
+  destino vive en el flujo (controller) vía QuestDestinationResolver static. RunState NO
+  calcula la BFS (Golden Rule §7: RunState = solo datos).
+- Los 2 Retazos MCguffin NO entran a ningún drop pool (subcarpeta Relics/Quest/).
+- El evento quest tiene SOLO 2 choices (Aceptar/Robar), por GDD.
+
+Validación obligatoria antes de cerrar:
+- Compilación limpia (zero console errors).
+- QuestTests (casos 8-16) en verde + suite EditMode completa sin regresiones (hoy 212/212).
+- Correr el menú Roguelike > Setup Event Config (crea MCguffin + eventos multidim).
+- Flujo E2E en RunScene: evento multidim → elegir A vs B muestra enunciados/recompensas
+  distintos; Aceptar el quest → nodo destino resaltado + pasivo aplica en combate (oro extra
+  A / bloqueo extra B); llegar al destino otorga FinalRewardGold; Robar → +100 oro sin quest.
+- Validación de datos en Unity-MCP (asset de MCguffin: Hooks/Effect/Amount; serialización
+  de StartQuest en el evento quest).
+
+Al cerrar: actualizá `_roadmap.md` (checkbox de 4b-2) y `_tech_snapshot.md` (subsistema
+Quests + eventos multidim), commit + push + PR a main. Con esto cierra M4 bloque 4b completo.
+```

--- a/Docs/dev/specs/m4_4b_events_quests_spec.md
+++ b/Docs/dev/specs/m4_4b_events_quests_spec.md
@@ -1,6 +1,6 @@
 # Spec — M4 bloque 4b: Eventos + Quests (DD-005, DD-021)
 
-> **ESTADO: 4b-1 IMPLEMENTADO — PR #125 (2026-06-18). 4b-2 PROPUESTA.**
+> **ESTADO: IMPLEMENTADO — 4b-1 PR #125 (2026-06-18) · 4b-2 PR #126 (2026-06-19).**
 >
 > Spec cerrado el 2026-06-18 en sesión `modo:diseno`. Las 4 decisiones abiertas
 > quedaron cerradas por Sebastián (ver §Decisiones cerradas). Dividido en **2


### PR DESCRIPTION
## Summary

- Subsistema de quests: `QuestState` + `QuestDestinationResolver` (BFS forward, sin RNG, determinista), `RelicCardPlayedBlockEffect` (pasivo MCguffin Mundo B: +1 bloqueo al jugar carta de escudo vía `OnCardPlayed`).
- Eventos multidimensionales: `EventDefinition` gana `EventVariant` serializable (`IsMultidimensional`, `WorldA`, `WorldB`). `EventNodeController` muestra pantalla de elección de mundo A/B antes de las choices. `EventResolver.ResolveVariant`.
- Quest/MCguffin: `EventConsequence` gana `ConsequenceType.StartQuest` + `QuestData`. `HandleStartQuest` en el controller resuelve destino por BFS forward y llama `state.StartQuest`. `RunState` gana `ActiveQuest + StartQuest + CompleteQuestIfDestination`. `RunFlowController.CompleteNode` llama `CompleteQuestIfDestination`.
- Mapa: `RunMapNodeView.SetQuestHighlight` + color ámbar `QuestDestBg`; `RunMapView.Refresh` resalta el nodo destino del quest activo de forma persistente.
- `EventConfigSetup` extendido: 2 Retazos MCguffin en `Relics/Quest/` (R-MCG-A + R-MCG-B) + 3 eventos multidim (`evt_md_forge`, `evt_md_relic`, `evt_md_quest_courier`). Pool total: 6 eventos.
- `QuestTests.cs` (casos 8-16 del spec): ResolveVariant A≠B, SelectDestination todas las topologías × nodos 1..6, CompleteQuestIfDestination, Robar=+100 sin quest, Reset limpia quest, RelicCardPlayedBlockEffect, fallback al Boss, determinismo.

## Test plan

- [ ] Abrir Unity y verificar compilación limpia (cero console errors)
- [ ] Window > Test Runner > EditMode > Run All → suite verde (212 → 221+/221+ esperados)
- [ ] Menú `Roguelike > Setup Event Config` → crea MCguffin assets + eventos multidim en `Relics/Quest/` y `Events/`
- [ ] RunScene: nodo Event multidimensional → elegir A vs B muestra enunciados/recompensas distintos
- [ ] RunScene: Aceptar el quest → nodo destino resaltado en ámbar; pasivo activo en combate (oro extra A / bloqueo extra B); llegar al destino otorga FinalRewardGold (75)
- [ ] RunScene: Robar → +100 oro inmediato, sin quest activo, sin Retazo en inventario
- [ ] Zero console errors en todo el flujo

Closes M4 bloque 4b completo (4b-1 PR #125 ya mergeado + esta 4b-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)