### PR TITLE
feat(enemies): M4 4c — transdimensionales + ancla (cierra M4)

### DIFF
--- a/Assets/Editor/EnemyConfigSetup.cs
+++ b/Assets/Editor/EnemyConfigSetup.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using RoguelikeCardBattler.Gameplay.Cards;
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Gameplay.Enemies;
+
+namespace RoguelikeCardBattler.Editor
+{
+    /// <summary>
+    /// M4 4c — genera (o reutiliza) 2 EnemyDefinitions de prueba para validar el
+    /// tipo activo por mundo en BattleScene: <c>TransdimTestEnemy</c> (transdim,
+    /// Rojo en Mundo A / Azul en Mundo B) y <c>AnchorTestEnemy</c> (ancla, Morado
+    /// fijo). Idempotente y NO toca los 5 SOs de enemigos existentes. Molde espejo
+    /// de <c>EventConfigSetup</c>.
+    /// </summary>
+    public static class EnemyConfigSetup
+    {
+        private const string EnemiesFolder = "Assets/ScriptableObjects/Enemies";
+
+        [MenuItem("Roguelike/Setup Enemy Test Data (4c)")]
+        public static void Setup()
+        {
+            EnsureFolder("Assets/ScriptableObjects", "Enemies", EnemiesFolder);
+
+            EnemyDefinition transdim = CreateOrUpdateEnemy(
+                "TransdimTestEnemy",
+                id: "enemy_transdim_test",
+                name: "Transdim de prueba",
+                maxHp: 40,
+                elementType: ElementType.Rojo,   // Mundo A
+                typeWorldB: ElementType.Azul,     // Mundo B
+                isAnchor: false);
+
+            EnemyDefinition anchor = CreateOrUpdateEnemy(
+                "AnchorTestEnemy",
+                id: "enemy_anchor_test",
+                name: "Ancla de prueba",
+                maxHp: 40,
+                elementType: ElementType.Morado,  // tipo fijo
+                typeWorldB: ElementType.None,
+                isAnchor: true);
+
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+
+            Debug.Log($"[EnemyConfigSetup] Listos: {transdim.name} (transdim Rojo/Azul) " +
+                      $"y {anchor.name} (ancla Morado). Carpeta: {EnemiesFolder}.");
+        }
+
+        private static EnemyDefinition CreateOrUpdateEnemy(
+            string assetName, string id, string name, int maxHp,
+            ElementType elementType, ElementType typeWorldB, bool isAnchor)
+        {
+            string path = $"{EnemiesFolder}/{assetName}.asset";
+            EnemyDefinition def = AssetDatabase.LoadAssetAtPath<EnemyDefinition>(path);
+            if (def == null)
+            {
+                def = ScriptableObject.CreateInstance<EnemyDefinition>();
+                AssetDatabase.CreateAsset(def, path);
+                Debug.Log($"[EnemyConfigSetup] Enemy creado: {path}");
+            }
+
+            def.SetDebugData(
+                id,
+                name,
+                maxHp,
+                0,
+                EnemyAIPattern.Sequence,
+                new List<string>(),
+                BuildMoves(),
+                1f,
+                null,
+                elementType,
+                typeWorldB,
+                isAnchor);
+            EditorUtility.SetDirty(def);
+            return def;
+        }
+
+        // Un único ataque para que el enemigo golpee al jugador en el E2E (sirve
+        // para ver el cambio de efectividad enemigo→jugador al conmutar de mundo).
+        private static List<EnemyMove> BuildMoves()
+        {
+            var attack = new EnemyMove();
+            attack.SetDebugData(
+                "mv_attack",
+                "Golpe",
+                "Un golpe directo.",
+                new List<EffectRef>
+                {
+                    new EffectRef
+                    {
+                        effectType = EffectType.Damage,
+                        value = 8,
+                        target = EffectTarget.SingleEnemy,
+                    },
+                },
+                newWeight: 1,
+                newSequenceIndex: 0,
+                newIntentType: EnemyIntentType.Attack);
+            return new List<EnemyMove> { attack };
+        }
+
+        private static void EnsureFolder(string parent, string newFolder, string fullPath)
+        {
+            if (!AssetDatabase.IsValidFolder(fullPath))
+                AssetDatabase.CreateFolder(parent, newFolder);
+        }
+    }
+}

--- a/Assets/Editor/EnemyConfigSetup.cs.meta
+++ b/Assets/Editor/EnemyConfigSetup.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a51e728c404c0424b997079782939d59

--- a/Assets/ScriptableObjects/Enemies/AnchorTestEnemy.asset
+++ b/Assets/ScriptableObjects/Enemies/AnchorTestEnemy.asset
@@ -1,0 +1,41 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 338b6c04c3364f30af226f884a2d4f1d, type: 3}
+  m_Name: AnchorTestEnemy
+  m_EditorClassIdentifier: RoguelikeCardBattler::RoguelikeCardBattler.Gameplay.Enemies.EnemyDefinition
+  id: enemy_anchor_test
+  enemyName: Ancla de prueba
+  maxHP: 40
+  baseBlock: 0
+  aiPattern: 1
+  tags: []
+  moves:
+  - id: mv_attack
+    moveName: Golpe
+    description: Un golpe directo.
+    effects:
+    - effectType: 0
+      value: 8
+      target: 1
+      statusType: 0
+      extraParams: []
+    weight: 1
+    sequenceIndex: 0
+    intentType: 1
+    minHpPercent: 0
+    maxHpPercent: 100
+  avatarScale: 1
+  avatarOffset: {x: 0, y: 0}
+  elementType: 4
+  typeWorldB: 0
+  isAnchor: 1
+  avatar: {fileID: 0}

--- a/Assets/ScriptableObjects/Enemies/AnchorTestEnemy.asset.meta
+++ b/Assets/ScriptableObjects/Enemies/AnchorTestEnemy.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fbbe3e9ce826d84458083fdf2dbf3846
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Enemies/TransdimTestEnemy.asset
+++ b/Assets/ScriptableObjects/Enemies/TransdimTestEnemy.asset
@@ -1,0 +1,41 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 338b6c04c3364f30af226f884a2d4f1d, type: 3}
+  m_Name: TransdimTestEnemy
+  m_EditorClassIdentifier: RoguelikeCardBattler::RoguelikeCardBattler.Gameplay.Enemies.EnemyDefinition
+  id: enemy_transdim_test
+  enemyName: Transdim de prueba
+  maxHP: 40
+  baseBlock: 0
+  aiPattern: 1
+  tags: []
+  moves:
+  - id: mv_attack
+    moveName: Golpe
+    description: Un golpe directo.
+    effects:
+    - effectType: 0
+      value: 8
+      target: 1
+      statusType: 0
+      extraParams: []
+    weight: 1
+    sequenceIndex: 0
+    intentType: 1
+    minHpPercent: 0
+    maxHpPercent: 100
+  avatarScale: 1
+  avatarOffset: {x: 0, y: 0}
+  elementType: 1
+  typeWorldB: 3
+  isAnchor: 0
+  avatar: {fileID: 0}

--- a/Assets/ScriptableObjects/Enemies/TransdimTestEnemy.asset.meta
+++ b/Assets/ScriptableObjects/Enemies/TransdimTestEnemy.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1285c6fc6547eb342954d8141a755351
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Combat/CombatHudView.cs
+++ b/Assets/Scripts/Gameplay/Combat/CombatHudView.cs
@@ -167,10 +167,20 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             _playerHpLabel.text = $"{_turnManager.PlayerHP}/{_turnManager.PlayerMaxHP}";
             _enemyHpLabel.text = $"{_turnManager.EnemyHP}/{_turnManager.EnemyMaxHP}";
             _enemyTypeLabel.text = BuildEnemyTypeLabel();
-            ElementType enemyType = _turnManager.EnemyElementType;
-            _enemyTypeLabel.color = enemyType == ElementType.None
-                ? Color.white
-                : ElementTypeColors.ReadableOnDark(enemyType);
+            EnemyDefinition enemyDef = _turnManager.CurrentEnemyDefinition;
+            if (enemyDef != null && enemyDef.IsTransdimensional)
+            {
+                // Dos tipos: el color lo aporta el rich-text inline por tipo, así que
+                // el label debe ir en blanco (un único Text no puede tener dos .color).
+                _enemyTypeLabel.color = Color.white;
+            }
+            else
+            {
+                ElementType enemyType = _turnManager.EnemyElementType;
+                _enemyTypeLabel.color = enemyType == ElementType.None
+                    ? Color.white
+                    : ElementTypeColors.ReadableOnDark(enemyType);
+            }
             _drawPileText.text = $"Draw: {_turnManager.PlayerDrawPileCount}";
             _discardPileText.text = $"Discard: {_turnManager.PlayerDiscardPileCount}";
             _enemyIntentText.text = BuildEnemyIntentLabel();
@@ -262,15 +272,33 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             };
         }
 
+        // Factor de atenuación del tipo del mundo inactivo en la ficha transdim.
+        private const float TransdimDimFactor = 0.45f;
+
         private string BuildEnemyTypeLabel()
         {
-            if (_turnManager == null)
+            EnemyDefinition def = _turnManager?.CurrentEnemyDefinition;
+            if (_turnManager == null || def == null)
             {
                 return "Type: —";
             }
 
-            ElementType type = _turnManager.EnemyElementType;
-            return type == ElementType.None ? "Type: —" : $"Type: {type}";
+            if (!def.IsTransdimensional)
+            {
+                // Tipo único o ancla → un solo tipo (resuelto por el getter).
+                ElementType type = _turnManager.EnemyElementType;
+                return type == ElementType.None ? "Type: —" : $"Type: {type}";
+            }
+
+            // Transdimensional → dos tipos: el del mundo activo a color pleno, el otro atenuado.
+            bool activeIsA = _turnManager.CurrentWorld == TurnManager.WorldSide.A;
+            string prefixA = activeIsA
+                ? ElementTypeColors.TypePrefix(def.ElementType)
+                : ElementTypeColors.TypePrefix(def.ElementType, TransdimDimFactor);
+            string prefixB = activeIsA
+                ? ElementTypeColors.TypePrefix(def.TypeWorldB, TransdimDimFactor)
+                : ElementTypeColors.TypePrefix(def.TypeWorldB);
+            return $"Type: {prefixA} / {prefixB}";
         }
 
         private void UpdateBlockVisuals(Text label, Image overlay, int blockValue)

--- a/Assets/Scripts/Gameplay/Combat/ElementTypeColors.cs
+++ b/Assets/Scripts/Gameplay/Combat/ElementTypeColors.cs
@@ -76,11 +76,17 @@ namespace RoguelikeCardBattler.Gameplay.Combat
         /// (ReadableOnDark). Fuente única de verdad del patrón que antes vivía inline en
         /// CardHandView.BuildCardLabel. Devuelve string.Empty para ElementType.None (sin
         /// prefijo). NO incluye espacio final ni separador — el caller decide el formato.
+        ///
+        /// <paramref name="brightness"/> &lt; 1 atenúa el color con <see cref="Dim"/>
+        /// (4c: ficha transdimensional renderiza el tipo del mundo inactivo apagado).
+        /// El default 1f mantiene el comportamiento original a color pleno.
         /// </summary>
-        public static string TypePrefix(ElementType type)
+        public static string TypePrefix(ElementType type, float brightness = 1f)
         {
             if (type == ElementType.None) return string.Empty;
-            string hex = ColorUtility.ToHtmlStringRGB(ReadableOnDark(type));
+            Color c = ReadableOnDark(type);
+            if (brightness < 1f) c = Dim(c, brightness);
+            string hex = ColorUtility.ToHtmlStringRGB(c);
             return $"<color=#{hex}>[{type}]</color>";
         }
 

--- a/Assets/Scripts/Gameplay/Combat/TurnManager.cs
+++ b/Assets/Scripts/Gameplay/Combat/TurnManager.cs
@@ -109,7 +109,26 @@ namespace RoguelikeCardBattler.Gameplay.Combat
 
         public float CurrentEnemyAvatarScale => enemyDefinition != null ? Mathf.Max(0.1f, enemyDefinition.AvatarScale) : 1f;
         public Vector2 CurrentEnemyAvatarOffset => enemyDefinition != null ? enemyDefinition.AvatarOffset : Vector2.zero;
-        public ElementType EnemyElementType => enemyDefinition != null ? enemyDefinition.ElementType : ElementType.None;
+        /// <summary>
+        /// Tipo elemental ACTIVO del enemigo, resuelto por mundo/ancla (M4 4c).
+        /// Punto único de verdad: las lecturas de daño (atacante y defensor) y el
+        /// HUD lo consumen. Firma sin cambios respecto al getter original; solo
+        /// cambia la semántica (antes devolvía siempre enemyDefinition.ElementType).
+        /// - Ancla: ignora el mundo (precede a typeWorldB aunque esté seteado).
+        /// - Transdimensional en Mundo B: usa TypeWorldB.
+        /// - Mundo A o tipo único: tipo base (elementType).
+        /// </summary>
+        public ElementType EnemyElementType
+        {
+            get
+            {
+                if (enemyDefinition == null) return ElementType.None;
+                if (enemyDefinition.IsAnchor) return enemyDefinition.ElementType;
+                if (currentWorld == WorldSide.B && enemyDefinition.TypeWorldB != ElementType.None)
+                    return enemyDefinition.TypeWorldB;
+                return enemyDefinition.ElementType;
+            }
+        }
         public EnemyDefinition CurrentEnemyDefinition => enemyDefinition;
         public int StyleCharges => _styleCharges;
         // Refs read-only para que IRelicEffect (Sub-PR 3B) pueda invocar la API
@@ -413,7 +432,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
             _plannedEnemyMove = null;
             if (move != null)
             {
-                QueueEffects(move.Effects, _enemy, _player, enemyDefinition?.ElementType ?? ElementType.None);
+                QueueEffects(move.Effects, _enemy, _player, EnemyElementType);
                 _actionQueue.ProcessAll();
             }
 
@@ -621,7 +640,7 @@ namespace RoguelikeCardBattler.Gameplay.Combat
                 return neutralAmount;
             }
 
-            ElementType defenderType = enemyDefinition != null ? enemyDefinition.ElementType : ElementType.None;
+            ElementType defenderType = EnemyElementType;
             Effectiveness effectiveness = ElementEffectiveness.GetEffectiveness(attackerType, defenderType);
             float multiplier = EffectivenessMultipliers.For(effectiveness);
             int finalAmount = Math.Max(0, Mathf.RoundToInt(baseAmount * multiplier));

--- a/Assets/Scripts/Gameplay/Enemies/EnemyDefinition.cs
+++ b/Assets/Scripts/Gameplay/Enemies/EnemyDefinition.cs
@@ -20,6 +20,11 @@ namespace RoguelikeCardBattler.Gameplay.Enemies
         [SerializeField] private float avatarScale = 1f;
         [SerializeField] private Vector2 avatarOffset = Vector2.zero;
         [SerializeField] private ElementType elementType = ElementType.None;
+        // Tipo en Mundo B. Solo significativo si el enemigo es transdimensional
+        // (typeWorldB != None && !isAnchor). Para tipo-único y ancla queda en None.
+        [SerializeField] private ElementType typeWorldB = ElementType.None;
+        // Si true, el tipo NO reacciona al cambio de mundo (ancla). Precede a typeWorldB.
+        [SerializeField] private bool isAnchor = false;
         [SerializeField] private Sprite avatar = null;
 
         public string Id => id;
@@ -32,6 +37,13 @@ namespace RoguelikeCardBattler.Gameplay.Enemies
         public float AvatarScale => avatarScale;
         public Vector2 AvatarOffset => avatarOffset;
         public ElementType ElementType => elementType;
+        public ElementType TypeWorldB => typeWorldB;
+        public bool IsAnchor => isAnchor;
+
+        // Derivada: un enemigo es transdimensional si tiene un tipo de Mundo B
+        // distinto y NO es ancla. No es un flag serializado (evita superficie de
+        // autoría redundante) — se computa de los otros dos campos.
+        public bool IsTransdimensional => !isAnchor && typeWorldB != ElementType.None;
         public Sprite Avatar => avatar;
 
 #if UNITY_EDITOR || UNITY_INCLUDE_TESTS
@@ -45,7 +57,9 @@ namespace RoguelikeCardBattler.Gameplay.Enemies
             List<EnemyMove> newMoves,
             float newAvatarScale = 1f,
             Vector2? newAvatarOffset = null,
-            ElementType newElementType = ElementType.None)
+            ElementType newElementType = ElementType.None,
+            ElementType newTypeWorldB = ElementType.None,
+            bool newIsAnchor = false)
         {
             id = newId;
             enemyName = newName;
@@ -57,6 +71,8 @@ namespace RoguelikeCardBattler.Gameplay.Enemies
             avatarScale = Mathf.Max(0.1f, newAvatarScale);
             avatarOffset = newAvatarOffset ?? Vector2.zero;
             elementType = newElementType;
+            typeWorldB = newTypeWorldB;
+            isAnchor = newIsAnchor;
         }
 #endif
     }

--- a/Assets/Tests/EditMode/CombatTestBase.cs
+++ b/Assets/Tests/EditMode/CombatTestBase.cs
@@ -122,7 +122,9 @@ namespace RoguelikeCardBattler.Tests.EditMode
             int maxHp,
             EnemyAIPattern pattern,
             List<EnemyMove> moves,
-            ElementType elementType = ElementType.None)
+            ElementType elementType = ElementType.None,
+            ElementType typeWorldB = ElementType.None,
+            bool isAnchor = false)
         {
             var enemy = ScriptableObject.CreateInstance<EnemyDefinition>();
             enemy.SetDebugData(
@@ -135,7 +137,9 @@ namespace RoguelikeCardBattler.Tests.EditMode
                 moves ?? new List<EnemyMove>(),
                 1f,
                 null,
-                elementType);
+                elementType,
+                typeWorldB,
+                isAnchor);
 
             _createdAssets.Add(enemy);
             return enemy;

--- a/Assets/Tests/EditMode/ElementTypeColorsTests.cs
+++ b/Assets/Tests/EditMode/ElementTypeColorsTests.cs
@@ -126,5 +126,42 @@ namespace RoguelikeCardBattler.Tests.EditMode
                     $"{type} debe incluir su nombre entre corchetes");
             }
         }
+
+        // ── TypePrefix brightness overload (M4 4c) ────────────────────────────
+
+        [Test]
+        public void TypePrefix_BrightnessOne_EqualsDefault()
+        {
+            // brightness == 1 no atenúa: idéntico al overload sin parámetro.
+            Assert.AreEqual(
+                ElementTypeColors.TypePrefix(ElementType.Rojo),
+                ElementTypeColors.TypePrefix(ElementType.Rojo, 1f),
+                "brightness=1 debe igualar el comportamiento a color pleno.");
+        }
+
+        [Test]
+        public void TypePrefix_BrightnessBelowOne_DimsHexTowardBlack()
+        {
+            // brightness < 1 aplica Dim → el hex resultante debe ser el de Dim(ReadableOnDark).
+            const float dim = 0.45f;
+            Color expectedColor = ElementTypeColors.Dim(
+                ElementTypeColors.ReadableOnDark(ElementType.Azul), dim);
+            string expectedHex = ColorUtility.ToHtmlStringRGB(expectedColor);
+
+            string dimmed = ElementTypeColors.TypePrefix(ElementType.Azul, dim);
+            StringAssert.Contains(expectedHex, dimmed,
+                "El hex atenuado debe coincidir con Dim(ReadableOnDark, factor).");
+            Assert.AreNotEqual(
+                ElementTypeColors.TypePrefix(ElementType.Azul),
+                dimmed,
+                "El prefijo atenuado debe diferir del pleno.");
+        }
+
+        [Test]
+        public void TypePrefix_BrightnessOnNone_StillReturnsEmpty()
+        {
+            Assert.AreEqual(string.Empty, ElementTypeColors.TypePrefix(ElementType.None, 0.45f),
+                "None no genera prefijo aunque se pida atenuado.");
+        }
     }
 }

--- a/Assets/Tests/EditMode/EnemyTransdimTests.cs
+++ b/Assets/Tests/EditMode/EnemyTransdimTests.cs
@@ -1,0 +1,162 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using RoguelikeCardBattler.Gameplay.Cards;
+using RoguelikeCardBattler.Gameplay.Combat;
+using RoguelikeCardBattler.Gameplay.Enemies;
+using UnityEngine;
+
+namespace RoguelikeCardBattler.Tests.EditMode
+{
+    /// <summary>
+    /// M4 4c — enemigos transdimensionales (tipo activo conmuta con el mundo) y
+    /// ancla (tipo fijo). Cubre defaults/derivada de EnemyDefinition, la resolución
+    /// de TurnManager.EnemyElementType por mundo/ancla, y que esa resolución fluye
+    /// al daño orgánico. NO re-asierta la tabla de efectividad (eso es de
+    /// ElementEffectivenessTests) — asierta que el tipo activo usado cambió.
+    /// </summary>
+    public class EnemyTransdimTests : CombatTestBase
+    {
+        private TurnManager CreateTurnManager(CardDefinition card, EnemyDefinition enemy)
+        {
+            var deck = new List<CardDeckEntry> { CreateSingleCardEntry(card) };
+
+            var go = CreateGameObject("TurnManager");
+            var manager = AddComponent<TurnManager>(go);
+            manager.SetTestConfig(maxHp: 30, energy: 3, startingHand: 1, cardsPerTurnCount: 1);
+            manager.SetTestData(deck, enemy);
+            return manager;
+        }
+
+        // ── Caso 1: defaults (regresión / guard) ────────────────────────────────
+        [Test]
+        public void EnemyDefinition_FreshInstance_HasTransdimDefaults()
+        {
+            var enemy = ScriptableObject.CreateInstance<EnemyDefinition>();
+            Assert.AreEqual(ElementType.None, enemy.TypeWorldB, "typeWorldB debe defaultear a None.");
+            Assert.IsFalse(enemy.IsAnchor, "isAnchor debe defaultear a false.");
+            Assert.IsFalse(enemy.IsTransdimensional, "Sin typeWorldB ni anchor, no es transdim.");
+            Object.DestroyImmediate(enemy);
+        }
+
+        // ── Caso 2: IsTransdimensional derivada ─────────────────────────────────
+        [Test]
+        public void IsTransdimensional_TrueOnlyWithTypeWorldBAndNotAnchor()
+        {
+            // typeWorldB != None && !anchor → true
+            var transdim = CreateEnemyDefinition(
+                "td", "Transdim", 10, EnemyAIPattern.Sequence, new List<EnemyMove>(),
+                elementType: ElementType.Rojo, typeWorldB: ElementType.Azul, isAnchor: false);
+            Assert.IsTrue(transdim.IsTransdimensional);
+
+            // anchor (aun con typeWorldB seteado) → false
+            var anchored = CreateEnemyDefinition(
+                "an", "Anchor", 10, EnemyAIPattern.Sequence, new List<EnemyMove>(),
+                elementType: ElementType.Rojo, typeWorldB: ElementType.Azul, isAnchor: true);
+            Assert.IsFalse(anchored.IsTransdimensional, "Ancla nunca es transdim, aunque tenga typeWorldB.");
+
+            // typeWorldB == None → false
+            var single = CreateEnemyDefinition(
+                "sg", "Single", 10, EnemyAIPattern.Sequence, new List<EnemyMove>(),
+                elementType: ElementType.Rojo, typeWorldB: ElementType.None, isAnchor: false);
+            Assert.IsFalse(single.IsTransdimensional, "Sin typeWorldB no es transdim.");
+        }
+
+        // ── Caso 3: resolución transdim sigue el mundo ──────────────────────────
+        [Test]
+        public void EnemyElementType_Transdim_FollowsCurrentWorld()
+        {
+            var card = CreateCardWithElement("filler", CardType.Skill, CardTarget.Self, cost: 99, ElementType.None);
+            var enemy = CreateEnemyDefinition(
+                "enemy_td", "Transdim", 30, EnemyAIPattern.Sequence, new List<EnemyMove>(),
+                elementType: ElementType.Rojo, typeWorldB: ElementType.Azul, isAnchor: false);
+
+            var manager = CreateTurnManager(card, enemy);
+            manager.InitializeCombat();
+
+            // Mundo A → tipo de A (Rojo).
+            Assert.AreEqual(TurnManager.WorldSide.A, manager.CurrentWorld);
+            Assert.AreEqual(ElementType.Rojo, manager.EnemyElementType);
+
+            // Mundo B → tipo de B (Azul).
+            manager.SetCurrentWorldForTest(TurnManager.WorldSide.B);
+            Assert.AreEqual(ElementType.Azul, manager.EnemyElementType);
+
+            // Volver a A → vuelve al tipo de A.
+            manager.SetCurrentWorldForTest(TurnManager.WorldSide.A);
+            Assert.AreEqual(ElementType.Rojo, manager.EnemyElementType);
+        }
+
+        // ── Caso 4: resolución ancla ignora el mundo ────────────────────────────
+        [Test]
+        public void EnemyElementType_Anchor_IgnoresWorld()
+        {
+            var card = CreateCardWithElement("filler", CardType.Skill, CardTarget.Self, cost: 99, ElementType.None);
+            // Ancla con typeWorldB seteado por error → igual ignora el mundo (isAnchor precede).
+            var enemy = CreateEnemyDefinition(
+                "enemy_anchor", "Anchor", 30, EnemyAIPattern.Sequence, new List<EnemyMove>(),
+                elementType: ElementType.Morado, typeWorldB: ElementType.Azul, isAnchor: true);
+
+            var manager = CreateTurnManager(card, enemy);
+            manager.InitializeCombat();
+
+            Assert.AreEqual(ElementType.Morado, manager.EnemyElementType);
+            manager.SetCurrentWorldForTest(TurnManager.WorldSide.B);
+            Assert.AreEqual(ElementType.Morado, manager.EnemyElementType, "El ancla no cambia de tipo con el mundo.");
+        }
+
+        // ── Caso 5: tipo único (backward-compat) ────────────────────────────────
+        [Test]
+        public void EnemyElementType_SingleType_SameInBothWorlds()
+        {
+            var card = CreateCardWithElement("filler", CardType.Skill, CardTarget.Self, cost: 99, ElementType.None);
+            var enemy = CreateEnemyDefinition(
+                "enemy_single", "Single", 30, EnemyAIPattern.Sequence, new List<EnemyMove>(),
+                elementType: ElementType.Amarillo, typeWorldB: ElementType.None, isAnchor: false);
+
+            var manager = CreateTurnManager(card, enemy);
+            manager.InitializeCombat();
+
+            Assert.AreEqual(ElementType.Amarillo, manager.EnemyElementType);
+            manager.SetCurrentWorldForTest(TurnManager.WorldSide.B);
+            Assert.AreEqual(ElementType.Amarillo, manager.EnemyElementType, "Tipo único no cambia con el mundo.");
+        }
+
+        // ── Caso 6: combate orgánico (la resolución fluye al daño) ──────────────
+        // Enemigo transdim Azul(A)/Amarillo(B). Carta Rojo 10 daño.
+        //   Rojo→Azul     = SuperEficaz → round(10*1.5) = 15.
+        //   Rojo→Amarillo = PocoEficaz  → round(10*0.75) = 8.
+        // No re-asierta la tabla; asierta que el daño cambia porque el tipo activo
+        // del enemigo conmutó con el mundo.
+        [Test]
+        public void EnemyElementType_Transdim_DamageEffectivenessChangesWithWorld()
+        {
+            // Mundo A: tipo activo del enemigo = Azul → SuperEficaz.
+            var cardA = CreateCardWithElement(
+                "strike_rojo_a", CardType.Attack, CardTarget.SingleEnemy, cost: 0, ElementType.Rojo,
+                CreateEffect(EffectType.Damage, 10, EffectTarget.SingleEnemy));
+            var enemyA = CreateEnemyDefinition(
+                "enemy_td_a", "Transdim A", maxHp: 50, EnemyAIPattern.Sequence, new List<EnemyMove>(),
+                elementType: ElementType.Azul, typeWorldB: ElementType.Amarillo, isAnchor: false);
+            var managerA = CreateTurnManager(cardA, enemyA);
+            managerA.InitializeCombat();
+            Assert.AreEqual(TurnManager.WorldSide.A, managerA.CurrentWorld);
+            managerA.PlayCard(managerA.PlayerHand[0]);
+            Assert.AreEqual(50 - 15, managerA.EnemyHP,
+                "Mundo A: tipo activo Azul → Rojo SuperEficaz → round(10*1.5)=15.");
+
+            // Mundo B: tipo activo del enemigo = Amarillo → PocoEficaz.
+            var cardB = CreateCardWithElement(
+                "strike_rojo_b", CardType.Attack, CardTarget.SingleEnemy, cost: 0, ElementType.Rojo,
+                CreateEffect(EffectType.Damage, 10, EffectTarget.SingleEnemy));
+            var enemyB = CreateEnemyDefinition(
+                "enemy_td_b", "Transdim B", maxHp: 50, EnemyAIPattern.Sequence, new List<EnemyMove>(),
+                elementType: ElementType.Azul, typeWorldB: ElementType.Amarillo, isAnchor: false);
+            var managerB = CreateTurnManager(cardB, enemyB);
+            managerB.InitializeCombat();
+            managerB.SetCurrentWorldForTest(TurnManager.WorldSide.B);
+            managerB.PlayCard(managerB.PlayerHand[0]);
+            Assert.AreEqual(50 - 8, managerB.EnemyHP,
+                "Mundo B: tipo activo Amarillo → Rojo PocoEficaz → round(10*0.75)=8.");
+        }
+    }
+}

--- a/Assets/Tests/EditMode/EnemyTransdimTests.cs.meta
+++ b/Assets/Tests/EditMode/EnemyTransdimTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9a9af04103135b7448c110081f97fdff

--- a/Docs/dev/GOLDEN_RULES.md
+++ b/Docs/dev/GOLDEN_RULES.md
@@ -63,8 +63,8 @@
 - ✓ Cambiar de mundo afecta:
   - Que lado de las cartas duales esta activo
   - El tipo activo del jugador (= tipo asignado al mundo)
-  - El tipo activo de enemigos transdimensionales (ver §6) — ⏳ pendiente
-  - NO afecta enemigos ancla (ver §6) — ⏳ pendiente
+  - El tipo activo de enemigos transdimensionales (ver §6) — ✓ implementado (M4 4c, PR #130)
+  - NO afecta enemigos ancla (ver §6) — ✓ implementado (M4 4c, PR #130)
 
 ---
 
@@ -188,7 +188,7 @@
 - Sequence: cicla por movimientos en orden
 - PhaseBased: declarado, no implementado aun (pendiente en M2)
 
-### Categorias dimensionales (⏳ DD-014)
+### Categorias dimensionales (✓ DD-014 — implementado M4 4c, PR #130)
 - **Estandar**: 1 o mas tipos elementales. El tipo activo cambia instantaneamente con el cambio de mundo del jugador. La ficha muestra ambos tipos cuando aplica
 - **Ancla**: tipo elemental fijo e invariable. No reacciona al cambio de mundo. Funcion estrategica: forzar al jugador a resolver con el mundo actual o construir mazo versatil
 

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -365,7 +365,7 @@ PR #127), **4c** enemigos transdimensionales + ancla (PR #130, ÚNICO bloque que
 TurnManager). El getter `EnemyElementType` resuelto por mundo/ancla + la ficha de dos
 tipos son el patrón que **M5** (boss Acto 1, DD-004) reutiliza. Detalle por bloque
 arriba (histórico de implementación). Suite EditMode 230/230 al cierre.
-**Pendiente de confirmación de Sebastián:** GOLDEN_RULES §2 + §6 (transdim/ancla ✓).
+GOLDEN_RULES §2 + §6 (transdim/ancla ✓) confirmados y commiteados 2026-06-29 (PR #130).
 
 ### M3 — Personalización del run
 **Fecha cierre:** 2026-06-05 (mapa horizontal 3F como último sub-PR cierra el milestone)

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -7,11 +7,17 @@
 > En `modo:implementacion` se lee al inicio para saber qué milestone está activo
 > y qué sub-tareas quedan.
 >
-> **Fase actual:** M4 activo. Pre-M4 visor de mazo: ✅ CERRADO (2026-06-17). Bloque 4a: ✅ CERRADO (2026-06-17). Bloque 4b-1: ✅ CERRADO (2026-06-18). Bloque 4b-2: ✅ CERRADO (2026-06-19). **Bloque 4b COMPLETO.**
-> **Milestone activo:** M4 — Resto del Acto 1 (bloques: 4a integridad de cartas, 4b eventos+quests, 4c transdim+ancla)
-> **Próximo bloque:** M4 bloque **4c** — Transdimensionales + Ancla (mecánico, patrón para M5). **ÚNICO bloque de M4 que toca archivos protegidos** (TurnManager). Arranca con sesión `modo:diseno` para su spec.
-> Próximo paso: spec de 4c con `modo:diseno` (campo `TypeWorldB` + flag `IsAnchor` en `EnemyDefinition`, resolución de tipo activo por mundo, ficha del enemigo con ambos tipos).
-> **Última actualización:** 2026-06-23 (sesión de arte + docs — `/cierre-sesion`): **Arte eventos multidim ✅ — PR #127.**
+> **Fase actual:** **M4 ✅ COMPLETO (2026-06-23).** Pre-M4 visor de mazo: ✅ (2026-06-17). Bloque 4a: ✅ (2026-06-17). Bloque 4b: ✅ (4b-1 2026-06-18 + 4b-2 2026-06-19). Bloque 4c: ✅ (2026-06-23). **Todos los bloques de M4 cerrados.**
+> **Milestone activo:** ninguno — M4 cerrado. **Próximo milestone: M5** (boss del Acto 1, DD-004 — reutiliza el patrón transdim de 4c).
+> **Próximo bloque:** arrancar M5 con sesión `modo:gdd`/`modo:diseno`. El boss de 2 tipos (uno por mundo) reutiliza el getter `EnemyElementType` resuelto por mundo + la ficha de dos tipos de 4c.
+> Próximo paso: definir el alcance de M5 (comportamiento dimensional del boss quedó FUERA de scope de 4c).
+> **Última actualización:** 2026-06-23 (`modo:implementacion`): **Bloque 4c CERRADO → M4 COMPLETO.**
+> Branch `feat/m4-4c-transdim-ancla`. `EnemyDefinition` +`typeWorldB`/`isAnchor`/`IsTransdimensional`;
+> `TurnManager.EnemyElementType` (PROTEGIDO) resuelve tipo activo por mundo/ancla (getter = punto único, 3 ediciones);
+> `ElementTypeColors.TypePrefix(type, brightness)` para el tipo atenuado; `CombatHudView` ficha de dos tipos;
+> `EnemyConfigSetup` (MenuItem `Roguelike/Setup Enemy Test Data (4c)`). Suite EditMode **230/230**, cero errores.
+> Pendiente para Sebastián: confirmar GOLDEN_RULES §2 (transdim/ancla ✓) y §6 (categorías dimensionales).
+> **Previa:** 2026-06-23 (sesión de arte + docs — `/cierre-sesion`): **Arte eventos multidim ✅ — PR #127.**
 > Fondos `evt_md_forge`/`evt_md_relic`/`evt_md_quest_courier` generados (dual-world neutral) y asignados a
 > `backgroundSprite` (antes caían al color #241A2E). `ART_PROMPTS.md` adelgazado a plantillas de formato por tipo
 > (A avatar / B cara carta / C fondo). `ART_NEEDS.md` registra slots E1 (3 simples ✔) + E2 (3 multidim ✔).
@@ -249,12 +255,18 @@ protegidos.**
 - Dependencia interna: 4a cerrado (eventos que otorgan mejoras necesitan que
   toda carta sea mejorable) + visor pre-M4 (verificación en playtest)
 
-#### Bloque 4c — Transdimensionales + Ancla (mecánico, patrón para M5)
-- [ ] Enemigos transdimensionales (DD-014): campo `TypeWorldB` en
-      `EnemyDefinition`, resolución de tipo activo según mundo actual
-- [ ] Enemigos ancla (DD-014): flag `IsAnchor` en `EnemyDefinition`, bypass
-      del cambio de mundo
-- [ ] Ficha del enemigo muestra ambos tipos (GOLDEN_RULES §6)
+#### Bloque 4c — Transdimensionales + Ancla (mecánico, patrón para M5) ✅ CERRADO (2026-06-23)
+**Spec** `Docs/dev/specs/m4_4c_transdim_ancla_spec.md` (IMPLEMENTADO). Branch
+`feat/m4-4c-transdim-ancla`. **Cierra M4.**
+- [x] Enemigos transdimensionales (DD-014): campo `typeWorldB` en
+      `EnemyDefinition` + derivada `IsTransdimensional`, resolución de tipo activo
+      según mundo actual en `TurnManager.EnemyElementType` (getter, único punto de verdad)
+- [x] Enemigos ancla (DD-014): flag `isAnchor` en `EnemyDefinition`, bypass
+      del cambio de mundo (precede a `typeWorldB`)
+- [x] Ficha del enemigo muestra ambos tipos (GOLDEN_RULES §6): `CombatHudView.BuildEnemyTypeLabel`
+      renderiza `[A] / [B]` con el inactivo atenuado (overload `ElementTypeColors.TypePrefix(type, brightness)`)
+- **Validación:** suite EditMode 230/230 (6 `EnemyTransdimTests` + 3 `TypePrefix` brightness),
+      `Roguelike/Setup Enemy Test Data (4c)` genera `TransdimTestEnemy`/`AnchorTestEnemy`. Cero errores.
 - **Nota de scope:** el GDD ubica transdim/ancla como contenido de Actos 2-3
   (DD-011). Entran a M4 porque el BOSS del Acto 1 (DD-004: 2 tipos, uno por
   mundo) ES la mecánica transdim estándar → M5 depende de este bloque. El

--- a/Docs/dev/_roadmap.md
+++ b/Docs/dev/_roadmap.md
@@ -312,11 +312,16 @@ el patrón para futuros bosses.
   ataque
 - Debuff Virus (DD-019, exclusivo del boss cyberpunk): bloqueo al 80%
   efectividad
-- 2 tipos por boss (1 SuperEficaz contra el jugador, 1 debilidad)
+- 2 tipos por boss (1 SuperEficaz contra el jugador, 1 debilidad) — **la maquinaria
+  de "2 tipos, uno por mundo" YA EXISTE** (4c): `EnemyDefinition.typeWorldB` + getter
+  `TurnManager.EnemyElementType` resuelto por mundo + ficha de dos tipos en
+  `CombatHudView`. M5 reusa esto; el boss es un transdim con comportamiento de fase encima.
 - Retazo único de boss vinculado narrativamente
 
 **Toca archivos protegidos:** sí (TurnManager + ActionQueue para hook
-post-ProcessAll y mutación de mundo desde IA).
+post-ProcessAll y mutación de mundo desde IA). **Nota 4c:** el comportamiento
+dimensional del boss (cambio de mundo forzado/automático desde la IA) quedó FUERA
+de scope de 4c — es trabajo de M5.
 
 **Dependencias:** M2 cerrado (cambio de mundo robusto), M4 cerrado — en
 particular el bloque 4c (transdim/ancla establecen el patrón de tipos
@@ -349,6 +354,18 @@ toca TurnManager).
 ---
 
 ## Completados
+
+### M4 — Resto del Acto 1 según GDD v2
+**Fecha cierre:** 2026-06-23 (bloque 4c transdim+ancla cierra el milestone)
+**Resumen:** completa el Acto 1 sobre la base de M3. Pre-M4 visor de mazo (PR #123)
++ 4 bloques: **4a** integridad de cartas (afinidad DD-022 opción A + cobertura de
+mejoras DD-023, sin tocar protegidos), **4b** eventos + quests (4b-1 motor + eventos
+simples PR #125; 4b-2 multidimensionales + quest/MCguffin PR #126; arte de fondos
+PR #127), **4c** enemigos transdimensionales + ancla (PR #130, ÚNICO bloque que tocó
+TurnManager). El getter `EnemyElementType` resuelto por mundo/ancla + la ficha de dos
+tipos son el patrón que **M5** (boss Acto 1, DD-004) reutiliza. Detalle por bloque
+arriba (histórico de implementación). Suite EditMode 230/230 al cierre.
+**Pendiente de confirmación de Sebastián:** GOLDEN_RULES §2 + §6 (transdim/ancla ✓).
 
 ### M3 — Personalización del run
 **Fecha cierre:** 2026-06-05 (mapa horizontal 3F como último sub-PR cierra el milestone)

--- a/Docs/dev/_tech_snapshot.md
+++ b/Docs/dev/_tech_snapshot.md
@@ -7,7 +7,27 @@
 > En `modo:implementacion` se lee OBLIGATORIAMENTE antes de cualquier cambio que
 > afecte arquitectura o componentes críticos.
 >
-> **Última actualización:** 2026-06-19 — **M4 bloque 4b-2: eventos multidimensionales + quest/MCguffin**
+> **Última actualización:** 2026-06-23 — **M4 bloque 4c: enemigos transdimensionales + ancla → M4 COMPLETO**
+> (branch `feat/m4-4c-transdim-ancla`). `EnemyDefinition` gana `typeWorldB` (ElementType, tipo en Mundo B) +
+> `isAnchor` (bool) + getters + **propiedad derivada `IsTransdimensional`** (`!isAnchor && typeWorldB != None`,
+> NO serializada); `SetDebugData` extendido con ambos params opcionales. **`TurnManager.cs` (PROTEGIDO)** —
+> 3 ediciones, todas canalizadas por un punto único: el getter `EnemyElementType` pasa de leer directo
+> `enemyDefinition.ElementType` a **resolver por mundo/ancla** (ancla → ElementType siempre; transdim en Mundo B →
+> TypeWorldB; Mundo A o tipo único → ElementType); los 2 read-sites de daño (enemigo atacante / defensor) ahora
+> consumen el getter. Cambio de **semántica**, firma idéntica — sin campos/eventos/métodos nuevos en TurnManager.
+> `ElementTypeColors.TypePrefix` gana param opcional `brightness=1f` (atenúa con `Dim` si `<1`; los callers
+> existentes con un arg quedan idénticos). `CombatHudView.BuildEnemyTypeLabel` renderiza **dos tipos** `[A] / [B]`
+> cuando el enemigo es transdim (activo a color pleno, inactivo atenuado a 0.45) + tinte del label a blanco en ese
+> caso (el color lo aporta el rich-text inline). Nuevo `Assets/Editor/EnemyConfigSetup.cs` (MenuItem
+> `Roguelike/Setup Enemy Test Data (4c)`, molde `EventConfigSetup`, idempotente) → `TransdimTestEnemy` (Rojo/Azul) +
+> `AnchorTestEnemy` (Morado fijo) en `Assets/ScriptableObjects/Enemies/`. Tests: `CombatTestBase.CreateEnemyDefinition`
+> +typeWorldB/isAnchor opcionales; nuevo `EnemyTransdimTests.cs` (6 casos: defaults, derivada, resolución por mundo,
+> ancla, tipo único, combate orgánico) + 3 casos `TypePrefix` brightness en `ElementTypeColorsTests`. **Validado
+> Unity-MCP (2026-06-23):** suite EditMode **230/230**, compilación limpia, MenuItem corrido (2 SOs con campos
+> correctos). FUERA de scope (no tocado): discrepancia tabla efectividad §3 vs código, comportamiento dimensional
+> del BOSS (M5). Pendiente confirmación de Sebastián: GOLDEN_RULES §2 + §6.
+>
+> **Última actualización previa:** 2026-06-19 — **M4 bloque 4b-2: eventos multidimensionales + quest/MCguffin**
 > (branch `feat/m4-4b2-events-quests`, **PR #126** → **bloque 4b COMPLETO**). Nuevo subsistema `Assets/Scripts/Run/Quests/`
 > (`QuestState.cs` datos del quest activo; `QuestDestinationResolver.cs` BFS forward static puro).
 > `RelicCardPlayedBlockEffect.cs` (MCguffin Mundo B: +1 bloqueo al jugar carta de escudo vía

--- a/Docs/dev/specs/m4_4c_transdim_ancla_spec.md
+++ b/Docs/dev/specs/m4_4c_transdim_ancla_spec.md
@@ -1,0 +1,335 @@
+# Spec — M4 Bloque 4c — Enemigos Transdimensionales + Ancla
+
+> **ESTADO: IMPLEMENTADO — branch `feat/m4-4c-transdim-ancla` (2026-06-23).**
+> Suite EditMode 230/230, validado Unity-MCP. Cierra M4. Pendiente confirmación
+> de Sebastián en GOLDEN_RULES §2 + §6.
+
+## Origen
+- **GDD** `DD-014` (enemigos transdimensionales + ancla), `DD-004` (boss Acto 1 —
+  2 tipos, uno por mundo — la mecánica que M5 necesita), `DD-011` (escalado por
+  acto: transdim en Acto 2, ancla en Acto 3).
+- **GOLDEN_RULES** §6 (categorías dimensionales: Estándar / Ancla; "la ficha
+  muestra ambos tipos cuando aplica") y §2 (efecto del cambio de mundo, hoy
+  marcado `⏳ pendiente` para transdim y ancla).
+- **Roadmap** M4 bloque 4c (último bloque de M4; único que toca un archivo
+  protegido).
+
+## Objetivo
+Implementar la maquinaria de **tipo activo por mundo** en enemigos: los
+transdimensionales conmutan su tipo con el cambio de mundo, los ancla lo ignoran,
+y la ficha del enemigo muestra ambos tipos cuando el enemigo es transdimensional.
+Es el patrón de "tipos múltiples por mundo" que el boss del Acto 1 (M5) reutiliza.
+
+## Comportamiento esperado
+Desde la perspectiva del jugador:
+
+- **Enemigo de tipo único** (los 5 actuales, Acto 1): sin cambios. Un tipo en
+  ambos mundos; la ficha muestra un tipo.
+- **Enemigo transdimensional:** la ficha muestra **dos tipos** (`[Rojo] / [Azul]`).
+  El tipo del mundo activo se ve a color pleno; el otro, atenuado. Al cambiar de
+  mundo, el tipo activo conmuta **instantáneamente**: la efectividad del daño
+  (jugador→enemigo y enemigo→jugador) se recalcula contra el nuevo tipo, y el
+  resaltado de la ficha se invierte. El jugador ve ambos tipos **antes** de gastar
+  el cambio, para anticipar el efecto.
+- **Enemigo ancla:** un solo tipo, **fijo e invariable**. Cambiar de mundo no lo
+  altera. La ficha muestra un solo tipo.
+
+## Sistemas afectados
+- **ScriptableObjects:** `EnemyDefinition` gana `typeWorldB` + `isAnchor` + la
+  propiedad derivada `IsTransdimensional`.
+- **Combate (PROTEGIDO):** `TurnManager` resuelve el tipo activo del enemigo según
+  el mundo actual / ancla. **[REQUIERE APROBACIÓN]**
+- **UI:** `CombatHudView` renderiza ambos tipos cuando el enemigo es transdim.
+- **Tests:** `CombatTestBase` + `EnemyDefinition.SetDebugData` extendidos; nuevo
+  `EnemyTransdimTests`.
+- **Editor:** nuevo `EnemyConfigSetup` (genera SOs de prueba para E2E).
+
+## Archivos a crear
+- `Assets/Editor/EnemyConfigSetup.cs` — generador idempotente (molde
+  `EventConfigSetup`) con `MenuItem "Roguelike/Setup Enemy Test Data (4c)"`. Crea
+  **2 SOs**: `TransdimTestEnemy` (transdim) + `AnchorTestEnemy` (ancla). NO toca
+  los 5 SOs existentes.
+- `Assets/Tests/EditMode/EnemyTransdimTests.cs` — tests de resolución de tipo por
+  mundo, defaults de los campos nuevos y `IsTransdimensional`.
+
+## Archivos a modificar
+- `Assets/Scripts/Gameplay/Enemies/EnemyDefinition.cs` (NO protegido) — agregar
+  campos `typeWorldB` + `isAnchor`, propiedades getter, propiedad derivada
+  `IsTransdimensional`, y extender `SetDebugData`.
+- `Assets/Scripts/Gameplay/Combat/TurnManager.cs` — **PROTEGIDO — [REQUIERE APROBACIÓN]**
+  — 3 ediciones quirúrgicas (ver Contratos).
+- `Assets/Scripts/Gameplay/Combat/CombatHudView.cs` (NO protegido) — `BuildEnemyTypeLabel()`
+  + tinte del label para el caso de dos tipos.
+- `Assets/Scripts/Gameplay/Combat/ElementTypeColors.cs` (NO protegido) — overload
+  `TypePrefix(type, brightness)` para el tipo atenuado (reuso, ver Contratos).
+- `Assets/Tests/EditMode/CombatTestBase.cs` (test helper) — `CreateEnemyDefinition`
+  acepta `typeWorldB` + `isAnchor` opcionales.
+
+## Archivos protegidos involucrados
+- [ ] Ninguno
+- [x] `TurnManager.cs` — **REQUIERE APROBACIÓN**. Tres ediciones, todas
+  centralizadas en una sola propiedad:
+  1. **Getter `EnemyElementType` ([TurnManager.cs:112](../../../Assets/Scripts/Gameplay/Combat/TurnManager.cs#L112))** — hoy
+     `=> enemyDefinition != null ? enemyDefinition.ElementType : ElementType.None;`.
+     Pasa a resolver por mundo/ancla (pseudocódigo en Contratos).
+  2. **Línea [TurnManager.cs:416](../../../Assets/Scripts/Gameplay/Combat/TurnManager.cs#L416)** —
+     `QueueEffects(move.Effects, _enemy, _player, enemyDefinition?.ElementType ?? ElementType.None);`
+     → el 4º argumento pasa a `EnemyElementType` (enemigo como **atacante**).
+  3. **Línea [TurnManager.cs:624](../../../Assets/Scripts/Gameplay/Combat/TurnManager.cs#L624)** —
+     `ElementType defenderType = enemyDefinition != null ? enemyDefinition.ElementType : ElementType.None;`
+     → `ElementType defenderType = EnemyElementType;` (enemigo como **defensor**).
+
+  > Hoy esos tres sitios leen `enemyDefinition.ElementType` directo. Tras el
+  > cambio, **todos** consumen el tipo resuelto a través de un único punto de
+  > verdad (el getter). No se agregan campos, eventos ni métodos públicos nuevos
+  > a TurnManager; sólo cambia la **semántica** del getter (firma idéntica).
+
+## Contratos
+
+### Datos — `EnemyDefinition`
+Agregar junto a `elementType` (insertar tras la línea 22, antes de `avatar`):
+
+| Campo | Tipo | Default | Significado |
+|-------|------|---------|-------------|
+| `elementType` (existente) | `ElementType` | `None` | Tipo en **Mundo A** / tipo **fijo** (para tipo-único y ancla) |
+| `typeWorldB` (nuevo) | `ElementType` | `None` | Tipo en **Mundo B**. Sólo significativo si el enemigo es transdim |
+| `isAnchor` (nuevo) | `bool` | `false` | Si `true`, el tipo NO reacciona al cambio de mundo |
+
+Propiedades públicas (patrón lambda read-only existente, tras la línea 34):
+```csharp
+public ElementType TypeWorldB => typeWorldB;
+public bool IsAnchor => isAnchor;
+
+// Derivada: un enemigo es transdimensional si tiene un tipo de Mundo B
+// distinto y NO es ancla. No es un flag serializado (evita superficie de
+// autoría redundante) — se computa de los otros dos campos.
+public bool IsTransdimensional => !isAnchor && typeWorldB != ElementType.None;
+```
+
+**Backward-compat:** los 5 SOs existentes quedan con `typeWorldB = None` e
+`isAnchor = false` por defecto → `IsTransdimensional == false` →
+`EnemyElementType` devuelve `elementType` en ambos mundos. Comportamiento
+idéntico al actual. (Cubierto por test de regresión.)
+
+### Resolución — `TurnManager.EnemyElementType` (getter, PROTEGIDO)
+```
+si enemyDefinition == null            → ElementType.None
+si enemyDefinition.IsAnchor           → enemyDefinition.ElementType      // ancla: ignora el mundo
+si currentWorld == B && TypeWorldB != None → enemyDefinition.TypeWorldB  // transdim, lado B
+en otro caso                          → enemyDefinition.ElementType      // Mundo A o tipo único
+```
+- **Precedencia:** `isAnchor` gana sobre `typeWorldB` (un ancla con `typeWorldB`
+  seteado por error igual ignora el mundo).
+- Es el **único** lugar de resolución; las 3 lecturas (112/416/624) pasan por él.
+
+### APIs públicas
+- `EnemyDefinition.TypeWorldB`, `.IsAnchor`, `.IsTransdimensional` (getters nuevos).
+- `TurnManager.EnemyElementType` — **firma sin cambios**; cambia la semántica
+  (ahora resuelto por mundo/ancla). `CurrentEnemyDefinition`
+  ([TurnManager.cs:113](../../../Assets/Scripts/Gameplay/Combat/TurnManager.cs#L113))
+  ya expone el SO → el HUD lee de ahí los dos tipos crudos, **no se agrega API
+  nueva a TurnManager para la ficha**.
+- `ElementTypeColors.TypePrefix(ElementType type, float brightness = 1f)` —
+  overload nuevo (NO protegido): con `brightness < 1f` aplica
+  `Dim(ReadableOnDark(type), brightness)` al color del rich-text. El overload
+  sin parámetro mantiene el comportamiento actual.
+
+### Eventos
+- Ninguno nuevo. La ficha se refresca por el polling existente de
+  `CombatHudView.Sync()` (corre cada frame), así que el resaltado conmuta solo al
+  cambiar de mundo sin necesidad de eventos.
+
+### UI — `CombatHudView.BuildEnemyTypeLabel()` ([CombatHudView.cs:265-274](../../../Assets/Scripts/Gameplay/Combat/CombatHudView.cs#L265))
+```
+def = _turnManager.CurrentEnemyDefinition
+si def == null → "Type: —"
+
+si !def.IsTransdimensional:                       // tipo único o ancla → 1 tipo
+    type = _turnManager.EnemyElementType          // resuelto
+    return type == None ? "Type: —" : $"Type: {type}"
+
+si def.IsTransdimensional:                         // 2 tipos
+    activoEsA = _turnManager.CurrentWorld == WorldSide.A
+    prefijoA  = activoEsA ? TypePrefix(def.ElementType) : TypePrefix(def.ElementType, DIM)
+    prefijoB  = activoEsA ? TypePrefix(def.TypeWorldB, DIM) : TypePrefix(def.TypeWorldB)
+    return $"Type: {prefijoA} / {prefijoB}"
+```
+- `DIM` = factor de atenuación (constante local, p. ej. `0.45f`).
+- **Tinte del label** ([CombatHudView.cs:170-173](../../../Assets/Scripts/Gameplay/Combat/CombatHudView.cs#L170)):
+  cuando el enemigo es transdim, poner `_enemyTypeLabel.color = Color.white` (el
+  color lo aporta el rich-text inline por tipo; un único `Text` no puede tener
+  dos `.color`). Para tipo único / ancla, mantener el `ReadableOnDark` actual.
+
+## Reuso
+- `ElementTypeColors.TypePrefix(type)` (rich-text `<color=#hex>[Tipo]</color>`),
+  `.Dim(color, factor)`, `.ReadableOnDark(type)` — ya existen y están testeados
+  (`ElementTypeColorsTests`).
+- `TurnManager.CurrentWorld`, `WorldSide`, `SetCurrentWorldForTest`,
+  `CurrentEnemyDefinition` — ya existen.
+- `CombatTestBase.CreateEnemyDefinition` + `EnemyDefinition.SetDebugData` —
+  patrón existente de construcción de SOs en memoria; sólo se extienden con
+  parámetros opcionales con default (no rompen llamadas existentes).
+- `EventConfigSetup.cs` — molde del generador idempotente (`EnsureFolder`,
+  `AssetDatabase.CreateAsset`, chequeo de existencia previa).
+- Patrón `[SerializeField] private` + getter lambda de `EnemyDefinition`.
+
+## Casos de prueba (EditMode)
+Todos construyen enemigos **en memoria** (no requieren SOs en disco):
+
+1. **Defaults (regresión / guard):** `EnemyDefinition` recién creado tiene
+   `TypeWorldB == None`, `IsAnchor == false`, `IsTransdimensional == false`.
+   (Extiende o acompaña a `DefinitionTypeDefaultsTests`.)
+2. **`IsTransdimensional`:** `true` sólo con `typeWorldB != None && !isAnchor`;
+   `false` si es ancla; `false` si `typeWorldB == None`.
+3. **Resolución transdim sigue el mundo:** enemigo con `elementType=Rojo`,
+   `typeWorldB=Azul`, `isAnchor=false` → `EnemyElementType == Rojo` en Mundo A,
+   `== Azul` en Mundo B (vía `SetCurrentWorldForTest`).
+4. **Resolución ancla ignora el mundo:** enemigo con `elementType=Morado`,
+   `isAnchor=true` (aun con `typeWorldB=Azul` seteado) → `EnemyElementType ==
+   Morado` en ambos mundos.
+5. **Resolución tipo único (backward-compat):** `typeWorldB=None`,
+   `isAnchor=false` → `EnemyElementType == elementType` en ambos mundos.
+6. **Combate orgánico (la resolución fluye al daño):** un transdim cuyo tipo de
+   Mundo A es SuperEficaz-recibido y el de Mundo B no, según la tabla **del
+   código** (`ElementEffectiveness.GetEffectiveness`). Jugar una carta tipada en
+   Mundo A y verificar el daño/multiplicador; cambiar a Mundo B y verificar que
+   cambia. *No re-asierta los valores de la tabla de efectividad* (eso es de
+   `ElementEffectivenessTests`); asierta que **el tipo activo usado** cambió con
+   el mundo. Reusa el patrón de `DamageEffectivenessTests`.
+7. **Regresión:** `DamageEffectivenessTests` y `AffinityTests` siguen en verde
+   sin cambios de aserción (sólo recompilan por la firma extendida de
+   `CreateEnemyDefinition` con defaults).
+
+## Validación manual (BattleScene)
+1. Ejecutar menú **`Roguelike/Setup Enemy Test Data (4c)`** → genera
+   `TransdimTestEnemy.asset` y `AnchorTestEnemy.asset`.
+2. Asignar `TransdimTestEnemy` al combate (vía nodo/config) e iniciar BattleScene.
+3. **Resultado esperado:** la ficha muestra `Type: [Rojo] / [Azul]`, con el tipo
+   del mundo activo (A=Rojo) a color pleno y Azul atenuado.
+4. Cambiar de mundo → el resaltado se invierte (Azul pleno, Rojo atenuado) y el
+   daño de una carta tipada cambia de efectividad contra el enemigo.
+5. Repetir con `AnchorTestEnemy` → un solo tipo en la ficha; cambiar de mundo NO
+   lo altera.
+6. Validar con Unity-MCP (compilación limpia, cero errores en consola).
+
+## Decisiones cerradas
+- Mecanismo dimensional **DD-014** cerrado por diseño (Estándar / Ancla).
+- **Sin tercer flag serializado:** "transdimensional" se **deriva**
+  (`typeWorldB != None && !isAnchor`).
+- `elementType` = tipo **Mundo A** / tipo **fijo**; `typeWorldB` = tipo **Mundo B**.
+- **`isAnchor` precede a `typeWorldB`** en la resolución.
+- **Backward-compat por defaults** (`None` / `false`) → los SOs existentes no
+  cambian de comportamiento.
+- **Ficha:** un solo `Text`, rich-text, ambos tipos, inactivo atenuado con `Dim`
+  *(decisión de Sebastián, 2026-06-23)*.
+- **SOs de prueba:** editor generator nuevo (`EnemyConfigSetup`), 2 SOs, sin tocar
+  los existentes; tests EditMode in-memory *(decisión de Sebastián, 2026-06-23)*.
+- **TurnManager:** 3 ediciones (getter + 2 read-sites), todo canalizado por una
+  única propiedad. Cambio de **semántica**, no de firma.
+- La tabla de efectividad sigue resolviéndose en `ElementEffectiveness` sin
+  cambios (4c sólo decide **qué tipo** entra, no los multiplicadores).
+
+## Decisiones abiertas (REQUIEREN cierre antes de implementar)
+Ninguna que bloquee 4c. Dos notas **fuera de scope** (no tocar en este Sub-PR):
+
+- **[CONTRADICCIÓN — fuera de scope]** La tabla de efectividad de GOLDEN_RULES §3
+  difiere del código (`ElementEffectiveness.GetEffectiveness`) en
+  Rojo↔Amarillo/Azul y Amarillo→Rojo. **No afecta a 4c**: 4c resuelve *qué tipo*
+  está activo, no los multiplicadores, y los tests de 4c asertan resolución (no
+  valores de la tabla). Decidir fuente de verdad (corregir doc o código) es un
+  ítem separado, abierto para Sebastián.
+- **[Nota — stale]** GOLDEN_RULES §6 dice "PhaseBased: declarado, no implementado
+  aún"; ya se implementó en Sub-PR D (2026-05-07). No es parte de 4c; corregir el
+  doc aparte.
+
+## Alternativas consideradas
+- **Resolver el tipo del enemigo fuera de TurnManager (como afinidad en 4a):**
+  descartada. 4a no tocó TurnManager porque ya leía `GetActiveCard(CurrentWorld).ElementType`
+  y el `AffinityResolver` producía una dual runtime tipada por mundo. El enemigo
+  **no tiene** una abstracción de "lado activo": hay un único campo
+  `enemyDefinition` y la resolución necesita `currentWorld`, que vive dentro de
+  TurnManager. No hay forma de evitar el toque al protegido.
+- **Flag `IsTransdimensional` serializado:** descartada — redundante y derivable;
+  agrega superficie de error de autoría (un SO con `typeWorldB` seteado pero el
+  flag olvidado).
+- **`EnemyDefinition.ResolveActiveType(WorldSide)`:** descartada — acoplaría el
+  namespace `Enemies` a `TurnManager.WorldSide` (enum anidado en Combat). Mejor
+  mantener el SO como **data pura** y dejar la resolución por mundo en TurnManager.
+- **Ficha con dos labels apilados / marcador `▸` en el activo:** descartadas por
+  decisión (ver Decisiones cerradas).
+
+## Estimación
+- **Complejidad:** media (coincide con el roadmap).
+- **Sub-tareas:**
+  1. `EnemyDefinition`: campos + getters + `IsTransdimensional` + `SetDebugData`.
+  2. `TurnManager`: 3 ediciones **[REQUIERE APROBACIÓN]**.
+  3. `ElementTypeColors`: overload `TypePrefix(type, brightness)` (+ su test).
+  4. `CombatHudView`: render de dos tipos + tinte.
+  5. `CombatTestBase` + `EnemyTransdimTests`.
+  6. `EnemyConfigSetup` (editor generator).
+- **Riesgo:** bajo-medio. El único riesgo real es el toque al protegido, acotado
+  a 3 líneas y centralizado en un getter. Backward-compat cubierto por defaults +
+  test de regresión. La discrepancia de la tabla §3 NO entra al camino crítico.
+
+## Prompt de handoff para `modo:implementacion`
+
+```text
+modo:implementacion
+
+Implementá el Sub-PR M4 4c — Enemigos Transdimensionales + Ancla. El spec cerrado
+está en Docs/dev/specs/m4_4c_transdim_ancla_spec.md — leelo completo antes de
+tocar código; todas las decisiones de diseño ya están cerradas, no abras ninguna.
+
+Setup de branch (dependencias previas — todas MERGED: 4b PRs #125/#126/#127;
+main en ff0d1cd):
+  git fetch --all --prune
+  git checkout -b feat/m4-4c-transdim-ancla origin/main
+
+Qué construir (resumen; el detalle y los contratos están en el spec):
+- Modificar Assets/Scripts/Gameplay/Enemies/EnemyDefinition.cs (NO protegido):
+  +typeWorldB (ElementType=None), +isAnchor (bool=false), getters, propiedad
+  derivada IsTransdimensional, y extender SetDebugData con ambos params opcionales.
+- Modificar Assets/Scripts/Gameplay/Combat/TurnManager.cs (PROTEGIDO): getter
+  EnemyElementType resuelve por mundo/ancla (pseudocódigo en el spec); líneas 416
+  y 624 leen por la propiedad EnemyElementType. Cambio de semántica, no de firma.
+- Modificar Assets/Scripts/Gameplay/Combat/ElementTypeColors.cs (NO protegido):
+  overload TypePrefix(type, brightness=1f) que atenúa con Dim cuando brightness<1.
+- Modificar Assets/Scripts/Gameplay/Combat/CombatHudView.cs (NO protegido):
+  BuildEnemyTypeLabel renderiza dos tipos cuando IsTransdimensional (activo pleno,
+  inactivo atenuado) + tinte del label a Color.white en ese caso.
+- Modificar Assets/Tests/EditMode/CombatTestBase.cs: CreateEnemyDefinition acepta
+  typeWorldB + isAnchor opcionales (default None/false).
+- Crear Assets/Tests/EditMode/EnemyTransdimTests.cs: casos 1-6 del spec (+ correr
+  la suite completa para el caso 7 de regresión).
+- Crear Assets/Editor/EnemyConfigSetup.cs: MenuItem "Roguelike/Setup Enemy Test
+  Data (4c)" idempotente (molde EventConfigSetup) → TransdimTestEnemy + AnchorTestEnemy.
+
+Reglas no negociables:
+- TurnManager.cs es PROTEGIDO: al editarlo, el hook protect-files pedirá allow/deny.
+  PARAR y confirmar con Sebastián antes de aplicar las 3 ediciones. NO delegar la
+  edición de TurnManager a un subagente — se hace en el hilo principal.
+- NO tocar ActionQueue.cs ni PlayerCombatActor.cs.
+- No manual editor setup: los SOs de prueba los genera el MenuItem, no a mano.
+- FUERA de scope: la discrepancia de la tabla de efectividad §3 vs código, y el
+  comportamiento dimensional del BOSS (eso es M5). 4c sólo resuelve el tipo activo
+  de enemigos normales + ficha.
+- No agregar un flag IsTransdimensional serializado — es derivado.
+
+Validación obligatoria antes de cerrar:
+- Compilación limpia (cero errores en consola).
+- Tests EditMode: EnemyTransdimTests nuevos en verde + suite completa sin
+  regresiones (hoy 221; quedan ~227-228).
+- Correr el menú Roguelike/Setup Enemy Test Data (4c) y verificar que crea los 2 SOs.
+- Flujo end-to-end en BattleScene: ficha de TransdimTestEnemy muestra dos tipos,
+  conmuta el resaltado al cambiar de mundo y cambia la efectividad del daño; el
+  AnchorTestEnemy no cambia al cambiar de mundo.
+- Validar con Unity-MCP (compilación + cero errores).
+
+Al cerrar: actualizá _roadmap.md (marcar los 3 checkboxes de 4c [x]; 4c es el
+último bloque de M4 → marcar M4 completo), _tech_snapshot.md (EnemyDefinition con
+typeWorldB/isAnchor/IsTransdimensional, getter resuelto de TurnManager,
+CombatHudView con dos tipos, EnemyConfigSetup). Proponer a Sebastián marcar en
+GOLDEN_RULES §2 (tipo activo transdim ✓ / ancla ✓) y §6 (categorías dimensionales)
+como implementados — esos docs los confirma él. Commit + push + PR a main
+(Closes #<issue 4c> si existe).
+```


### PR DESCRIPTION
## Qué

Implementa **M4 bloque 4c** — enemigos transdimensionales (tipo activo conmuta con el mundo) y ancla (tipo fijo). **Cierra M4.** Spec: `Docs/dev/specs/m4_4c_transdim_ancla_spec.md`.

## Cambios

- **`EnemyDefinition`** (no protegido): `typeWorldB` + `isAnchor` + getters + derivada `IsTransdimensional` (`!isAnchor && typeWorldB != None`, **no serializada**); `SetDebugData` extendido.
- **`TurnManager`** 🔒 PROTEGIDO (aprobado por Sebastián): el getter `EnemyElementType` pasa a **resolver por mundo/ancla** como punto único de verdad; los 2 read-sites de daño (enemigo atacante/defensor) consumen el getter. **Cambio de semántica, firma idéntica** — sin campos/eventos/métodos nuevos.
- **`ElementTypeColors.TypePrefix`**: param opcional `brightness=1f` (atenúa con `Dim` si `<1`; callers existentes intactos).
- **`CombatHudView.BuildEnemyTypeLabel`**: dos tipos `[A] / [B]` en transdim (activo pleno, inactivo atenuado) + tinte del label a blanco.
- **`EnemyConfigSetup`** (nuevo, editor): MenuItem `Roguelike/Setup Enemy Test Data (4c)` → `TransdimTestEnemy` (Rojo/Azul) + `AnchorTestEnemy` (Morado fijo).
- **Tests**: `EnemyTransdimTests` (6 casos) + 3 casos `TypePrefix` brightness; `CombatTestBase.CreateEnemyDefinition` extendido.

## Validación (Unity-MCP)

- ✅ Compilación limpia, cero errores.
- ✅ Suite EditMode **230/230** (221 base + 6 EnemyTransdim + 3 TypePrefix).
- ✅ MenuItem genera los 2 SOs con valores serializados correctos.
- ⏳ Render visual de la ficha en BattleScene: presentación (no CLI-testeable) — pendiente eyeball de Sebastián.

## Fuera de scope

- Discrepancia tabla efectividad GOLDEN_RULES §3 vs código.
- Comportamiento dimensional del BOSS (M5).
- Pendiente confirmación de Sebastián: GOLDEN_RULES §2 (transdim/ancla ✓) + §6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)